### PR TITLE
Refactor format/drm enums

### DIFF
--- a/playkit/src/androidTest/java/com/kaltura/playkit/backend/OvpMediaProviderAndroidTest.java
+++ b/playkit/src/androidTest/java/com/kaltura/playkit/backend/OvpMediaProviderAndroidTest.java
@@ -111,12 +111,12 @@ public class OvpMediaProviderAndroidTest extends BaseTest {
                             assertNotNull(firstSource.getDrmData());
                             assertTrue(firstSource.getDrmData().size() >= 0);
                             assertTrue(firstSource.getUrl().endsWith("mpd"));
-                            assertTrue(firstSource.getMediaFormat().equals(PKMediaFormat.dash_drm));
+                            assertTrue(firstSource.getMediaFormat().equals(PKMediaFormat.dash));
 
                             PKMediaSource secondSource = data.getResponse().getSources().get(1);
                             assertTrue(secondSource.getDrmData().size() >= 0);
                             assertTrue(secondSource.getUrl().endsWith("mpd"));
-                            assertTrue(secondSource.getMediaFormat().equals(PKMediaFormat.dash_drm));
+                            assertTrue(secondSource.getMediaFormat().equals(PKMediaFormat.dash));
                         }
                     });
                 } else {
@@ -148,7 +148,7 @@ public class OvpMediaProviderAndroidTest extends BaseTest {
                             assertNotNull(firstSource.getDrmData());
                             assertTrue(firstSource.getDrmData().size() == 2);
                             assertTrue(firstSource.getUrl().endsWith("mpd"));
-                            assertTrue(firstSource.getMediaFormat().equals(PKMediaFormat.dash_drm));
+                            assertTrue(firstSource.getMediaFormat().equals(PKMediaFormat.dash));
 
                             /*someone added drm data to the third retrieved source (applehttp), so this section is not valid
                             PKMediaSource secondSource = data.getResponse().getSources().get(1);

--- a/playkit/src/androidTest/java/com/kaltura/playkit/backend/PhoenixMediaProviderAndroidTest.java
+++ b/playkit/src/androidTest/java/com/kaltura/playkit/backend/PhoenixMediaProviderAndroidTest.java
@@ -326,13 +326,13 @@ latchCount--;
                             assertTrue(sources.size() == 3);
                             for (PKMediaSource source : sources) {
                                 if (source.getId().equals(MediaId2_File_Main_SD)) {
-                                    assertTrue(source.getMediaFormat().equals(PKMediaFormat.wvm_widevine));
+                                    assertTrue(source.getMediaFormat().equals(PKMediaFormat.wvm));
                                 }
                                 if (source.getId().equals(MediaId2_File_Web_HD)) {
-                                    assertTrue(source.getMediaFormat().equals(PKMediaFormat.hls_clear));
+                                    assertTrue(source.getMediaFormat().equals(PKMediaFormat.hls));
                                 }
                                 if (source.getId().equals(MediaId2_File_SD_Dash)) {
-                                    assertTrue(source.getMediaFormat().equals(PKMediaFormat.dash_clear));
+                                    assertTrue(source.getMediaFormat().equals(PKMediaFormat.dash));
                                 }
                             }
                             assertTrue(response.getResponse().getMediaType().equals(PKMediaEntry.MediaEntryType.Unknown));

--- a/playkit/src/androidTest/java/com/kaltura/playkit/player/SourceSelectorAndroidTest.java
+++ b/playkit/src/androidTest/java/com/kaltura/playkit/player/SourceSelectorAndroidTest.java
@@ -20,15 +20,23 @@ import static org.junit.Assert.assertTrue;
 @RunWith(AndroidJUnit4.class)
 public class SourceSelectorAndroidTest {
 
+    public static final String MPD_EXAMPLE = "http://example.com/a.mpd";
+    public static final String MP4_EXAMPLE = "http://example.com/a.mp4";
+    public static final String M3U8_EXAMPLE = "http://example.com/a.m3u8";
+    public static final String WVM_EXAMPLE = "http://example.com/a.wvm";
+    public static final String MP3_EXAMPLE = "http://example.com/a.mp3";
+
+
+
     PKMediaSource dashWidevine = new PKMediaSource()
             .setMediaFormat(PKMediaFormat.dash)
             .setUrl("http://example.com/a.mpd")
             .setDrmData(Collections.singletonList(new PKDrmParams("http://whatever", PKDrmParams.Scheme.WidevineCENC)));
-    PKMediaSource dashClear = new PKMediaSource().setMediaFormat(PKMediaFormat.dash).setUrl("http://example.com/a.mpd");
-    PKMediaSource mp4 = new PKMediaSource().setMediaFormat(PKMediaFormat.mp4).setUrl("http://example.com/a.mp4");
-    PKMediaSource hls = new PKMediaSource().setMediaFormat(PKMediaFormat.hls).setUrl("http://example.com/a.m3u8");
-    PKMediaSource wvm = new PKMediaSource().setMediaFormat(PKMediaFormat.wvm).setUrl("http://example.com/a.wvm");
-    PKMediaSource mp3 = new PKMediaSource().setMediaFormat(PKMediaFormat.mp3).setUrl("http://example.com/a.mp3");
+    PKMediaSource dashClear = new PKMediaSource().setMediaFormat(PKMediaFormat.dash).setUrl(MPD_EXAMPLE);
+    PKMediaSource mp4 = new PKMediaSource().setMediaFormat(PKMediaFormat.mp4).setUrl(MP4_EXAMPLE);
+    PKMediaSource hls = new PKMediaSource().setMediaFormat(PKMediaFormat.hls).setUrl(M3U8_EXAMPLE);
+    PKMediaSource wvm = new PKMediaSource().setMediaFormat(PKMediaFormat.wvm).setUrl(WVM_EXAMPLE);
+    PKMediaSource mp3 = new PKMediaSource().setMediaFormat(PKMediaFormat.mp3).setUrl(MP3_EXAMPLE);
 
     private PKMediaEntry entry(PKMediaSource... sources) {
         return new PKMediaEntry().setSources(Arrays.asList(sources));

--- a/playkit/src/androidTest/java/com/kaltura/playkit/player/SourceSelectorAndroidTest.java
+++ b/playkit/src/androidTest/java/com/kaltura/playkit/player/SourceSelectorAndroidTest.java
@@ -2,6 +2,7 @@ package com.kaltura.playkit.player;
 
 import android.support.test.runner.AndroidJUnit4;
 
+import com.kaltura.playkit.PKDrmParams;
 import com.kaltura.playkit.PKMediaEntry;
 import com.kaltura.playkit.PKMediaFormat;
 import com.kaltura.playkit.PKMediaSource;
@@ -10,6 +11,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.util.Arrays;
+import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -18,12 +20,15 @@ import static org.junit.Assert.assertTrue;
 @RunWith(AndroidJUnit4.class)
 public class SourceSelectorAndroidTest {
 
-    PKMediaSource dashWidevine = new PKMediaSource().setMediaFormat(PKMediaFormat.dash_drm).setUrl("http://example.com/a.mpd");
-    PKMediaSource dashClear = new PKMediaSource().setMediaFormat(PKMediaFormat.dash_clear).setUrl("http://example.com/a.mpd");
-    PKMediaSource mp4 = new PKMediaSource().setMediaFormat(PKMediaFormat.mp4_clear).setUrl("http://example.com/a.mp4");
-    PKMediaSource hls = new PKMediaSource().setMediaFormat(PKMediaFormat.hls_clear).setUrl("http://example.com/a.m3u8");
-    PKMediaSource wvm = new PKMediaSource().setMediaFormat(PKMediaFormat.wvm_widevine).setUrl("http://example.com/a.wvm");
-    PKMediaSource mp3 = new PKMediaSource().setMediaFormat(PKMediaFormat.mp3_clear).setUrl("http://example.com/a.mp3");
+    PKMediaSource dashWidevine = new PKMediaSource()
+            .setMediaFormat(PKMediaFormat.dash)
+            .setUrl("http://example.com/a.mpd")
+            .setDrmData(Collections.singletonList(new PKDrmParams("http://whatever", PKDrmParams.Scheme.WidevineCENC)));
+    PKMediaSource dashClear = new PKMediaSource().setMediaFormat(PKMediaFormat.dash).setUrl("http://example.com/a.mpd");
+    PKMediaSource mp4 = new PKMediaSource().setMediaFormat(PKMediaFormat.mp4).setUrl("http://example.com/a.mp4");
+    PKMediaSource hls = new PKMediaSource().setMediaFormat(PKMediaFormat.hls).setUrl("http://example.com/a.m3u8");
+    PKMediaSource wvm = new PKMediaSource().setMediaFormat(PKMediaFormat.wvm).setUrl("http://example.com/a.wvm");
+    PKMediaSource mp3 = new PKMediaSource().setMediaFormat(PKMediaFormat.mp3).setUrl("http://example.com/a.mp3");
 
     private PKMediaEntry entry(PKMediaSource... sources) {
         return new PKMediaEntry().setSources(Arrays.asList(sources));
@@ -31,18 +36,18 @@ public class SourceSelectorAndroidTest {
 
     @Test
     public void mediaFormatByExtension() throws Exception {
-        assertEquals(PKMediaFormat.dash_clear, PKMediaFormat.valueOfExt("mpd"));
-        assertEquals(PKMediaFormat.mp4_clear, PKMediaFormat.valueOfExt("mp4"));
-        assertEquals(PKMediaFormat.hls_clear, PKMediaFormat.valueOfExt("m3u8"));
-        assertEquals(PKMediaFormat.wvm_widevine, PKMediaFormat.valueOfExt("wvm"));
+        assertEquals(PKMediaFormat.dash, PKMediaFormat.valueOfExt("mpd"));
+        assertEquals(PKMediaFormat.mp4, PKMediaFormat.valueOfExt("mp4"));
+        assertEquals(PKMediaFormat.hls, PKMediaFormat.valueOfExt("m3u8"));
+        assertEquals(PKMediaFormat.wvm, PKMediaFormat.valueOfExt("wvm"));
         assertEquals(null, PKMediaFormat.valueOfExt("foo"));
         assertEquals(null, PKMediaFormat.valueOfExt(null));
 
 
-        assertEquals(PKMediaFormat.dash_clear, PKMediaFormat.valueOfUrl(dashClear.getUrl()));
-        assertEquals(PKMediaFormat.mp4_clear, PKMediaFormat.valueOfUrl(mp4.getUrl()));
-        assertEquals(PKMediaFormat.hls_clear, PKMediaFormat.valueOfUrl(hls.getUrl()));
-        assertEquals(PKMediaFormat.wvm_widevine, PKMediaFormat.valueOfUrl(wvm.getUrl()));
+        assertEquals(PKMediaFormat.dash, PKMediaFormat.valueOfUrl(dashClear.getUrl()));
+        assertEquals(PKMediaFormat.mp4, PKMediaFormat.valueOfUrl(mp4.getUrl()));
+        assertEquals(PKMediaFormat.hls, PKMediaFormat.valueOfUrl(hls.getUrl()));
+        assertEquals(PKMediaFormat.wvm, PKMediaFormat.valueOfUrl(wvm.getUrl()));
         
     }
 
@@ -53,6 +58,7 @@ public class SourceSelectorAndroidTest {
         assertTrue(SourceSelector.selectSource(entry(mp4, hls)) == hls);
         assertTrue(SourceSelector.selectSource(entry(hls, mp4, dashClear)) == dashClear);
         assertTrue(SourceSelector.selectSource(entry(hls, wvm)) == hls);
+        assertTrue(SourceSelector.selectSource(entry(dashWidevine, wvm, hls, mp4)) == dashWidevine);
         assertTrue(SourceSelector.selectSource(entry(mp3)) == mp3);
 //        assertTrue(SourceSelector.selectSource(entry(mp4, wvm)) == wvm);
 

--- a/playkit/src/main/java/com/kaltura/playkit/LocalAssetsManager.java
+++ b/playkit/src/main/java/com/kaltura/playkit/LocalAssetsManager.java
@@ -135,17 +135,17 @@ public class LocalAssetsManager {
     private static PKDrmParams findSupportedDrmParams(@NonNull PKMediaSource mediaSource) {
         for (PKDrmParams params : mediaSource.getDrmData()) {
             switch (params.getScheme()) {
-                case widevine_cenc:
+                case WidevineCENC:
                     if (MediaSupport.widevineModular()) {
                         return params;
                     }
                     break;
-                case widevine_classic:
+                case WidevineClassic:
                     if (MediaSupport.widevineClassic()) {
                         return params;
                     }
                     break;
-                case playready_cenc:
+                case PlayReadyCENC:
                     log.d("Skipping unsupported PlayReady params");
                     break;
             }
@@ -192,11 +192,10 @@ public class LocalAssetsManager {
             return null;
         }
         switch (format) {
-            case dash_clear:
-            case dash_drm:
-                return PKDrmParams.Scheme.widevine_cenc;
-            case wvm_widevine:
-                return PKDrmParams.Scheme.widevine_classic;
+            case dash:
+                return PKDrmParams.Scheme.WidevineCENC;
+            case wvm:
+                return PKDrmParams.Scheme.WidevineClassic;
             default:
                 return null;
         }

--- a/playkit/src/main/java/com/kaltura/playkit/PKDrmParams.java
+++ b/playkit/src/main/java/com/kaltura/playkit/PKDrmParams.java
@@ -34,6 +34,9 @@ public class PKDrmParams implements Parcelable {
                     case Unknown:
                         supported = false;
                         break;
+                    default:
+                        supported = false;
+                        break;
                 }
             }
             return supported;

--- a/playkit/src/main/java/com/kaltura/playkit/PKDrmParams.java
+++ b/playkit/src/main/java/com/kaltura/playkit/PKDrmParams.java
@@ -9,22 +9,37 @@ public class PKDrmParams implements Parcelable {
 
     public enum Scheme {
 
-        WidevineCENC(MediaSupport.widevineModular()),
-        PlayReadyCENC(MediaSupport.playready()),
-        WidevineClassic(MediaSupport.widevineClassic()),
-        PlayReadyClassic(false),
-        FairPlay(false),
-        Unknown(false);
+        WidevineCENC,
+        PlayReadyCENC,
+        WidevineClassic,
+        PlayReadyClassic,
+        FairPlay,
+        Unknown;
 
         public boolean isSupported() {
+            if (supported == null) {
+                switch (this) {
+                    case WidevineCENC:
+                        supported = MediaSupport.widevineModular();
+                        break;
+                    case PlayReadyCENC:
+                        supported = MediaSupport.playReady();
+                        break;
+                    case WidevineClassic:
+                        supported = MediaSupport.widevineClassic();
+                        break;
+                    case PlayReadyClassic:
+                    case FairPlay:
+                    case Unknown:
+                        supported = false;
+                        break;
+                }
+            }
             return supported;
+            
         }
 
-        private final boolean supported;
-
-        Scheme(boolean supported) {
-            this.supported = supported;
-        }
+        private Boolean supported;
     }
 
     private String licenseUri;

--- a/playkit/src/main/java/com/kaltura/playkit/PKDrmParams.java
+++ b/playkit/src/main/java/com/kaltura/playkit/PKDrmParams.java
@@ -3,28 +3,32 @@ package com.kaltura.playkit;
 import android.os.Parcel;
 import android.os.Parcelable;
 
+import com.kaltura.playkit.player.MediaSupport;
+
 public class PKDrmParams implements Parcelable {
 
     public enum Scheme {
 
-        widevine_cenc,
-        playready_cenc,
-        widevine_classic,
-        playready,
-        fairplay,
-        none
+        WidevineCENC(MediaSupport.widevineModular()),
+        PlayReadyCENC(MediaSupport.playready()),
+        WidevineClassic(MediaSupport.widevineClassic()),
+        PlayReadyClassic(false),
+        FairPlay(false),
+        Unknown(false);
+
+        public boolean isSupported() {
+            return supported;
+        }
+
+        private final boolean supported;
+
+        Scheme(boolean supported) {
+            this.supported = supported;
+        }
     }
-    /*in IOS:
-    public enum Scheme: Int {
-        case widevineCenc
-        case playreadyCenc
-        case widevineClassic
-        case fairplay
-        case unknown
-    }*/
 
     private String licenseUri;
-    private Scheme scheme = Scheme.none;
+    private Scheme scheme = Scheme.Unknown;
 
     public PKDrmParams(String licenseUrl, Scheme scheme){
         this.licenseUri = licenseUrl;
@@ -33,9 +37,13 @@ public class PKDrmParams implements Parcelable {
 
     protected PKDrmParams(Parcel in) {
         licenseUri = in.readString();
-        scheme = Utils.byValue(Scheme.class, in.readString(), Scheme.none);//Scheme.valueOf(in.readString());
+        scheme = Utils.byValue(Scheme.class, in.readString(), Scheme.Unknown);//Scheme.valueOf(in.readString());
     }
 
+    public boolean isSchemeSupported() {
+        return scheme != null && scheme.isSupported();
+    }
+    
     public String getLicenseUri() {
         return licenseUri;
     }

--- a/playkit/src/main/java/com/kaltura/playkit/PKDrmParams.java
+++ b/playkit/src/main/java/com/kaltura/playkit/PKDrmParams.java
@@ -16,6 +16,7 @@ public class PKDrmParams implements Parcelable {
         FairPlay,
         Unknown;
 
+        private Boolean supported;
         public boolean isSupported() {
             if (supported == null) {
                 switch (this) {
@@ -38,8 +39,6 @@ public class PKDrmParams implements Parcelable {
             return supported;
             
         }
-
-        private Boolean supported;
     }
 
     private String licenseUri;

--- a/playkit/src/main/java/com/kaltura/playkit/PKMediaFormat.java
+++ b/playkit/src/main/java/com/kaltura/playkit/PKMediaFormat.java
@@ -6,20 +6,13 @@ import java.util.HashMap;
 import java.util.Map;
 
 public enum PKMediaFormat {
-    mp4_clear("video/mp4", "mp4"),
-    dash_clear("application/dash+xml", "mpd"),
-    dash_drm("application/dash+xml", "mpd"),
-    wvm_widevine("video/wvm", "wvm"),
-    hls_clear("application/x-mpegURL", "m3u8"),
-    mp3_clear("audio/mpeg", "mp3");
-
-    /* in IOS:
-     case dash
-        case hls
-        case wvm
-        case mp4
-        case mp3
-        case unknown*/
+    dash("application/dash+xml", "mpd"),
+    hls("application/x-mpegURL", "m3u8"),
+    wvm("video/wvm", "wvm"),
+    mp4("video/mp4", "mp4"),
+    mp3("audio/mpeg", "mp3"),
+    unknown(null, null),
+    ;
 
     public final String mimeType;
     public final String pathExt;

--- a/playkit/src/main/java/com/kaltura/playkit/PKMediaSource.java
+++ b/playkit/src/main/java/com/kaltura/playkit/PKMediaSource.java
@@ -61,7 +61,7 @@ public class PKMediaSource implements Parcelable {
     }
 
     public boolean hasDrmParams() {
-        return (drmData != null && drmData.size() > 0) ? true : false;
+        return (drmData != null && drmData.size() > 0);
     }
 
     @Override

--- a/playkit/src/main/java/com/kaltura/playkit/backend/base/FormatsHelper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/backend/base/FormatsHelper.java
@@ -1,6 +1,5 @@
 package com.kaltura.playkit.backend.base;
 
-import com.kaltura.playkit.PKDrmParams;
 import com.kaltura.playkit.PKMediaFormat;
 import com.kaltura.playkit.backend.base.data.BasePlaybackSource;
 
@@ -15,7 +14,6 @@ public class FormatsHelper {
 
     public enum StreamFormat {
         MpegDash("mpegdash"),
-        MpegDashDrm("mpegdash+drm"),
         AppleHttp("applehttp"),
         Url("url"),
         UrlDrm("url+drm"),
@@ -47,11 +45,10 @@ public class FormatsHelper {
 
     static{
         SupportedFormats = new HashMap<StreamFormat, PKMediaFormat>();
-        SupportedFormats.put(StreamFormat.MpegDash, PKMediaFormat.dash_clear);
-        SupportedFormats.put(StreamFormat.MpegDashDrm, PKMediaFormat.dash_drm);
-        SupportedFormats.put(StreamFormat.AppleHttp, PKMediaFormat.hls_clear);
-        SupportedFormats.put(StreamFormat.Url, PKMediaFormat.mp4_clear);
-        SupportedFormats.put(StreamFormat.UrlDrm, PKMediaFormat.wvm_widevine);
+        SupportedFormats.put(StreamFormat.MpegDash, PKMediaFormat.dash);
+        SupportedFormats.put(StreamFormat.AppleHttp, PKMediaFormat.hls);
+        SupportedFormats.put(StreamFormat.Url, PKMediaFormat.mp4);
+        SupportedFormats.put(StreamFormat.UrlDrm, PKMediaFormat.wvm);
     }
 
     public static Map<StreamFormat, PKMediaFormat> getSupportedFormats() {
@@ -64,11 +61,11 @@ public class FormatsHelper {
         StreamFormat streamFormat = StreamFormat.byValue(format);
         switch (streamFormat) {
             case MpegDash:
-                return hasDrm ? SupportedFormats.get(StreamFormat.MpegDashDrm) : SupportedFormats.get(StreamFormat.MpegDash);
+                return PKMediaFormat.dash;
             case Url:
-                return hasDrm ? SupportedFormats.get(StreamFormat.UrlDrm) : SupportedFormats.get(StreamFormat.Url);
+                return hasDrm ? PKMediaFormat.wvm : PKMediaFormat.mp4;
             case AppleHttp:
-                return hasDrm ? null : SupportedFormats.get(StreamFormat.AppleHttp);
+                return PKMediaFormat.hls;
         }
         return null;
     }
@@ -78,29 +75,16 @@ public class FormatsHelper {
         StreamFormat streamFormat = StreamFormat.byValue(format);
         switch (streamFormat) {
             case MpegDash:
-                return schemes == null ?
-                        SupportedFormats.get(StreamFormat.MpegDash) :
-                        schemes.contains(PKDrmParams.Scheme.widevine_cenc.name()) ?
-                                SupportedFormats.get(StreamFormat.MpegDashDrm) :
-                                null;
+                return PKMediaFormat.dash;
 
             case Url:
-                return schemes == null ?
-                        SupportedFormats.get(StreamFormat.Url) :
-                        schemes.contains(PKDrmParams.Scheme.widevine_classic.name()) ?
-                                SupportedFormats.get(StreamFormat.UrlDrm) :
-                                null;
+                return schemes == null ? PKMediaFormat.mp4 : PKMediaFormat.wvm;
 
             case AppleHttp:
-                return schemes == null ?
-                        SupportedFormats.get(StreamFormat.AppleHttp) :
-                        null;
-                        /*!schemes.contains(PKDrmParams.Scheme.FAIRPLAY.name()) ?
-                                SupportedFormats.get(StreamFormat.UrlDrm) :
-                                null;*/
+                return PKMediaFormat.hls;
 
             default:
-                return null;
+                return PKMediaFormat.unknown;
 
         }
     }

--- a/playkit/src/main/java/com/kaltura/playkit/backend/base/FormatsHelper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/backend/base/FormatsHelper.java
@@ -69,26 +69,7 @@ public class FormatsHelper {
         }
         return null;
     }
-
-    // for future use
-    public static PKMediaFormat getPKMediaFormat(String format, String schemes) {
-        StreamFormat streamFormat = StreamFormat.byValue(format);
-        switch (streamFormat) {
-            case MpegDash:
-                return PKMediaFormat.dash;
-
-            case Url:
-                return schemes == null ? PKMediaFormat.mp4 : PKMediaFormat.wvm;
-
-            case AppleHttp:
-                return PKMediaFormat.hls;
-
-            default:
-                return PKMediaFormat.unknown;
-
-        }
-    }
-
+    
     /**
      * checks if the format name from the source parameter has a matching supported {@link PKMediaFormat}
      * element.

--- a/playkit/src/main/java/com/kaltura/playkit/backend/ovp/KalturaOvpMediaProvider.java
+++ b/playkit/src/main/java/com/kaltura/playkit/backend/ovp/KalturaOvpMediaProvider.java
@@ -59,9 +59,9 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
-import static com.kaltura.playkit.PKDrmParams.Scheme.playready_cenc;
-import static com.kaltura.playkit.PKDrmParams.Scheme.widevine_cenc;
-import static com.kaltura.playkit.PKDrmParams.Scheme.widevine_classic;
+import static com.kaltura.playkit.PKDrmParams.Scheme.PlayReadyCENC;
+import static com.kaltura.playkit.PKDrmParams.Scheme.WidevineCENC;
+import static com.kaltura.playkit.PKDrmParams.Scheme.WidevineClassic;
 
 /**
  * Created by tehilarozin on 30/10/2016.
@@ -560,11 +560,11 @@ public class KalturaOvpMediaProvider extends BEMediaProvider {
 
         switch (name) {
             case "drm.WIDEVINE_CENC":
-                return widevine_cenc;
+                return WidevineCENC;
             case "drm.PLAYREADY_CENC":
-                return playready_cenc;
+                return PlayReadyCENC;
             case "widevine.WIDEVINE":
-                return widevine_classic;
+                return WidevineClassic;
             default:
                 return null;
         }

--- a/playkit/src/main/java/com/kaltura/playkit/backend/phoenix/PhoenixMediaProvider.java
+++ b/playkit/src/main/java/com/kaltura/playkit/backend/phoenix/PhoenixMediaProvider.java
@@ -38,10 +38,10 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 
-import static com.kaltura.playkit.PKDrmParams.Scheme.playready;
-import static com.kaltura.playkit.PKDrmParams.Scheme.playready_cenc;
-import static com.kaltura.playkit.PKDrmParams.Scheme.widevine_cenc;
-import static com.kaltura.playkit.PKDrmParams.Scheme.widevine_classic;
+import static com.kaltura.playkit.PKDrmParams.Scheme.PlayReadyClassic;
+import static com.kaltura.playkit.PKDrmParams.Scheme.PlayReadyCENC;
+import static com.kaltura.playkit.PKDrmParams.Scheme.WidevineCENC;
+import static com.kaltura.playkit.PKDrmParams.Scheme.WidevineClassic;
 
 
 /**
@@ -467,13 +467,13 @@ public class PhoenixMediaProvider extends BEMediaProvider {
 
         switch (scheme) {
             case "WIDEVINE_CENC":
-                return widevine_cenc;
+                return WidevineCENC;
             case "PLAYREADY_CENC":
-                return playready_cenc;
+                return PlayReadyCENC;
             case "WIDEVINE":
-                return widevine_classic;
+                return WidevineClassic;
             case "PLAYREADY":
-                return playready;
+                return PlayReadyClassic;
             default:
                 return null;
         }

--- a/playkit/src/main/java/com/kaltura/playkit/drm/DeferredDrmSessionManager.java
+++ b/playkit/src/main/java/com/kaltura/playkit/drm/DeferredDrmSessionManager.java
@@ -74,8 +74,8 @@ public class DeferredDrmSessionManager implements DrmSessionManager<FrameworkMed
         if (mediaSource.hasDrmParams()) {
             List<PKDrmParams> drmData = mediaSource.getDrmData();
             for (PKDrmParams pkDrmParam : drmData) {
-                // selecting widevine_cenc as default right now
-                if (PKDrmParams.Scheme.widevine_cenc == pkDrmParam.getScheme()) {
+                // selecting WidevineCENC as default right now
+                if (PKDrmParams.Scheme.WidevineCENC == pkDrmParam.getScheme()) {
                     licenseUrl = pkDrmParam.getLicenseUri();
                     break;
                 }

--- a/playkit/src/main/java/com/kaltura/playkit/drm/DrmAdapter.java
+++ b/playkit/src/main/java/com/kaltura/playkit/drm/DrmAdapter.java
@@ -27,11 +27,11 @@ public abstract class DrmAdapter {
         }
         
         switch (scheme) {
-            case widevine_cenc:
+            case WidevineCENC:
                 return new WidevineModularAdapter(context, localDataStore);
-            case widevine_classic:
+            case WidevineClassic:
                 return new WidevineClassicAdapter(context);
-            case playready_cenc:
+            case PlayReadyCENC:
                 log.d("Unsupported scheme PlayReady");
                 break;
         }

--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
@@ -171,17 +171,16 @@ class ExoPlayerWrapper implements PlayerEngine, ExoPlayer.EventListener {
 
         switch (format) {
             // mp4 and mp3 both use ExtractorMediaSource
-            case mp4_clear:
-            case mp3_clear:
+            case mp4:
+            case mp3:
                 return new ExtractorMediaSource(uri, mediaDataSourceFactory, new DefaultExtractorsFactory(),
                         mainHandler, eventLogger);
 
-            case dash_clear:
-            case dash_drm:
+            case dash:
                 return new DashMediaSource(uri, buildDataSourceFactory(false),
                         new DefaultDashChunkSource.Factory(mediaDataSourceFactory), mainHandler, eventLogger);
 
-            case hls_clear:
+            case hls:
                 return new HlsMediaSource(uri, mediaDataSourceFactory, mainHandler, eventLogger);
 
             default:

--- a/playkit/src/main/java/com/kaltura/playkit/player/MediaSupport.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/MediaSupport.java
@@ -67,13 +67,12 @@ public class MediaSupport {
     }
 
     public static boolean widevineModular() {
-        if (!initialized) {
-            // Encrypted dash is only supported in Android v4.3 and up -- needs MediaDrm class.
-            // Make sure Widevine is supported
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2 && MediaDrm.isCryptoSchemeSupported(WIDEVINE_UUID)) {
-                widevineModular = true;
-            }
+        // Encrypted dash is only supported in Android v4.3 and up -- needs MediaDrm class.
+        // Make sure Widevine is supported
+        if (!initialized && Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2 && MediaDrm.isCryptoSchemeSupported(WIDEVINE_UUID)) {
+            widevineModular = true;
         }
+
         return widevineModular;
     }
 

--- a/playkit/src/main/java/com/kaltura/playkit/player/MediaSupport.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/MediaSupport.java
@@ -23,7 +23,7 @@ public class MediaSupport {
     private static boolean initialized = false;
 
     private static final PKLog log = PKLog.get("MediaSupport");
-    
+
     public static void initialize(@NonNull final Context context) {
         if (initialized) {
             return;
@@ -37,7 +37,7 @@ public class MediaSupport {
             }
         }.start();
     }
-    
+
     private static void checkWidevineClassic(Context context) {
         DrmManagerClient drmManagerClient = new DrmManagerClient(context);
         try {
@@ -56,30 +56,27 @@ public class MediaSupport {
             drmManagerClient.release();
         }
     }
-    
+
     public static boolean widevineClassic() {
         if (initialized) {
             return widevineClassic;
         }
-        
+
         log.w("MediaSupport not initialized; assuming no Widevine Classic support");
-        
         return false;
     }
 
     public static boolean widevineModular() {
         if (!initialized) {
             // Encrypted dash is only supported in Android v4.3 and up -- needs MediaDrm class.
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
-                // Make sure Widevine is supported.
-                if (MediaDrm.isCryptoSchemeSupported(WIDEVINE_UUID)) {
-                    widevineModular = true;
-                }
+            // Make sure Widevine is supported
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2 && MediaDrm.isCryptoSchemeSupported(WIDEVINE_UUID)) {
+                widevineModular = true;
             }
         }
         return widevineModular;
     }
-    
+
     public static boolean playReady() {
         return false;   // Not yet.
     }

--- a/playkit/src/main/java/com/kaltura/playkit/player/MediaSupport.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/MediaSupport.java
@@ -18,9 +18,9 @@ public class MediaSupport {
     public static final UUID WIDEVINE_UUID = UUID.fromString("edef8ba9-79d6-4ace-a3c8-27dcd51d21ed");
 
 
-    private static Boolean widevineClassic;
-    private static Boolean widevineModular;
-    private static boolean initialized;
+    private static boolean widevineClassic = false;
+    private static boolean widevineModular = false;
+    private static boolean initialized = false;
 
     private static final PKLog log = PKLog.get("MediaSupport");
     
@@ -58,7 +58,7 @@ public class MediaSupport {
     }
     
     public static boolean widevineClassic() {
-        if (widevineClassic != null) {
+        if (initialized) {
             return widevineClassic;
         }
         
@@ -68,21 +68,19 @@ public class MediaSupport {
     }
 
     public static boolean widevineModular() {
-        if (widevineModular != null) {
-            return widevineModular;
-        }
-        // Encrypted dash is only supported in Android v4.3 and up -- needs MediaDrm class.
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
-            // Make sure Widevine is supported.
-            if (MediaDrm.isCryptoSchemeSupported(WIDEVINE_UUID)) {
-                widevineModular = true;
-                return true;
+        if (!initialized) {
+            // Encrypted dash is only supported in Android v4.3 and up -- needs MediaDrm class.
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
+                // Make sure Widevine is supported.
+                if (MediaDrm.isCryptoSchemeSupported(WIDEVINE_UUID)) {
+                    widevineModular = true;
+                }
             }
         }
-        return false;
+        return widevineModular;
     }
     
-    public static boolean playready() {
+    public static boolean playReady() {
         return false;   // Not yet.
     }
 }

--- a/playkit/src/main/java/com/kaltura/playkit/player/PlayerController.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/PlayerController.java
@@ -159,7 +159,7 @@ public class PlayerController implements Player {
             return;
         }
 
-        if (source.getMediaFormat() != PKMediaFormat.wvm_widevine) {
+        if (source.getMediaFormat() != PKMediaFormat.wvm) {
             if (player == null) {
                 player = new ExoPlayerWrapper(context);
                 togglePlayerListeners(true);

--- a/playkit/src/main/java/com/kaltura/playkit/plugins/ads/ima/IMAConfig.java
+++ b/playkit/src/main/java/com/kaltura/playkit/plugins/ads/ima/IMAConfig.java
@@ -53,7 +53,7 @@ public class IMAConfig {
         this.adCountDown              = true;
         this.adLoadTimeOut            = DEFAULT_AD_LOAD_TIMEOUT;
         this.videoMimeTypes           = new ArrayList<>();
-        this.videoMimeTypes.add(PKMediaFormat.mp4_clear.mimeType);
+        this.videoMimeTypes.add(PKMediaFormat.mp4.mimeType);
         this.adTagURL = null;         //=> must be set via setter
 
         //if (tagTimes == null) {

--- a/playkitdemo/src/main/java/com/kaltura/playkitdemo/LocalAssets.java
+++ b/playkitdemo/src/main/java/com/kaltura/playkitdemo/LocalAssets.java
@@ -29,11 +29,11 @@ import java.util.Collections;
 public class LocalAssets {
     private static final PKLog log = PKLog.get("LocalAssets");
     
-    private PKDrmParams drmParams = new PKDrmParams("https://udrm.kaltura.com/widevine/license?custom_data=eyJjYV9zeXN0ZW0iOiJPVlAiLCJ1c2VyX3Rva2VuIjoiZGpKOE1UZzFNVFUzTVh4NThBVkFQOXo1R0lvU3BXWE95emEtdWlQNnk5cXpBdkpkMzZfUFZOcUNfT0NZWWhLRVh5LThqcGFMRktGcU15d3VTN2ZLZmxibTd1VVJGQkVtSGxsNkc4NEU2LUxrcnFXbVV1ZWEtZnFqdXc9PSIsImFjY291bnRfaWQiOiIxODUxNTcxIiwiY29udGVudF9pZCI6IjBfcGw1bGJmbzAiLCJmaWxlcyI6IjBfendxM2w0NHIsMF91YTYycms2cywwX290bWFxcG5mLDBfeXdrbXFua2csMV9lMHF0YWoxaiwxX2IycXp5dmE3In0%3D&signature=LFiNPZL8%2BNevsZ8cNhrmSDM4SDQ%3D", PKDrmParams.Scheme.widevine_classic);
+    private PKDrmParams drmParams = new PKDrmParams("https://udrm.kaltura.com/widevine/license?custom_data=eyJjYV9zeXN0ZW0iOiJPVlAiLCJ1c2VyX3Rva2VuIjoiZGpKOE1UZzFNVFUzTVh4NThBVkFQOXo1R0lvU3BXWE95emEtdWlQNnk5cXpBdkpkMzZfUFZOcUNfT0NZWWhLRVh5LThqcGFMRktGcU15d3VTN2ZLZmxibTd1VVJGQkVtSGxsNkc4NEU2LUxrcnFXbVV1ZWEtZnFqdXc9PSIsImFjY291bnRfaWQiOiIxODUxNTcxIiwiY29udGVudF9pZCI6IjBfcGw1bGJmbzAiLCJmaWxlcyI6IjBfendxM2w0NHIsMF91YTYycms2cywwX290bWFxcG5mLDBfeXdrbXFua2csMV9lMHF0YWoxaiwxX2IycXp5dmE3In0%3D&signature=LFiNPZL8%2BNevsZ8cNhrmSDM4SDQ%3D", PKDrmParams.Scheme.WidevineClassic);
     private PKMediaSource widevineClassicSource = new PKMediaSource()
             .setId("wvc")
             .setDrmData(Collections.singletonList(drmParams))
-            .setMediaFormat(PKMediaFormat.wvm_widevine)
+            .setMediaFormat(PKMediaFormat.wvm)
             .setUrl("http://cdnapi.kaltura.com/p/1851571/playManifest/entryId/0_pl5lbfo0/format/url/tags/widevine/protocol/http/a.wvm");
     private String localAssetPath;
 

--- a/playkitdemo/src/main/java/com/kaltura/playkitdemo/MainActivity.java
+++ b/playkitdemo/src/main/java/com/kaltura/playkitdemo/MainActivity.java
@@ -148,8 +148,8 @@ public class MainActivity extends AppCompatActivity implements AdapterView.OnIte
 
     private void startSimpleOvpMediaLoading(OnMediaLoadCompletion completion) {
         new KalturaOvpMediaProvider()
-                .setSessionProvider(new SimpleOvpSessionProvider("https://cdnapisec.kaltura.com", 1851571, null))
-                .setEntryId("0_pl5lbfo0")
+                .setSessionProvider(new SimpleOvpSessionProvider("https://cdnapisec.kaltura.com", 2222401, null))
+                .setEntryId("1_f93tepsn")
                 .load(completion);
     }
 


### PR DESCRIPTION
Capitalization renames of drm schemes.

Changes in PKMediaFormat enum:
- unified dash_clear and dash_drm as dash
- renamed hls_clear, mp4_clear, mp3_clear to hls, mp4, mp3
- renamed wvm_widevine to wvm

This simplifies FormatsHelper in providers.