### PR TITLE
null pointer protection on the mappedTrackInfo. There is a small chan…

### DIFF
--- a/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
@@ -82,6 +82,7 @@ class TrackSelectionHelper {
     boolean prepareTracks() {
         mappedTrackInfo = selector.getCurrentMappedTrackInfo();
         if(mappedTrackInfo == null){
+            log.w("Trying to get current MappedTrackInfo returns null");
             return false;
         }
         warnAboutUnsupportedRenderTypes();
@@ -261,6 +262,10 @@ class TrackSelectionHelper {
 
         log.i("change track to uniqueID -> " + uniqueId);
         mappedTrackInfo = selector.getCurrentMappedTrackInfo();
+        if(mappedTrackInfo == null){
+            log.w("Trying to get current MappedTrackInfo returns null. Do not change track with id - " + uniqueId);
+            return;
+        }
         int[] uniqueTrackId = parseUniqueId(uniqueId);
         int rendererIndex = uniqueTrackId[RENDERER_INDEX];
 


### PR DESCRIPTION
…ce that it will be null if prepare is called and at the same time application is trying to change track. So now, if the mappedTrackInfo is null the method will be exited, but warning will be logged.