### PR TITLE
Implemented SourceSelector

### DIFF
--- a/playkit/src/main/java/com/kaltura/playkit/PKMediaFormat.java
+++ b/playkit/src/main/java/com/kaltura/playkit/PKMediaFormat.java
@@ -37,7 +37,7 @@ public enum PKMediaFormat {
             String path = Uri.parse(sourceURL).getPath();
             int extIndex = path.lastIndexOf(".");
             if (extIndex < 0) {
-                return mediaFormat;
+                return null;
             }
             mediaFormat = PKMediaFormat.valueOfExt(path.substring(extIndex));
         }

--- a/playkit/src/main/java/com/kaltura/playkit/PlayKitManager.java
+++ b/playkit/src/main/java/com/kaltura/playkit/PlayKitManager.java
@@ -2,6 +2,8 @@ package com.kaltura.playkit;
 
 import android.content.Context;
 
+import com.kaltura.playkit.player.MediaSupport;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -33,6 +35,9 @@ public class PlayKitManager {
     }
 
     public static Player loadPlayer(PlayerConfig playerConfig, Context context) {
+
+        MediaSupport.initialize(context);
+        
         PlayerLoader playerLoader = new PlayerLoader(context);
         playerLoader.load(playerConfig);
         return playerLoader;

--- a/playkit/src/main/java/com/kaltura/playkit/player/MediaSupport.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/MediaSupport.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.drm.DrmManagerClient;
 import android.media.MediaDrm;
 import android.os.Build;
+import android.support.annotation.NonNull;
 
 import com.kaltura.playkit.PKLog;
 
@@ -18,6 +19,11 @@ public class MediaSupport {
     private static Boolean widevineModular;
 
     private static final PKLog log = PKLog.get("MediaSupport");
+    
+    public static void initialize(@NonNull Context context) {
+        widevineClassic(context);
+        widevineModular();
+    }
 
     public static boolean widevineClassic(Context context) {
         if (widevineClassic != null) {

--- a/playkit/src/main/java/com/kaltura/playkit/player/PlayerController.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/PlayerController.java
@@ -134,7 +134,12 @@ public class PlayerController implements Player {
 
         PKMediaSource source = SourceSelector.selectSource(mediaConfig.getMediaEntry());
 
-        if (source.getMediaFormat() != null && !source.getMediaFormat().equals(PKMediaFormat.wvm_widevine)) {
+        if (source == null) {
+            log.e("No playable source found for entry");
+            return;
+        }
+        
+        if (source.getMediaFormat() != PKMediaFormat.wvm_widevine) {
             if (player == null) {
                 player = new ExoPlayerWrapper(context);
                 wrapperView.addView(player.getView());

--- a/playkit/src/main/java/com/kaltura/playkit/player/SourceSelector.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/SourceSelector.java
@@ -1,16 +1,77 @@
 package com.kaltura.playkit.player;
 
+import android.support.annotation.Nullable;
+
+import com.kaltura.playkit.PKLog;
 import com.kaltura.playkit.PKMediaEntry;
+import com.kaltura.playkit.PKMediaFormat;
 import com.kaltura.playkit.PKMediaSource;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Created by Noam Tamim @ Kaltura on 29/11/2016.
  */
 
 class SourceSelector {
+    
+    private static final PKLog log = PKLog.get("SourceSelector");
+    private final PKMediaEntry mediaEntry;
+    
+    SourceSelector(PKMediaEntry mediaEntry) {
+        this.mediaEntry = mediaEntry;
+    }
+    
+    @Nullable
+    private PKMediaSource sourceByFormat(PKMediaFormat format) {
+        for (PKMediaSource source : mediaEntry.getSources()) {
+            if (source.getMediaFormat() == format) {
+                return source;
+            }
+        }
+        return null;
+    }
+    
+    @Nullable
+    PKMediaSource getPreferredSource() {
+
+        // Default preference: DASH, HLS, WVM, MP4
+
+        List<PKMediaFormat> pref = new ArrayList<>(10);
+
+        // Dash is always available.
+        pref.add(PKMediaFormat.dash_clear);
+        
+        // Dash+Widevine is only available from Android 4.3 
+        if (MediaSupport.widevineModular()) {
+            pref.add(PKMediaFormat.dash_widevine);  
+        }
+        
+        // HLS clear is always available
+        pref.add(PKMediaFormat.hls_clear);
+        
+        // Widevine Classic is OPTIONAL from Android 6. 
+        if (MediaSupport.widevineClassic(null)) {
+            pref.add(PKMediaFormat.wvm_widevine);
+        }
+        
+        // MP4 is always available, but gives inferior performance.
+        pref.add(PKMediaFormat.mp4_clear);
+        
+        for (PKMediaFormat format : pref) {
+            PKMediaSource source = sourceByFormat(format);
+            if (source != null) {
+                return source;
+            }
+        }
+
+        log.e("No playable sources found!");
+        return null;
+    }
+
     static PKMediaSource selectSource(PKMediaEntry mediaEntry) {
-        // TODO: really implement this.
-        return mediaEntry.getSources().get(0);
+        return new SourceSelector(mediaEntry).getPreferredSource();
     }
 }
 


### PR DESCRIPTION
Native preference: DASH*, HLS, WVM*, MP4

* DASH with Widevine is only available from Android 4.3
* WVM is optional from Android 6