### PR TITLE
Fem 1445

### DIFF
--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
@@ -95,7 +95,7 @@ class ExoPlayerWrapper implements PlayerEngine, ExoPlayer.EventListener, Metadat
     private int sameErrorOccurrenceCounter = 0;
     private List<PKMetadata> metadataList = new ArrayList<>();
 
-    private String[] lastSelectedTrackIndexes = {TrackSelectionHelper.NONE, TrackSelectionHelper.NONE, TrackSelectionHelper.NONE};
+    private String[] mLastSelectedTrackIndexes = {TrackSelectionHelper.NONE, TrackSelectionHelper.NONE, TrackSelectionHelper.NONE};
 
     @Override
     public void onBandwidthSample(int elapsedMs, long bytes, long bitrate) {
@@ -107,6 +107,8 @@ class ExoPlayerWrapper implements PlayerEngine, ExoPlayer.EventListener, Metadat
         void onTracksInfoReady(PKTracks PKTracks);
 
         void onTrackChanged();
+
+        void updateLastSelectedTrackIndexes(String[] lastSelectedTrackIndexes);
     }
 
     private TracksInfoListener tracksInfoListener = new TracksInfoListener() {
@@ -121,6 +123,11 @@ class ExoPlayerWrapper implements PlayerEngine, ExoPlayer.EventListener, Metadat
         @Override
         public void onTrackChanged() {
             sendEvent(PlayerEvent.Type.PLAYBACK_INFO_UPDATED);
+        }
+
+        @Override
+        public void updateLastSelectedTrackIndexes(String[] lastSelectedTrackIndexes) {
+            mLastSelectedTrackIndexes = lastSelectedTrackIndexes;
         }
     };
 
@@ -159,7 +166,7 @@ class ExoPlayerWrapper implements PlayerEngine, ExoPlayer.EventListener, Metadat
         TrackSelection.Factory trackSelectionFactory =
                 new AdaptiveTrackSelection.Factory(bandwidthMeter);
         DefaultTrackSelector trackSelector = new DefaultTrackSelector(trackSelectionFactory);
-        trackSelectionHelper = new TrackSelectionHelper(trackSelector, trackSelectionFactory, lastSelectedTrackIndexes);
+        trackSelectionHelper = new TrackSelectionHelper(trackSelector, trackSelectionFactory, mLastSelectedTrackIndexes);
         trackSelectionHelper.setTracksInfoListener(tracksInfoListener);
 
         return trackSelector;
@@ -477,7 +484,6 @@ class ExoPlayerWrapper implements PlayerEngine, ExoPlayer.EventListener, Metadat
             this.eventLogger = null;
             player.release();
             player = null;
-            this.lastSelectedTrackIndexes = trackSelectionHelper.getLastSelectedTrackIds();
             trackSelectionHelper.release();
             trackSelectionHelper = null;
             eventLogger = null;

--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
@@ -97,12 +97,12 @@ class ExoPlayerWrapper implements PlayerEngine, ExoPlayer.EventListener, Metadat
 
     private String[] lastSelectedTrackIds = {TrackSelectionHelper.NONE, TrackSelectionHelper.NONE, TrackSelectionHelper.NONE};
 
+    private TrackSelectionHelper.TracksInfoListener tracksInfoListener = initTracksInfoListener();
+
     @Override
     public void onBandwidthSample(int elapsedMs, long bytes, long bitrate) {
         sendEvent(PlayerEvent.Type.PLAYBACK_INFO_UPDATED);
     }
