### PR TITLE
Fix widevice classic change media if done multiple times one after an…

### DIFF
--- a/playkit/src/main/java/com/kaltura/playkit/player/MediaPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/MediaPlayerWrapper.java
@@ -37,7 +37,7 @@ public class MediaPlayerWrapper implements PlayerEngine, SurfaceHolder.Callback,
 
     private static final PKLog log = PKLog.get("MediaPlayerWrapper");
 
-    private static int ILLEGAL_STATEׁ_ORERATION = -38;
+    private static int ILLEGAL_STATEׁ_OPERATION = -38;
 
     private Context context;
     private MediaPlayer player;
@@ -476,7 +476,7 @@ public class MediaPlayerWrapper implements PlayerEngine, SurfaceHolder.Callback,
         String errMsg = "onError what = " + what;
         log.e(errMsg);
 
-        if (what == ILLEGAL_STATEׁ_ORERATION) {
+        if (what == ILLEGAL_STATEׁ_OPERATION) {
             release();
             player.reset();
             try {


### PR DESCRIPTION
…other without waiting for previous prepare

each time when  switch to new media it created new callback listeners for player it allowed to unsynchronize all events if it calls very often and fast

now we do it once and prevent doing it when we are in preparing state