### PR TITLE
FEM-1372 PhoenixAnalyticsPlugin fix and minor refactor

### DIFF
--- a/playkit/src/main/java/com/kaltura/playkit/plugins/PhoenixAnalyticsPlugin.java
+++ b/playkit/src/main/java/com/kaltura/playkit/plugins/PhoenixAnalyticsPlugin.java
@@ -43,17 +43,22 @@ public class PhoenixAnalyticsPlugin extends PKPlugin {
         BITRATE_CHANGE,
         ERROR
     }
-    private boolean isFirstPlay = true;
-    private boolean intervalOn = false;
-    private long mContinueTime;
-    public PKMediaConfig mediaConfig;
-    public JsonObject pluginConfig;
+
     private Context mContext;
     public Player player;
+    public MessageBus messageBus; // used also by TVPAI Analytics
+    public JsonObject pluginConfig;
+    public PKMediaConfig mediaConfig;
+
     public RequestQueue requestsExecutor;
     private java.util.Timer timer = new java.util.Timer();
+
+    private long mContinueTime;
     private long lastKnownPlayerPosition = 0;
-    public MessageBus messageBus; // used also by TVPAI Analytics
+
+    private boolean isFirstPlay = true;
+    private boolean intervalOn = false;
+    private boolean timerWasCancelled = false;
 
 
     public static final Factory factory = new Factory() {
@@ -104,6 +109,7 @@ public class PhoenixAnalyticsPlugin extends PKPlugin {
     public void onDestroy() {
         log.d("onDestroy");
         timer.cancel();
+        timerWasCancelled = true;
     }
 
     @Override
@@ -155,7 +161,7 @@ public class PhoenixAnalyticsPlugin extends PKPlugin {
                         } else {
                             sendAnalyticsEvent(PhoenixActionType.PLAY);
                         }
-                        if (!intervalOn){
+                        if (!intervalOn || !timerWasCancelled){
                             startMediaHitInterval();
                             intervalOn = true;
                         }


### PR DESCRIPTION
+ Some small refactoring.
+ Add flag that will indicate that plugin was destroyed and schedule timer is cancelled. In some rare cases app can crash because it will try to schedule a timer task on the timer that was cancelled in onDestroy.