### PR TITLE
fix for the null pointer exception when application paused.

### DIFF
--- a/playkit/src/main/java/com/kaltura/playkit/player/PlayerController.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/PlayerController.java
@@ -257,6 +257,11 @@ public class PlayerController implements Player {
     @Override
     public void onApplicationPaused() {
         log.d("onApplicationPaused");
+        if(player == null){
+            log.e("Attempt to invoke 'release()' on null instance of the player engine");
+            return;
+        }
+
         player.release();
         togglePlayerListeners(false);
         wasReleased = true;


### PR DESCRIPTION
just added check for null, and if playerEngine is null, we will print the attempt to error log and return from the function without calling the playerEngine.release()