### PR TITLE
Cleanups in all Kaltura analytics plugins

### DIFF
--- a/playkit/src/androidTest/java/com/kaltura/playkit/plugins/ott/PhoenixTvpapiAndroidTest.java
+++ b/playkit/src/androidTest/java/com/kaltura/playkit/plugins/ott/PhoenixTvpapiAndroidTest.java
@@ -1,4 +1,4 @@
-package com.kaltura.playkit.plugins;
+package com.kaltura.playkit.plugins.ott;
 
 import android.content.Context;
 import android.support.test.InstrumentationRegistry;
@@ -13,6 +13,7 @@ import com.kaltura.playkit.PKMediaEntry;
 import com.kaltura.playkit.PKMediaSource;
 import com.kaltura.playkit.Player;
 import com.kaltura.playkit.PlayerEvent;
+import com.kaltura.playkit.plugins.MockPlayer;
 
 import org.junit.Assert;
 import org.junit.Before;

--- a/playkit/src/androidTest/java/com/kaltura/playkit/plugins/ovp/KalturaAnalyticsAndroidTest.java
+++ b/playkit/src/androidTest/java/com/kaltura/playkit/plugins/ovp/KalturaAnalyticsAndroidTest.java
@@ -1,4 +1,4 @@
-package com.kaltura.playkit.plugins;
+package com.kaltura.playkit.plugins.ovp;
 
 import android.content.Context;
 import android.support.test.InstrumentationRegistry;
@@ -11,8 +11,10 @@ import com.kaltura.playkit.PKEvent;
 import com.kaltura.playkit.PKMediaConfig;
 import com.kaltura.playkit.PKMediaEntry;
 import com.kaltura.playkit.PKMediaSource;
+import com.kaltura.playkit.PlayKitManager;
 import com.kaltura.playkit.Player;
 import com.kaltura.playkit.PlayerEvent;
+import com.kaltura.playkit.plugins.MockPlayer;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -22,25 +24,22 @@ import org.junit.runner.RunWith;
 import java.util.ArrayList;
 
 /**
- * Created by zivilan on 11/12/2016.
+ * Created by zivilan on 12/12/2016.
  */
-
 @RunWith(AndroidJUnit4.class)
