### PR TITLE
FEM-1371

### DIFF
--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
@@ -121,7 +121,6 @@ class ExoPlayerWrapper implements PlayerEngine, ExoPlayer.EventListener, Metadat
         this.context = context;
         mediaDataSourceFactory = buildDataSourceFactory(true);
         exoPlayerView = new ExoPlayerView(context);
-        window = new Timeline.Window();
     }
 
     private void initializePlayer() {
@@ -327,7 +326,7 @@ class ExoPlayerWrapper implements PlayerEngine, ExoPlayer.EventListener, Metadat
         log.d("onTimelineChanged");
         sendDistinctEvent(PlayerEvent.Type.LOADED_METADATA);
         sendDistinctEvent(PlayerEvent.Type.DURATION_CHANGE);
-        shouldResetPlayerPosition = timeline != null && !timeline.isEmpty()
+        shouldResetPlayerPosition = timeline != null && !timeline.isEmpty() && window != null
                 && !timeline.getWindow(timeline.getWindowCount() - 1, window).isDynamic;
     }
 


### PR DESCRIPTION
make shure that we do not call timeline.getWindow(timeline.getWindowCount() - 1, window) if window is null. Also remove unnecessary cal to new Timeline.Window in ExoPlayerWrapper.java constructor. (It is called in initializePlayer method)