-
-    private TrackSelectionHelper.TracksInfoListener tracksInfoListener = initTracksInfoListener();
 
 
     ExoPlayerWrapper(Context context) {

--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
@@ -95,7 +95,7 @@ class ExoPlayerWrapper implements PlayerEngine, ExoPlayer.EventListener, Metadat
     private int sameErrorOccurrenceCounter = 0;
     private List<PKMetadata> metadataList = new ArrayList<>();
 
-    private String[] lastSelectedTrackIndexes = {TrackSelectionHelper.NONE_SUFFIX, TrackSelectionHelper.NONE_SUFFIX, TrackSelectionHelper.NONE_SUFFIX};
+    private String[] lastSelectedTrackIndexes = {TrackSelectionHelper.NONE, TrackSelectionHelper.NONE, TrackSelectionHelper.NONE};
 
     @Override
     public void onBandwidthSample(int elapsedMs, long bytes, long bitrate) {

--- a/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
@@ -541,6 +541,7 @@ class TrackSelectionHelper {
     }
 
     void release() {
+        tracksInfoListener.updateLastSelectedTrackIndexes(lastSelectedTrackIds);
         tracksInfoListener = null;
         clearTracksLists();
     }
@@ -609,10 +610,6 @@ class TrackSelectionHelper {
 
     void setCea608CaptionsEnabled(boolean cea608CaptionsEnabled) {
         this.cea608CaptionsEnabled = cea608CaptionsEnabled;
-    }
-
-    String[] getLastSelectedTrackIds() {
-        return lastSelectedTrackIds;
     }
 }
 

--- a/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
@@ -38,8 +38,8 @@ class TrackSelectionHelper {
     private static final int TRACK_INDEX = 2;
     private static final int TRACK_RENDERERS_AMOUNT = 3;
 
-    static final String NONE_SUFFIX = "none";
-    private static final String ADAPTIVE_SUFFIX = "adaptive";
+    static final String NONE = "none";
+    private static final String ADAPTIVE = "adaptive";
 
     private static final String VIDEO = "video";
     private static final String VIDEO_PREFIX = "Video:";
@@ -65,7 +65,7 @@ class TrackSelectionHelper {
     private long currentVideoWidth = Consts.NO_VALUE;
     private long currentVideoHeight = Consts.NO_VALUE;
 
-    private String[] lastSelectedTrackIds = {NONE_SUFFIX, NONE_SUFFIX, NONE_SUFFIX};
+    private String[] lastSelectedTrackIds = {NONE, NONE, NONE};
 
     private boolean cea608CaptionsEnabled; //Flag that indicates if application interested in receiving cea-608 text track format.
 
@@ -185,7 +185,7 @@ class TrackSelectionHelper {
             return;
         }
         String uniqueId = getUniqueId(Consts.TRACK_TYPE_TEXT, 0, TRACK_DISABLED);
-        textTracks.add(0, new TextTrack(uniqueId, NONE_SUFFIX, NONE_SUFFIX, -1));
+        textTracks.add(0, new TextTrack(uniqueId, NONE, NONE, -1));
     }
 
     /**
@@ -210,15 +210,16 @@ class TrackSelectionHelper {
     /**
      * Will restore last selected track, only if there was actual selection and it is
      * differed from the default selection.
-     * @param trackList - the list of tracks to manipulate.
+     *
+     * @param trackList           - the list of tracks to manipulate.
      * @param lastSelectedTrackId - last selected track unique id.
-     * @param defaultTrackIndex - the index of the default track.
+     * @param defaultTrackIndex   - the index of the default track.
      * @return - The index of the last selected track id.
      */
     private int restoreLastSelectedTrack(List<? extends BaseTrack> trackList, String lastSelectedTrackId, int defaultTrackIndex) {
         //If track was previously selected and selection is differed from the default selection apply it.
         String defaultUniqueId = trackList.get(defaultTrackIndex).getUniqueId();
-        if (!NONE_SUFFIX.equals(lastSelectedTrackId) && !lastSelectedTrackId.equals(defaultUniqueId)) {
+        if (!NONE.equals(lastSelectedTrackId) && !lastSelectedTrackId.equals(defaultUniqueId)) {
             changeTrack(lastSelectedTrackId);
             for (int i = 0; i < trackList.size(); i++) {
                 if (lastSelectedTrackId.equals(trackList.get(i).getUniqueId())) {
@@ -281,9 +282,9 @@ class TrackSelectionHelper {
         uniqueStringBuilder.append(groupIndex);
         uniqueStringBuilder.append(",");
         if (trackIndex == TRACK_ADAPTIVE) {
-            uniqueStringBuilder.append(ADAPTIVE_SUFFIX);
+            uniqueStringBuilder.append(ADAPTIVE);
         } else if (trackIndex == TRACK_DISABLED) {
-            uniqueStringBuilder.append(NONE_SUFFIX);
+            uniqueStringBuilder.append(NONE);
         } else {
             uniqueStringBuilder.append(trackIndex);
         }
@@ -346,10 +347,10 @@ class TrackSelectionHelper {
 
         for (int i = 0; i < strArray.length; i++) {
             switch (strArray[i]) {
-                case ADAPTIVE_SUFFIX:
+                case ADAPTIVE:
                     parsedUniqueId[i] = TRACK_ADAPTIVE;
                     break;
-                case NONE_SUFFIX:
+                case NONE:
                     parsedUniqueId[i] = TRACK_DISABLED;
                     break;
                 default:
@@ -468,7 +469,7 @@ class TrackSelectionHelper {
     private int getIndexFromUniqueId(String uniqueId, int groupIndex) {
         String uniqueIdWithoutPrefix = removePrefix(uniqueId);
         String[] strArray = uniqueIdWithoutPrefix.split(",");
-        if (strArray[groupIndex].equals(ADAPTIVE_SUFFIX)) {
+        if (strArray[groupIndex].equals(ADAPTIVE)) {
             return -1;
         }
 
@@ -539,7 +540,7 @@ class TrackSelectionHelper {
         textTracks.clear();
     }
 
-    public void release() {
+    void release() {
         tracksInfoListener = null;
         clearTracksLists();
     }
@@ -606,11 +607,11 @@ class TrackSelectionHelper {
         tracksInfoListener.onTrackChanged();
     }
 
-    public void setCea608CaptionsEnabled(boolean cea608CaptionsEnabled) {
+    void setCea608CaptionsEnabled(boolean cea608CaptionsEnabled) {
         this.cea608CaptionsEnabled = cea608CaptionsEnabled;
     }
 
-    public String[] getLastSelectedTrackIds() {
+    String[] getLastSelectedTrackIds() {
         return lastSelectedTrackIds;
     }
 }

--- a/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
@@ -54,20 +54,30 @@ class TrackSelectionHelper {
     private final DefaultTrackSelector selector;
     private MappingTrackSelector.MappedTrackInfo mappedTrackInfo;
     private final TrackSelection.Factory adaptiveTrackSelectionFactory;
-    private ExoPlayerWrapper.TracksInfoListener tracksInfoListener;
+    private TracksInfoListener tracksInfoListener;
 
     private List<VideoTrack> videoTracks = new ArrayList<>();
     private List<AudioTrack> audioTracks = new ArrayList<>();
     private List<TextTrack> textTracks = new ArrayList<>();
+
+    private String[] lastSelectedTrackIds;
 
     private long currentVideoBitrate = Consts.NO_VALUE;
     private long currentAudioBitrate = Consts.NO_VALUE;
     private long currentVideoWidth = Consts.NO_VALUE;
     private long currentVideoHeight = Consts.NO_VALUE;
 
-    private String[] lastSelectedTrackIds = {NONE, NONE, NONE};
 
     private boolean cea608CaptionsEnabled; //Flag that indicates if application interested in receiving cea-608 text track format.
+
+    interface TracksInfoListener {
+
+        void onTracksInfoReady(PKTracks PKTracks);
+
+        void onTrackChanged();
+
+        void onRelease(String[] selectedTracks);
+    }
 
 
     /**
@@ -530,7 +540,7 @@ class TrackSelectionHelper {
         }
     }
 
-    void setTracksInfoListener(ExoPlayerWrapper.TracksInfoListener tracksInfoListener) {
+    void setTracksInfoListener(TracksInfoListener tracksInfoListener) {
         this.tracksInfoListener = tracksInfoListener;
     }
 
@@ -541,7 +551,7 @@ class TrackSelectionHelper {
     }
 
     void release() {
-        tracksInfoListener.updateLastSelectedTrackIndexes(lastSelectedTrackIds);
+        tracksInfoListener.onRelease(lastSelectedTrackIds);
         tracksInfoListener = null;
         clearTracksLists();
     }


### PR DESCRIPTION
+ When application is going background/foreground the last selected tracks will be saved and restored to their previous selection automatically.

 + The defaultTrackIndex in PKTracks will be decided based on the last selection. If user have been selected some track and went background/foreground the last selected track will be set as "default". If no selection made, the default will be taken based on the source manifest.
