### PR TITLE
Device capabilities: send the entire report as a string.

### DIFF
--- a/playkit/src/main/java/com/kaltura/playkit/PKDeviceCapabilities.java
+++ b/playkit/src/main/java/com/kaltura/playkit/PKDeviceCapabilities.java
@@ -85,7 +85,7 @@ public class PKDeviceCapabilities {
         JsonObject report = getReport(context);
         
         JsonObject data = new JsonObject();
-        data.add("data", report);
+        data.addProperty("data", report.toString());
 
         String dataString = data.toString();
         try {


### PR DESCRIPTION
```{"data": {"key": "value"}}```

becomes

```{"data": "{\"key\": \"value\"}"}```

In other words, the actual report is stringified before being added to the request.