### PR TITLE
When application is going background it is possible that onTracksChan…

### DIFF
--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
@@ -318,7 +318,10 @@ class ExoPlayerWrapper implements PlayerEngine, ExoPlayer.EventListener {
     @Override
     public void onTracksChanged(TrackGroupArray trackGroups, TrackSelectionArray trackSelections) {
         log.d("onTracksChanged");
-
+        //if onOnTracksChanged happened when application went background, do not update the tracks.
+        if(trackSelectionHelper == null){
+            return;
+        }
         //if the track info new -> map the available tracks. and when ready, notify user about available tracks.
         if (shouldGetTracksInfo) {
             shouldGetTracksInfo = !trackSelectionHelper.prepareTracks();


### PR DESCRIPTION
…ged() is still called by the exoplayer. So it will try to update not existing TrackSelectionHelper.

Added null pointer protection in order to avoid this issue.