### PR TITLE
Moved version definition and bintray config to version.gradle.

### DIFF
--- a/playkit/build.gradle
+++ b/playkit/build.gradle
@@ -1,15 +1,14 @@
 apply plugin: 'com.android.library'
-
-def libVersionName = '0.1.0'
+apply from: 'version.gradle'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.0"
+    buildToolsVersion "25.0.2"
 
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 25
-        versionName libVersionName
+        versionName playkitVersion  // defined in version.gradle
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
     buildTypes {
@@ -54,19 +53,3 @@ dependencies {
     androidTestCompile 'com.android.support.test:runner:0.5'
 }
 
-try {
-    apply plugin: 'bintray-release'
-
-    publish {
-        artifactId = 'playkit'
-        description = 'Kaltura PlayKit Library'
-        repoName = 'android'
-        userOrg = 'kaltura'
-        groupId = 'com.kaltura.playkit'
-        version = libVersionName
-        autoPublish = false
-        licences = ['AGPL-3.0']
-    }
-} catch (UnknownPluginException ignored) {
-    // Ignore - it's ok not to have this plugin.
-}

--- a/playkit/version.gradle
+++ b/playkit/version.gradle
@@ -1,0 +1,34 @@
+
+// PlayKit Library Version
+ext.playkitVersion = 'dev'
+
+
+
+
+
+// Append short commit hash to dev builds, i.e. "dev.a1b2c3d"
+if (playkitVersion == 'dev') {
+    def cmd = "git rev-parse --short HEAD"
+    def proc = cmd.execute()
+    def commit = proc.text.trim()
+    ext.playkitVersion = 'dev.' + commit
+}
+
+
+// Publish to Bintray
+try {
+    apply plugin: 'bintray-release'
+
+    publish {
+        artifactId = 'playkit'
+        description = 'PlayKit: Kaltura Player SDK'
+        repoName = 'android'
+        userOrg = 'kaltura'
+        groupId = 'com.kaltura.playkit'
+        version = playkitVersion
+        autoPublish = false
+        licences = ['AGPL-3.0']
+    }
+} catch (UnknownPluginException ignored) {
+    // Ignore - it's ok not to have this plugin - it's only used for bintray uploads.
+}

--- a/travis-push-to-bintray.sh
+++ b/travis-push-to-bintray.sh
@@ -17,7 +17,7 @@ if [[ ! $TAG_VERSION_NAME =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
 fi
 
 # Check that defined library version matches the tag.
-if ! grep -q "def libVersionName = '$TAG_VERSION_NAME'" playkit/build.gradle
+if ! grep -q "ext.playkitVersion = '$TAG_VERSION_NAME'" playkit/version.gradle
 then
     >&2 echo "error: Library version name in build.gradle does not match tag name."
     exit 1


### PR DESCRIPTION
PlayKit version is now defined as ext.playkitVersion in version.gradle. In all non-release branches, this value must be 'dev'. In that case, the short commit hash is appended.