### PR TITLE
Bug fix.

### DIFF
--- a/playkit/src/main/java/com/kaltura/playkit/player/PlayerController.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/PlayerController.java
@@ -98,12 +98,7 @@ public class PlayerController implements Player {
         PKMediaSource source = SourceSelector.selectSource(mediaConfig.getMediaEntry());
 
         player.load(source);
-        long startPosition = mediaConfig.getStartPosition() * MILLISECONDS_MULTIPLIER;
-        if(startPosition <= player.getDuration()){
-            startPlaybackFrom(startPosition);
-        }else{
-            log.w("The start position is grater then duration of the video!");
-        }
+        startPlaybackFrom(mediaConfig.getStartPosition() * MILLISECONDS_MULTIPLIER);
     }
 
     @Override
@@ -123,10 +118,15 @@ public class PlayerController implements Player {
             log.e("Attempt to invoke 'startPlaybackFrom()' on null instance of the player engine");
             return;
         }
-        if(!wasReleased){
-            togglePlayerListeners(false);
-            player.startFrom(startPosition);
-            togglePlayerListeners(true);
+
+        if(startPosition <= mediaConfig.getMediaEntry().getDuration()){
+            if(!wasReleased){
+                togglePlayerListeners(false);
+                player.startFrom(startPosition);
+                togglePlayerListeners(true);
+            }
+        }else{
+            log.w("The start position is grater then duration of the video! Start position " + startPosition + ", duration " + mediaConfig.getMediaEntry().getDuration());
         }
     }
 


### PR DESCRIPTION
The startPosition check should be in front of mediaConfig.getMediaEntry().getDuration() and not player.getDuration. Because the player.getDuration() in this stage is always Consts.Time_Unset.