-public class KalturaStatsAndroidTest {
+public class KalturaAnalyticsAndroidTest {
 
     private Player player;
     private Context context;
     private JsonObject pluginConfig;
     private MessageBus messageBus;
-    private KalturaStatsPlugin plugin;
+    private KalturaAnalyticsPlugin plugin;
     private int duration = 3000;
     private long seek = 100;
     private String entryId = "259295";
     private int partnerId = 1281471;
-    private String widgetId = "_" + partnerId;
     private int uiconfId = 24997472;
     private PlayerEvent event;
-    private boolean isSeek;
 
     @Before
     public void setUp(){
@@ -53,7 +52,7 @@ public class KalturaStatsAndroidTest {
         ((MockPlayer) player).setDuration(duration);
         player.seekTo(seek);
 
-        plugin = (KalturaStatsPlugin) KalturaStatsPlugin.factory.newInstance();
+        plugin = (KalturaAnalyticsPlugin) KalturaAnalyticsPlugin.factory.newInstance();
         plugin.onLoad(player, pluginConfig, messageBus, context);
     }
 
@@ -62,7 +61,7 @@ public class KalturaStatsAndroidTest {
         pluginConfig = new JsonObject();
         pluginConfig.addProperty("sessionId", "b3460681-b994-6fad-cd8b-f0b65736e837");
         pluginConfig.addProperty("uiconfId", uiconfId);
-        pluginConfig.addProperty("baseUrl", "https://stats.kaltura.com/api_v3/index.php");
+        pluginConfig.addProperty("baseUrl", "https://analytics.kaltura.com/api_v3/index.php");
         pluginConfig.addProperty("partnerId", partnerId);
         pluginConfig.addProperty("timerInterval", 30);
     }
@@ -80,20 +79,19 @@ public class KalturaStatsAndroidTest {
     @Test
     public void testSeekPlugin(){
         event = new PlayerEvent(PlayerEvent.Type.SEEKED);
-        isSeek = true;
         messageBus.listen(new PKEvent.Listener() {
             @Override
             public void onEvent(PKEvent event) {
-                Assert.assertTrue(((LogEvent)event).log.contains(KalturaStatsPlugin.factory.getName()));
+                Assert.assertTrue(((LogEvent)event).log.contains(KalturaAnalyticsPlugin.factory.getName()));
                 Assert.assertTrue(((LogEvent)event).log.contains("SEEK"));
-                Assert.assertTrue(((LogEvent)event).request.contains("duration=" + (duration / 1000)));
-                Assert.assertTrue(((LogEvent)event).request.contains("eventType=" + KalturaStatsPlugin.KStatsEvent.SEEK.getValue()));
-                Assert.assertTrue(((LogEvent)event).request.contains("currentPoint=" + seek));
-                Assert.assertTrue(((LogEvent)event).request.contains("seek=" + isSeek));
+                Assert.assertTrue(((LogEvent)event).request.contains("action=trackEvent"));
+                Assert.assertTrue(((LogEvent)event).request.contains("eventType=" + KalturaAnalyticsPlugin.KAnalonyEvents.SEEK.getValue()));
+                Assert.assertTrue(((LogEvent)event).request.contains("playbackType=live"));
+                Assert.assertTrue(((LogEvent)event).request.contains("clientVer=" + PlayKitManager.CLIENT_TAG));
                 Assert.assertTrue(((LogEvent)event).request.contains("entryId=" + entryId));
                 Assert.assertTrue(((LogEvent)event).request.contains("uiconfId=" + uiconfId));
-                Assert.assertTrue(((LogEvent)event).request.contains("widgetId=" + widgetId));
-                Assert.assertTrue(((LogEvent)event).request.contains("partnerId=" + partnerId));
+                Assert.assertTrue(((LogEvent)event).request.contains("position=" + seek));
+                Assert.assertTrue(((LogEvent)event).request.contains("eventIndex=" + 0));
             }
         }, LogEvent.LogType.LogEvent);
         messageBus.post(event);
@@ -102,20 +100,19 @@ public class KalturaStatsAndroidTest {
     @Test
     public void testPlayPlugin(){
         event = new PlayerEvent(PlayerEvent.Type.PLAY);
-        isSeek = false;
         messageBus.listen(new PKEvent.Listener() {
             @Override
             public void onEvent(PKEvent event) {
-                Assert.assertTrue(((LogEvent)event).log.contains(KalturaStatsPlugin.factory.getName()));
+                Assert.assertTrue(((LogEvent)event).log.contains(KalturaAnalyticsPlugin.factory.getName()));
                 Assert.assertTrue(((LogEvent)event).log.contains("PLAY"));
-                Assert.assertTrue(((LogEvent)event).request.contains("duration=" + (duration / 1000)));
-                Assert.assertTrue(((LogEvent)event).request.contains("eventType=" + KalturaStatsPlugin.KStatsEvent.PLAY.getValue()));
-                Assert.assertTrue(((LogEvent)event).request.contains("currentPoint=" + seek));
-                Assert.assertTrue(((LogEvent)event).request.contains("seek=" + isSeek));
+                Assert.assertTrue(((LogEvent)event).request.contains("action=trackEvent"));
+                Assert.assertTrue(((LogEvent)event).request.contains("eventType=" + KalturaAnalyticsPlugin.KAnalonyEvents.PLAY_REQUEST.getValue()));
+                Assert.assertTrue(((LogEvent)event).request.contains("playbackType=live"));
+                Assert.assertTrue(((LogEvent)event).request.contains("clientVer=" + PlayKitManager.CLIENT_TAG));
                 Assert.assertTrue(((LogEvent)event).request.contains("entryId=" + entryId));
                 Assert.assertTrue(((LogEvent)event).request.contains("uiconfId=" + uiconfId));
-                Assert.assertTrue(((LogEvent)event).request.contains("widgetId=" + widgetId));
-                Assert.assertTrue(((LogEvent)event).request.contains("partnerId=" + partnerId));
+                Assert.assertTrue(((LogEvent)event).request.contains("position=" + seek));
+                Assert.assertTrue(((LogEvent)event).request.contains("eventIndex=" + 0));
             }
         }, LogEvent.LogType.LogEvent);
         messageBus.post(event);

--- a/playkit/src/androidTest/java/com/kaltura/playkit/plugins/ovp/KalturaStatsAndroidTest.java
+++ b/playkit/src/androidTest/java/com/kaltura/playkit/plugins/ovp/KalturaStatsAndroidTest.java
@@ -1,4 +1,4 @@
-package com.kaltura.playkit.plugins;
+package com.kaltura.playkit.plugins.ovp;
 
 import android.content.Context;
 import android.support.test.InstrumentationRegistry;
@@ -11,9 +11,9 @@ import com.kaltura.playkit.PKEvent;
 import com.kaltura.playkit.PKMediaConfig;
 import com.kaltura.playkit.PKMediaEntry;
 import com.kaltura.playkit.PKMediaSource;
-import com.kaltura.playkit.PlayKitManager;
 import com.kaltura.playkit.Player;
 import com.kaltura.playkit.PlayerEvent;
+import com.kaltura.playkit.plugins.MockPlayer;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -23,22 +23,25 @@ import org.junit.runner.RunWith;
 import java.util.ArrayList;
 
 /**
- * Created by zivilan on 12/12/2016.
+ * Created by zivilan on 11/12/2016.
  */
+
 @RunWith(AndroidJUnit4.class)
-public class KalturaAnalyticsAndroidTest {
+public class KalturaStatsAndroidTest {
 
     private Player player;
     private Context context;
     private JsonObject pluginConfig;
     private MessageBus messageBus;
-    private KalturaAnalyticsPlugin plugin;
+    private KalturaStatsPlugin plugin;
     private int duration = 3000;
     private long seek = 100;
     private String entryId = "259295";
     private int partnerId = 1281471;
+    private String widgetId = "_" + partnerId;
     private int uiconfId = 24997472;
     private PlayerEvent event;
+    private boolean isSeek;
 
     @Before
     public void setUp(){
@@ -51,7 +54,7 @@ public class KalturaAnalyticsAndroidTest {
         ((MockPlayer) player).setDuration(duration);
         player.seekTo(seek);
 
-        plugin = (KalturaAnalyticsPlugin) KalturaAnalyticsPlugin.factory.newInstance();
+        plugin = (KalturaStatsPlugin) KalturaStatsPlugin.factory.newInstance();
         plugin.onLoad(player, pluginConfig, messageBus, context);
     }
 
@@ -60,7 +63,7 @@ public class KalturaAnalyticsAndroidTest {
         pluginConfig = new JsonObject();
         pluginConfig.addProperty("sessionId", "b3460681-b994-6fad-cd8b-f0b65736e837");
         pluginConfig.addProperty("uiconfId", uiconfId);
-        pluginConfig.addProperty("baseUrl", "https://analytics.kaltura.com/api_v3/index.php");
+        pluginConfig.addProperty("baseUrl", "https://stats.kaltura.com/api_v3/index.php");
         pluginConfig.addProperty("partnerId", partnerId);
         pluginConfig.addProperty("timerInterval", 30);
     }
@@ -78,19 +81,20 @@ public class KalturaAnalyticsAndroidTest {
     @Test
     public void testSeekPlugin(){
         event = new PlayerEvent(PlayerEvent.Type.SEEKED);
+        isSeek = true;
         messageBus.listen(new PKEvent.Listener() {
             @Override
             public void onEvent(PKEvent event) {
-                Assert.assertTrue(((LogEvent)event).log.contains(KalturaAnalyticsPlugin.factory.getName()));
+                Assert.assertTrue(((LogEvent)event).log.contains(KalturaStatsPlugin.factory.getName()));
                 Assert.assertTrue(((LogEvent)event).log.contains("SEEK"));
-                Assert.assertTrue(((LogEvent)event).request.contains("action=trackEvent"));
-                Assert.assertTrue(((LogEvent)event).request.contains("eventType=" + KalturaAnalyticsPlugin.KAnalonyEvents.SEEK.getValue()));
-                Assert.assertTrue(((LogEvent)event).request.contains("playbackType=live"));
-                Assert.assertTrue(((LogEvent)event).request.contains("clientVer=" + PlayKitManager.CLIENT_TAG));
+                Assert.assertTrue(((LogEvent)event).request.contains("duration=" + (duration / 1000)));
+                Assert.assertTrue(((LogEvent)event).request.contains("eventType=" + KalturaStatsPlugin.KStatsEvent.SEEK.getValue()));
+                Assert.assertTrue(((LogEvent)event).request.contains("currentPoint=" + seek));
+                Assert.assertTrue(((LogEvent)event).request.contains("seek=" + isSeek));
                 Assert.assertTrue(((LogEvent)event).request.contains("entryId=" + entryId));
                 Assert.assertTrue(((LogEvent)event).request.contains("uiconfId=" + uiconfId));
-                Assert.assertTrue(((LogEvent)event).request.contains("position=" + seek));
-                Assert.assertTrue(((LogEvent)event).request.contains("eventIndex=" + 0));
+                Assert.assertTrue(((LogEvent)event).request.contains("widgetId=" + widgetId));
+                Assert.assertTrue(((LogEvent)event).request.contains("partnerId=" + partnerId));
             }
         }, LogEvent.LogType.LogEvent);
         messageBus.post(event);
@@ -99,19 +103,20 @@ public class KalturaAnalyticsAndroidTest {
     @Test
     public void testPlayPlugin(){
         event = new PlayerEvent(PlayerEvent.Type.PLAY);
+        isSeek = false;
         messageBus.listen(new PKEvent.Listener() {
             @Override
             public void onEvent(PKEvent event) {
-                Assert.assertTrue(((LogEvent)event).log.contains(KalturaAnalyticsPlugin.factory.getName()));
+                Assert.assertTrue(((LogEvent)event).log.contains(KalturaStatsPlugin.factory.getName()));
                 Assert.assertTrue(((LogEvent)event).log.contains("PLAY"));
-                Assert.assertTrue(((LogEvent)event).request.contains("action=trackEvent"));
-                Assert.assertTrue(((LogEvent)event).request.contains("eventType=" + KalturaAnalyticsPlugin.KAnalonyEvents.PLAY_REQUEST.getValue()));
-                Assert.assertTrue(((LogEvent)event).request.contains("playbackType=live"));
-                Assert.assertTrue(((LogEvent)event).request.contains("clientVer=" + PlayKitManager.CLIENT_TAG));
+                Assert.assertTrue(((LogEvent)event).request.contains("duration=" + (duration / 1000)));
+                Assert.assertTrue(((LogEvent)event).request.contains("eventType=" + KalturaStatsPlugin.KStatsEvent.PLAY.getValue()));
+                Assert.assertTrue(((LogEvent)event).request.contains("currentPoint=" + seek));
+                Assert.assertTrue(((LogEvent)event).request.contains("seek=" + isSeek));
                 Assert.assertTrue(((LogEvent)event).request.contains("entryId=" + entryId));
                 Assert.assertTrue(((LogEvent)event).request.contains("uiconfId=" + uiconfId));
-                Assert.assertTrue(((LogEvent)event).request.contains("position=" + seek));
-                Assert.assertTrue(((LogEvent)event).request.contains("eventIndex=" + 0));
+                Assert.assertTrue(((LogEvent)event).request.contains("widgetId=" + widgetId));
+                Assert.assertTrue(((LogEvent)event).request.contains("partnerId=" + partnerId));
             }
         }, LogEvent.LogType.LogEvent);
         messageBus.post(event);

--- a/playkit/src/main/java/com/kaltura/playkit/api/tvpapi/services/MediaMarkService.java
+++ b/playkit/src/main/java/com/kaltura/playkit/api/tvpapi/services/MediaMarkService.java
@@ -8,7 +8,7 @@ import com.kaltura.netkit.connect.request.RequestBuilder;
  */
 
 public class MediaMarkService {
-    public static RequestBuilder sendTVPAPIEVent(String baseUrl, JsonObject initObj, String action, String assetId, String fileId, long position) {
+    public static RequestBuilder sendTVPAPIEvent(String baseUrl, JsonObject initObj, String action, String assetId, String fileId, long position) {
         return new RequestBuilder()
                 .method("POST")
                 .url(baseUrl)

--- a/playkit/src/main/java/com/kaltura/playkit/plugins/ott/OttEvent.java
+++ b/playkit/src/main/java/com/kaltura/playkit/plugins/ott/OttEvent.java
@@ -1,4 +1,6 @@
-package com.kaltura.playkit;
+package com.kaltura.playkit.plugins.ott;
+
+import com.kaltura.playkit.PKEvent;
 
 /**
  * Created by zivilan on 15/12/2016.

--- a/playkit/src/main/java/com/kaltura/playkit/plugins/ott/PhoenixAnalyticsConfig.java
+++ b/playkit/src/main/java/com/kaltura/playkit/plugins/ott/PhoenixAnalyticsConfig.java
@@ -1,4 +1,4 @@
-package com.kaltura.playkit.plugins.configs;
+package com.kaltura.playkit.plugins.ott;
 
 import com.google.gson.JsonObject;
 

--- a/playkit/src/main/java/com/kaltura/playkit/plugins/ott/PhoenixAnalyticsEvent.java
+++ b/playkit/src/main/java/com/kaltura/playkit/plugins/ott/PhoenixAnalyticsEvent.java
@@ -1,4 +1,4 @@
-package com.kaltura.playkit.plugins;
+package com.kaltura.playkit.plugins.ott;
 
 import com.kaltura.playkit.PKEvent;
 
@@ -6,17 +6,17 @@ import com.kaltura.playkit.PKEvent;
  * Created by anton.afanasiev on 27/03/2017.
  */
 
-public class TVPapiAnalyticsEvent implements PKEvent {
+public class PhoenixAnalyticsEvent implements PKEvent {
 
     public enum Type {
         REPORT_SENT
     }
 
-    public static class TVPapiAnalyticsReport extends TVPapiAnalyticsEvent {
+    public static class PhoenixAnalyticsReport extends PhoenixAnalyticsEvent {
 
         private String reportedEventName;
 
-        public TVPapiAnalyticsReport(String reportedEventName) {
+        public PhoenixAnalyticsReport(String reportedEventName) {
             this.reportedEventName = reportedEventName;
         }
 

--- a/playkit/src/main/java/com/kaltura/playkit/plugins/ott/PhoenixAnalyticsPlugin.java
+++ b/playkit/src/main/java/com/kaltura/playkit/plugins/ott/PhoenixAnalyticsPlugin.java
@@ -9,7 +9,6 @@ import com.kaltura.netkit.connect.request.RequestBuilder;
 import com.kaltura.netkit.connect.response.ResponseElement;
 import com.kaltura.netkit.utils.OnRequestCompletion;
 import com.kaltura.playkit.MessageBus;
-import com.kaltura.playkit.OttEvent;
 import com.kaltura.playkit.PKEvent;
 import com.kaltura.playkit.PKLog;
 import com.kaltura.playkit.PKMediaConfig;

--- a/playkit/src/main/java/com/kaltura/playkit/plugins/ott/PhoenixAnalyticsPlugin.java
+++ b/playkit/src/main/java/com/kaltura/playkit/plugins/ott/PhoenixAnalyticsPlugin.java
@@ -1,4 +1,4 @@
-package com.kaltura.playkit.plugins;
+package com.kaltura.playkit.plugins.ott;
 
 import android.content.Context;
 
@@ -17,7 +17,6 @@ import com.kaltura.playkit.PKPlugin;
 import com.kaltura.playkit.Player;
 import com.kaltura.playkit.PlayerEvent;
 import com.kaltura.playkit.api.phoenix.services.BookmarkService;
-import com.kaltura.playkit.plugins.configs.PhoenixAnalyticsConfig;
 import com.kaltura.playkit.utils.Consts;
 
 import java.util.Timer;
@@ -28,21 +27,21 @@ public class PhoenixAnalyticsPlugin extends PKPlugin {
     private static final PKLog log = PKLog.get("PhoenixAnalyticsPlugin");
     private static final double MEDIA_ENDED_THRESHOLD = 0.98;
 
-    private int mediaHitInterval;
-    private String fileId;
-    private String baseUrl;
+    // Fields shared with TVPAPIAnalyticsPlugin
+    int mediaHitInterval;
+    String fileId;
+    String baseUrl;
+    Context context;
+    Player player;
+    MessageBus messageBus; // used also by TVPAPI Analytics
+    PKMediaConfig mediaConfig;
+    RequestQueue requestsExecutor;
+    Timer timer;
+    long lastKnownPlayerPosition = 0;
+
+    // Private fields
     private String ks;
     private int partnerId;
-    private Context context;
-    private Player player;
-    private MessageBus messageBus; // used also by TVPAPI Analytics
-    private PKMediaConfig mediaConfig;
-
-    private RequestQueue requestsExecutor;
-    private Timer timer;
-
-    private long lastKnownPlayerPosition = 0;
-
     private boolean isFirstPlay = true;
     private boolean intervalOn = false;
     private boolean timerWasCancelled = false;
@@ -239,10 +238,8 @@ public class PhoenixAnalyticsPlugin extends PKPlugin {
      * @param eventType - Enum stating the event type to send
      */
     protected void sendAnalyticsEvent(final PhoenixActionType eventType) {
-
-        String action = eventType.name().toLowerCase(); // used only for copmare
-
-        if (!"stop".equals(action)) {
+        
+        if (eventType != PhoenixActionType.STOP) {
             lastKnownPlayerPosition = player.getCurrentPosition() / Consts.MILLISECONDS_MULTIPLIER;
         }
         RequestBuilder requestBuilder = BookmarkService.actionAdd(baseUrl, partnerId, ks,
@@ -262,75 +259,10 @@ public class PhoenixAnalyticsPlugin extends PKPlugin {
         requestsExecutor.queue(requestBuilder.build());
     }
 
-    String getFileId() {
-        return fileId;
-    }
-
     PKEvent.Listener getEventListener() {
         return mEventListener;
     }
 
-    public String getBaseUrl() {
-        return baseUrl;
-    }
-
-    public Context getContext() {
-        return context;
-    }
-
-    public void setContext(Context mContext) {
-        this.context = mContext;
-    }
-
-    public Player getPlayer() {
-        return player;
-    }
-
-
-    public void setPlayer(Player player) {
-        this.player = player;
-    }
-
-    public MessageBus getMessageBus() {
-        return messageBus;
-    }
-
-    public void setMessageBus(MessageBus messageBus) {
-        this.messageBus = messageBus;
-    }
-
-
-    RequestQueue getRequestsExecutor() {
-        return requestsExecutor;
-    }
-
-    void setRequestsExecutor(RequestQueue requestsExecutor) {
-        this.requestsExecutor = requestsExecutor;
-    }
-
-    Timer getTimer() {
-        return timer;
-    }
-
-    void setTimer(Timer timer) {
-        this.timer = timer;
-    }
-
-    PKMediaConfig getMediaConfig() {
-        return mediaConfig;
-    }
-
-    void setMediaConfig(PKMediaConfig mediaConfig) {
-        this.mediaConfig = mediaConfig;
-    }
-
-    int getMediaHitInterval() {
-        return mediaHitInterval;
-    }
-
-    void setMediaHitInterval(int mediaHitInterval) {
-        this.mediaHitInterval = mediaHitInterval;
-    }
 
     private static PhoenixAnalyticsConfig parseConfig(Object config) {
         if (config instanceof PhoenixAnalyticsConfig) {

--- a/playkit/src/main/java/com/kaltura/playkit/plugins/ott/TVPAPIAnalyticsConfig.java
+++ b/playkit/src/main/java/com/kaltura/playkit/plugins/ott/TVPAPIAnalyticsConfig.java
@@ -1,4 +1,4 @@
-package com.kaltura.playkit.plugins.configs;
+package com.kaltura.playkit.plugins.ott;
 
 import com.google.gson.JsonObject;
 

--- a/playkit/src/main/java/com/kaltura/playkit/plugins/ott/TVPAPIAnalyticsEvent.java
+++ b/playkit/src/main/java/com/kaltura/playkit/plugins/ott/TVPAPIAnalyticsEvent.java
@@ -1,4 +1,4 @@
-package com.kaltura.playkit.plugins;
+package com.kaltura.playkit.plugins.ott;
 
 import com.kaltura.playkit.PKEvent;
 
@@ -6,17 +6,17 @@ import com.kaltura.playkit.PKEvent;
  * Created by anton.afanasiev on 27/03/2017.
  */
 
-public class PhoenixAnalyticsEvent implements PKEvent {
+public class TVPAPIAnalyticsEvent implements PKEvent {
 
     public enum Type {
         REPORT_SENT
     }
 
-    public static class PhoenixAnalyticsReport extends PhoenixAnalyticsEvent {
+    public static class TVPAPIAnalyticsReport extends TVPAPIAnalyticsEvent {
 
         private String reportedEventName;
 
-        public PhoenixAnalyticsReport(String reportedEventName) {
+        public TVPAPIAnalyticsReport(String reportedEventName) {
             this.reportedEventName = reportedEventName;
         }
 

--- a/playkit/src/main/java/com/kaltura/playkit/plugins/ott/TVPAPIAnalyticsPlugin.java
+++ b/playkit/src/main/java/com/kaltura/playkit/plugins/ott/TVPAPIAnalyticsPlugin.java
@@ -8,7 +8,6 @@ import com.kaltura.netkit.connect.request.RequestBuilder;
 import com.kaltura.netkit.connect.response.ResponseElement;
 import com.kaltura.netkit.utils.OnRequestCompletion;
 import com.kaltura.playkit.MessageBus;
-import com.kaltura.playkit.OttEvent;
 import com.kaltura.playkit.PKLog;
 import com.kaltura.playkit.PKPlugin;
 import com.kaltura.playkit.Player;

--- a/playkit/src/main/java/com/kaltura/playkit/plugins/ott/TVPAPIAnalyticsPlugin.java
+++ b/playkit/src/main/java/com/kaltura/playkit/plugins/ott/TVPAPIAnalyticsPlugin.java
@@ -82,7 +82,6 @@ public class TVPAPIAnalyticsPlugin extends PhoenixAnalyticsPlugin {
      */
     @Override
     protected void sendAnalyticsEvent(final PhoenixActionType eventType){
-        String fileId = this.fileId;
         String method = eventType == PhoenixActionType.HIT ? "MediaHit": "MediaMark";
         String action = eventType.name().toLowerCase();
 
@@ -94,7 +93,7 @@ public class TVPAPIAnalyticsPlugin extends PhoenixAnalyticsPlugin {
             lastKnownPlayerPosition = player.getCurrentPosition() / Consts.MILLISECONDS_MULTIPLIER;
         }
         RequestBuilder requestBuilder = MediaMarkService.sendTVPAPIEvent(baseUrl + "m=" + method, initObject, action,
-                mediaConfig.getMediaEntry().getId(), fileId, lastKnownPlayerPosition);
+                mediaConfig.getMediaEntry().getId(), this.fileId, lastKnownPlayerPosition);
 
         requestBuilder.completion(new OnRequestCompletion() {
             @Override

--- a/playkit/src/main/java/com/kaltura/playkit/plugins/ott/TVPAPIAnalyticsPlugin.java
+++ b/playkit/src/main/java/com/kaltura/playkit/plugins/ott/TVPAPIAnalyticsPlugin.java
@@ -1,4 +1,4 @@
-package com.kaltura.playkit.plugins;
+package com.kaltura.playkit.plugins.ott;
 
 import android.content.Context;
 
@@ -14,15 +14,12 @@ import com.kaltura.playkit.PKPlugin;
 import com.kaltura.playkit.Player;
 import com.kaltura.playkit.PlayerEvent;
 import com.kaltura.playkit.api.tvpapi.services.MediaMarkService;
-import com.kaltura.playkit.plugins.configs.TVPAPIAnalyticsConfig;
 import com.kaltura.playkit.utils.Consts;
 
 import java.util.Timer;
 
 public class TVPAPIAnalyticsPlugin extends PhoenixAnalyticsPlugin {
     private static final PKLog log = PKLog.get("TVPAPIAnalyticsPlugin");
-    private long lastKnownPlayerPosition = 0;
-    private String baseUrl;
     private JsonObject initObject;
 
     public static final Factory factory = new Factory() {
@@ -46,10 +43,10 @@ public class TVPAPIAnalyticsPlugin extends PhoenixAnalyticsPlugin {
     protected void onLoad(Player player, Object config, final MessageBus messageBus, Context context) {
         log.d("onLoad");
         setPluginMembers(config);
-        setPlayer(player);
-        setContext(context);
-        setTimer(new Timer());
-        setRequestsExecutor(APIOkRequestsExecutor.getSingleton());
+        this.player = player;
+        this.context = context;
+        this.timer = new Timer();
+        this.requestsExecutor = APIOkRequestsExecutor.getSingleton();
         if (baseUrl != null && !baseUrl.isEmpty() &&  initObject != null) {
             messageBus.listen(getEventListener(), PlayerEvent.Type.PLAY, PlayerEvent.Type.PAUSE, PlayerEvent.Type.ENDED, PlayerEvent.Type.ERROR, PlayerEvent.Type.LOADED_METADATA, PlayerEvent.Type.STOPPED, PlayerEvent.Type.REPLAY, PlayerEvent.Type.SEEKED, PlayerEvent.Type.SOURCE_SELECTED);
         } else {
@@ -67,7 +64,7 @@ public class TVPAPIAnalyticsPlugin extends PhoenixAnalyticsPlugin {
             if (timerIntervalSec > 0) {
                 timerInterval = timerIntervalSec * Consts.MILLISECONDS_MULTIPLIER;
             }
-            setMediaHitInterval((int) timerInterval);
+            this.mediaHitInterval = (int) timerInterval;
         }
     }
 
@@ -76,7 +73,7 @@ public class TVPAPIAnalyticsPlugin extends PhoenixAnalyticsPlugin {
         setPluginMembers(config);
         if (baseUrl == null || baseUrl.isEmpty() || initObject == null) {
             cancelTimer();
-            getMessageBus().remove(getEventListener(),(Enum[]) PlayerEvent.Type.values());
+            messageBus.remove(getEventListener(),(Enum[]) PlayerEvent.Type.values());
         }
     }
 
@@ -86,31 +83,31 @@ public class TVPAPIAnalyticsPlugin extends PhoenixAnalyticsPlugin {
      */
     @Override
     protected void sendAnalyticsEvent(final PhoenixActionType eventType){
-        String fileId = getFileId();
+        String fileId = this.fileId;
+        String method = eventType == PhoenixActionType.HIT ? "MediaHit": "MediaMark";
         String action = eventType.name().toLowerCase();
-        String method = action.equals("hit")? "MediaHit": "MediaMark";
 
         if (initObject == null) {
             return;
         }
 
-        if (!"stop".equals(action)) {
-            lastKnownPlayerPosition = getPlayer().getCurrentPosition() / Consts.MILLISECONDS_MULTIPLIER;
+        if (eventType != PhoenixActionType.STOP) {
+            lastKnownPlayerPosition = player.getCurrentPosition() / Consts.MILLISECONDS_MULTIPLIER;
         }
-        RequestBuilder requestBuilder = MediaMarkService.sendTVPAPIEVent(baseUrl + "m=" + method, initObject, action,
-                getMediaConfig().getMediaEntry().getId(), fileId, lastKnownPlayerPosition);
+        RequestBuilder requestBuilder = MediaMarkService.sendTVPAPIEvent(baseUrl + "m=" + method, initObject, action,
+                mediaConfig.getMediaEntry().getId(), fileId, lastKnownPlayerPosition);
 
         requestBuilder.completion(new OnRequestCompletion() {
             @Override
             public void onComplete(ResponseElement response) {
                 if (response.isSuccess() && response.getResponse().toLowerCase().contains("concurrent")){
-                    getMessageBus().post(new OttEvent(OttEvent.OttEventType.Concurrency));
-                    getMessageBus().post(new TVPapiAnalyticsEvent.TVPapiAnalyticsReport(eventType.toString()));
+                    messageBus.post(new OttEvent(OttEvent.OttEventType.Concurrency));
+                    messageBus.post(new TVPAPIAnalyticsEvent.TVPAPIAnalyticsReport(eventType.toString()));
                 }
                 log.d("onComplete send event: " + eventType);
             }
         });
-        getRequestsExecutor().queue(requestBuilder.build());
+        requestsExecutor.queue(requestBuilder.build());
     }
 
     private static TVPAPIAnalyticsConfig parseConfig(Object config) {

--- a/playkit/src/main/java/com/kaltura/playkit/plugins/ovp/KalturaAnalyticsPlugin.java
+++ b/playkit/src/main/java/com/kaltura/playkit/plugins/ovp/KalturaAnalyticsPlugin.java
@@ -1,4 +1,4 @@
-package com.kaltura.playkit.plugins;
+package com.kaltura.playkit.plugins.ovp;
 
 import android.content.Context;
 

--- a/playkit/src/main/java/com/kaltura/playkit/plugins/ovp/KalturaLiveStatsConfig.java
+++ b/playkit/src/main/java/com/kaltura/playkit/plugins/ovp/KalturaLiveStatsConfig.java
@@ -1,4 +1,4 @@
-package com.kaltura.playkit.plugins.configs;
+package com.kaltura.playkit.plugins.ovp;
 
 import com.google.gson.JsonObject;
 

--- a/playkit/src/main/java/com/kaltura/playkit/plugins/ovp/KalturaLiveStatsEvent.java
+++ b/playkit/src/main/java/com/kaltura/playkit/plugins/ovp/KalturaLiveStatsEvent.java
@@ -1,4 +1,4 @@
-package com.kaltura.playkit.plugins;
+package com.kaltura.playkit.plugins.ovp;
 
 import com.kaltura.playkit.PKEvent;
 

--- a/playkit/src/main/java/com/kaltura/playkit/plugins/ovp/KalturaLiveStatsPlugin.java
+++ b/playkit/src/main/java/com/kaltura/playkit/plugins/ovp/KalturaLiveStatsPlugin.java
@@ -1,4 +1,4 @@
-package com.kaltura.playkit.plugins;
+package com.kaltura.playkit.plugins.ovp;
 
 import android.content.Context;
 
@@ -19,7 +19,6 @@ import com.kaltura.playkit.PlaybackInfo;
 import com.kaltura.playkit.Player;
 import com.kaltura.playkit.PlayerEvent;
 import com.kaltura.playkit.api.ovp.services.LiveStatsService;
-import com.kaltura.playkit.plugins.configs.KalturaLiveStatsConfig;
 import com.kaltura.playkit.utils.Consts;
 
 import java.util.Date;

--- a/playkit/src/main/java/com/kaltura/playkit/plugins/ovp/KalturaStatsConfig.java
+++ b/playkit/src/main/java/com/kaltura/playkit/plugins/ovp/KalturaStatsConfig.java
@@ -1,4 +1,4 @@
-package com.kaltura.playkit.plugins.configs;
+package com.kaltura.playkit.plugins.ovp;
 
 import com.google.gson.JsonObject;
 import com.kaltura.playkit.utils.Consts;

--- a/playkit/src/main/java/com/kaltura/playkit/plugins/ovp/KalturaStatsEvent.java
+++ b/playkit/src/main/java/com/kaltura/playkit/plugins/ovp/KalturaStatsEvent.java
@@ -1,4 +1,4 @@
-package com.kaltura.playkit.plugins;
+package com.kaltura.playkit.plugins.ovp;
 
 import com.kaltura.playkit.PKEvent;
 

--- a/playkit/src/main/java/com/kaltura/playkit/plugins/ovp/KalturaStatsPlugin.java
+++ b/playkit/src/main/java/com/kaltura/playkit/plugins/ovp/KalturaStatsPlugin.java
@@ -1,4 +1,4 @@
-package com.kaltura.playkit.plugins;
+package com.kaltura.playkit.plugins.ovp;
 
 import android.content.Context;
 
@@ -21,7 +21,6 @@ import com.kaltura.playkit.api.ovp.services.StatsService;
 import com.kaltura.playkit.plugins.ads.AdEvent;
 import com.kaltura.playkit.plugins.ads.AdInfo;
 import com.kaltura.playkit.plugins.ads.AdPositionType;
-import com.kaltura.playkit.plugins.configs.KalturaStatsConfig;
 import com.kaltura.playkit.utils.Consts;
 
 import java.util.TimerTask;

--- a/playkit/src/main/java/com/kaltura/playkit/plugins/youbora/YouboraAdManager.java
+++ b/playkit/src/main/java/com/kaltura/playkit/plugins/youbora/YouboraAdManager.java
@@ -1,4 +1,4 @@
-package com.kaltura.playkit.plugins.Youbora;
+package com.kaltura.playkit.plugins.youbora;
 
 import com.kaltura.playkit.MessageBus;
 import com.kaltura.playkit.PKEvent;

--- a/playkit/src/main/java/com/kaltura/playkit/plugins/youbora/YouboraConfig.java
+++ b/playkit/src/main/java/com/kaltura/playkit/plugins/youbora/YouboraConfig.java
@@ -1,4 +1,4 @@
-package com.kaltura.playkit.plugins.Youbora;
+package com.kaltura.playkit.plugins.youbora;
 
 
 import com.google.gson.JsonObject;

--- a/playkit/src/main/java/com/kaltura/playkit/plugins/youbora/YouboraEvent.java
+++ b/playkit/src/main/java/com/kaltura/playkit/plugins/youbora/YouboraEvent.java
@@ -1,4 +1,4 @@
-package com.kaltura.playkit.plugins.Youbora;
+package com.kaltura.playkit.plugins.youbora;
 
 import com.kaltura.playkit.PKEvent;
 

--- a/playkit/src/main/java/com/kaltura/playkit/plugins/youbora/YouboraLibraryManager.java
+++ b/playkit/src/main/java/com/kaltura/playkit/plugins/youbora/YouboraLibraryManager.java
@@ -1,4 +1,4 @@
-package com.kaltura.playkit.plugins.Youbora;
+package com.kaltura.playkit.plugins.youbora;
 
 import com.kaltura.playkit.MessageBus;
 import com.kaltura.playkit.PKEvent;

--- a/playkit/src/main/java/com/kaltura/playkit/plugins/youbora/YouboraPlugin.java
+++ b/playkit/src/main/java/com/kaltura/playkit/plugins/youbora/YouboraPlugin.java
@@ -1,4 +1,4 @@
-package com.kaltura.playkit.plugins.Youbora;
+package com.kaltura.playkit.plugins.youbora;
 
 import android.content.Context;
 


### PR DESCRIPTION
BREAKING CHANGES

- Classes moved to package com.kaltura.playkit.plugins.ott:
	PhoenixAnalyticsPlugin, PhoenixAnalyticsEvent, PhoenixAnalyticsConfig,
	TVPAPIAnalyticsPlugin, TVPAPIAnalyticsEvent, TVPAPIAnalyticsConfig

- Classes moved to package com.kaltura.playkit.plugins.ovp:
	KalturaAnalyticsPlugin, KalturaLiveStatsConfig, KalturaLiveStatsEvent, KalturaLiveStatsPlugin, KalturaStatsConfig, KalturaStatsEvent, KalturaStatsPlugin