### PR TITLE
Add copyright banner to all source files

### DIFF
--- a/playkit-java-banner.py
+++ b/playkit-java-banner.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+
+BANNER = """/*
+ * ============================================================================
+ * Copyright (C) %d Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+"""
+
+
+import os
+from datetime import datetime
+
+FIRST_YEAR = 2017
+THIS_YEAR = datetime.now().year
+
+def has_banner(d):
+	d = d.lstrip()
+	for year in xrange(FIRST_YEAR, THIS_YEAR + 1):
+		if d.startswith(BANNER % year):
+			return True
+	return False
+
+banner = BANNER % THIS_YEAR
+for root, dirs, files in os.walk('.'):
+	for name in files:
+		fileExt = os.path.splitext(name)[1]
+		if fileExt != '.java':
+			continue
+		
+		fullPath = os.path.join(root, name)
+		d = file(fullPath, 'rb').read()
+		
+		if has_banner(d):
+			continue
+		
+		d = banner + '\n' + d
+		
+		file(fullPath, 'wb').write(d)
+

--- a/playkit-java-banner.py
+++ b/playkit-java-banner.py
@@ -28,7 +28,7 @@ def has_banner(d):
 	return False
 
 banner = BANNER % THIS_YEAR
-for root, dirs, files in os.walk('.'):
+for root, dirs, files in os.walk('playkit/src/main/java/com/kaltura/playkit'):
 	for name in files:
 		fileExt = os.path.splitext(name)[1]
 		if fileExt != '.java':

--- a/playkit/src/main/java/com/kaltura/playkit/Assert.java
+++ b/playkit/src/main/java/com/kaltura/playkit/Assert.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit;
 
 import android.text.TextUtils;

--- a/playkit/src/main/java/com/kaltura/playkit/LocalAssetsManager.java
+++ b/playkit/src/main/java/com/kaltura/playkit/LocalAssetsManager.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit;
 
 import android.content.Context;

--- a/playkit/src/main/java/com/kaltura/playkit/LocalDataStore.java
+++ b/playkit/src/main/java/com/kaltura/playkit/LocalDataStore.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit;
 
 import java.io.FileNotFoundException;

--- a/playkit/src/main/java/com/kaltura/playkit/LogEvent.java
+++ b/playkit/src/main/java/com/kaltura/playkit/LogEvent.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit;
 
 /**

--- a/playkit/src/main/java/com/kaltura/playkit/MediaEntryProvider.java
+++ b/playkit/src/main/java/com/kaltura/playkit/MediaEntryProvider.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit;
 
 import com.kaltura.playkit.mediaproviders.base.OnMediaLoadCompletion;

--- a/playkit/src/main/java/com/kaltura/playkit/MessageBus.java
+++ b/playkit/src/main/java/com/kaltura/playkit/MessageBus.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit;
 
 import android.os.Handler;

--- a/playkit/src/main/java/com/kaltura/playkit/PKDeviceCapabilities.java
+++ b/playkit/src/main/java/com/kaltura/playkit/PKDeviceCapabilities.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit;
 
 import android.annotation.TargetApi;

--- a/playkit/src/main/java/com/kaltura/playkit/PKDrmParams.java
+++ b/playkit/src/main/java/com/kaltura/playkit/PKDrmParams.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit;
 
 import android.os.Parcel;

--- a/playkit/src/main/java/com/kaltura/playkit/PKError.java
+++ b/playkit/src/main/java/com/kaltura/playkit/PKError.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit;
 
 import android.support.annotation.NonNull;

--- a/playkit/src/main/java/com/kaltura/playkit/PKEvent.java
+++ b/playkit/src/main/java/com/kaltura/playkit/PKEvent.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit;
 
 public interface PKEvent {

--- a/playkit/src/main/java/com/kaltura/playkit/PKLog.java
+++ b/playkit/src/main/java/com/kaltura/playkit/PKLog.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit;
 
 import android.util.Log;

--- a/playkit/src/main/java/com/kaltura/playkit/PKMediaConfig.java
+++ b/playkit/src/main/java/com/kaltura/playkit/PKMediaConfig.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit;
 
 /**

--- a/playkit/src/main/java/com/kaltura/playkit/PKMediaEntry.java
+++ b/playkit/src/main/java/com/kaltura/playkit/PKMediaEntry.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit;
 
 import android.os.Parcel;

--- a/playkit/src/main/java/com/kaltura/playkit/PKMediaFormat.java
+++ b/playkit/src/main/java/com/kaltura/playkit/PKMediaFormat.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit;
 
 import android.net.Uri;

--- a/playkit/src/main/java/com/kaltura/playkit/PKMediaSource.java
+++ b/playkit/src/main/java/com/kaltura/playkit/PKMediaSource.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit;
 
 import android.os.Parcel;

--- a/playkit/src/main/java/com/kaltura/playkit/PKPlugin.java
+++ b/playkit/src/main/java/com/kaltura/playkit/PKPlugin.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit;
 
 import android.content.Context;

--- a/playkit/src/main/java/com/kaltura/playkit/PKPluginConfigs.java
+++ b/playkit/src/main/java/com/kaltura/playkit/PKPluginConfigs.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit;
 
 import java.util.HashMap;

--- a/playkit/src/main/java/com/kaltura/playkit/PKRequestParams.java
+++ b/playkit/src/main/java/com/kaltura/playkit/PKRequestParams.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit;
 
 import android.net.Uri;

--- a/playkit/src/main/java/com/kaltura/playkit/PlayKitManager.java
+++ b/playkit/src/main/java/com/kaltura/playkit/PlayKitManager.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit;
 
 import android.content.Context;

--- a/playkit/src/main/java/com/kaltura/playkit/PlaybackInfo.java
+++ b/playkit/src/main/java/com/kaltura/playkit/PlaybackInfo.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit;
 
 /**

--- a/playkit/src/main/java/com/kaltura/playkit/Player.java
+++ b/playkit/src/main/java/com/kaltura/playkit/Player.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit;
 
 import android.support.annotation.NonNull;

--- a/playkit/src/main/java/com/kaltura/playkit/PlayerDecorator.java
+++ b/playkit/src/main/java/com/kaltura/playkit/PlayerDecorator.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit;
 
 import android.support.annotation.NonNull;

--- a/playkit/src/main/java/com/kaltura/playkit/PlayerDecoratorBase.java
+++ b/playkit/src/main/java/com/kaltura/playkit/PlayerDecoratorBase.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit;
 
 import android.support.annotation.NonNull;

--- a/playkit/src/main/java/com/kaltura/playkit/PlayerEvent.java
+++ b/playkit/src/main/java/com/kaltura/playkit/PlayerEvent.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit;
 
 import com.kaltura.playkit.player.PKTracks;

--- a/playkit/src/main/java/com/kaltura/playkit/PlayerLoader.java
+++ b/playkit/src/main/java/com/kaltura/playkit/PlayerLoader.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit;
 
 import android.content.Context;

--- a/playkit/src/main/java/com/kaltura/playkit/PlayerState.java
+++ b/playkit/src/main/java/com/kaltura/playkit/PlayerState.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit;
 
 /**

--- a/playkit/src/main/java/com/kaltura/playkit/Utils.java
+++ b/playkit/src/main/java/com/kaltura/playkit/Utils.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit;
 
 import android.content.Context;

--- a/playkit/src/main/java/com/kaltura/playkit/addon/cast/AdsInfoData.java
+++ b/playkit/src/main/java/com/kaltura/playkit/addon/cast/AdsInfoData.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.addon.cast;
 
 import java.util.List;

--- a/playkit/src/main/java/com/kaltura/playkit/addon/cast/BasicCastBuilder.java
+++ b/playkit/src/main/java/com/kaltura/playkit/addon/cast/BasicCastBuilder.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.addon.cast;
 
 import android.support.annotation.NonNull;

--- a/playkit/src/main/java/com/kaltura/playkit/addon/cast/CastAdInfoParser.java
+++ b/playkit/src/main/java/com/kaltura/playkit/addon/cast/CastAdInfoParser.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.addon.cast;
 
 import com.google.android.gms.cast.AdBreakInfo;

--- a/playkit/src/main/java/com/kaltura/playkit/addon/cast/CastConfigHelper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/addon/cast/CastConfigHelper.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.addon.cast;
 
 import android.text.TextUtils;

--- a/playkit/src/main/java/com/kaltura/playkit/addon/cast/CastInfo.java
+++ b/playkit/src/main/java/com/kaltura/playkit/addon/cast/CastInfo.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.addon.cast;
 
 

--- a/playkit/src/main/java/com/kaltura/playkit/addon/cast/OVPCastBuilder.java
+++ b/playkit/src/main/java/com/kaltura/playkit/addon/cast/OVPCastBuilder.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.addon.cast;
 
 import android.support.annotation.NonNull;

--- a/playkit/src/main/java/com/kaltura/playkit/addon/cast/OVPCastConfigHelper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/addon/cast/OVPCastConfigHelper.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.addon.cast;
 
 import android.text.TextUtils;

--- a/playkit/src/main/java/com/kaltura/playkit/addon/cast/TVPAPICastBuilder.java
+++ b/playkit/src/main/java/com/kaltura/playkit/addon/cast/TVPAPICastBuilder.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.addon.cast;
 
 import android.support.annotation.NonNull;

--- a/playkit/src/main/java/com/kaltura/playkit/addon/cast/TVPAPICastConfigHelper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/addon/cast/TVPAPICastConfigHelper.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.addon.cast;
 
 import org.json.JSONArray;

--- a/playkit/src/main/java/com/kaltura/playkit/ads/AdController.java
+++ b/playkit/src/main/java/com/kaltura/playkit/ads/AdController.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.ads;
 
 /**

--- a/playkit/src/main/java/com/kaltura/playkit/ads/AdEnabledPlayerController.java
+++ b/playkit/src/main/java/com/kaltura/playkit/ads/AdEnabledPlayerController.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.ads;
 
 import android.support.annotation.NonNull;

--- a/playkit/src/main/java/com/kaltura/playkit/ads/AdTagType.java
+++ b/playkit/src/main/java/com/kaltura/playkit/ads/AdTagType.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.ads;
 
 public enum AdTagType {

--- a/playkit/src/main/java/com/kaltura/playkit/ads/PKAdErrorType.java
+++ b/playkit/src/main/java/com/kaltura/playkit/ads/PKAdErrorType.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.ads;
 
 

--- a/playkit/src/main/java/com/kaltura/playkit/ads/PKAdInfo.java
+++ b/playkit/src/main/java/com/kaltura/playkit/ads/PKAdInfo.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.ads;
 
 import com.kaltura.playkit.plugins.ads.AdPositionType;

--- a/playkit/src/main/java/com/kaltura/playkit/ads/PKAdProviderListener.java
+++ b/playkit/src/main/java/com/kaltura/playkit/ads/PKAdProviderListener.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.ads;
 
 public interface PKAdProviderListener {

--- a/playkit/src/main/java/com/kaltura/playkit/api/KalturaAPIException.java
+++ b/playkit/src/main/java/com/kaltura/playkit/api/KalturaAPIException.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.api;
 
 import com.kaltura.netkit.connect.response.BaseResult;

--- a/playkit/src/main/java/com/kaltura/playkit/api/KalturaString.java
+++ b/playkit/src/main/java/com/kaltura/playkit/api/KalturaString.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.api;
 
 /**

--- a/playkit/src/main/java/com/kaltura/playkit/api/KalturaValue.java
+++ b/playkit/src/main/java/com/kaltura/playkit/api/KalturaValue.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.api;
 
 /**

--- a/playkit/src/main/java/com/kaltura/playkit/api/base/model/BasePlaybackContext.java
+++ b/playkit/src/main/java/com/kaltura/playkit/api/base/model/BasePlaybackContext.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.api.base.model;
 
 import com.google.gson.annotations.SerializedName;

--- a/playkit/src/main/java/com/kaltura/playkit/api/base/model/BasePlaybackSource.java
+++ b/playkit/src/main/java/com/kaltura/playkit/api/base/model/BasePlaybackSource.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.api.base.model;
 
 import android.text.TextUtils;

--- a/playkit/src/main/java/com/kaltura/playkit/api/base/model/KalturaDrmPlaybackPluginData.java
+++ b/playkit/src/main/java/com/kaltura/playkit/api/base/model/KalturaDrmPlaybackPluginData.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.api.base.model;
 
 import com.kaltura.netkit.connect.response.BaseResult;

--- a/playkit/src/main/java/com/kaltura/playkit/api/ovp/APIDefines.java
+++ b/playkit/src/main/java/com/kaltura/playkit/api/ovp/APIDefines.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.api.ovp;
 
 import android.support.annotation.IntDef;

--- a/playkit/src/main/java/com/kaltura/playkit/api/ovp/KalturaOvpErrorHelper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/api/ovp/KalturaOvpErrorHelper.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.api.ovp;
 
 import com.kaltura.netkit.utils.ErrorElement;

--- a/playkit/src/main/java/com/kaltura/playkit/api/ovp/KalturaOvpParser.java
+++ b/playkit/src/main/java/com/kaltura/playkit/api/ovp/KalturaOvpParser.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.api.ovp;
 
 import android.support.annotation.NonNull;

--- a/playkit/src/main/java/com/kaltura/playkit/api/ovp/OvpConfigs.java
+++ b/playkit/src/main/java/com/kaltura/playkit/api/ovp/OvpConfigs.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.api.ovp;
 
 /**

--- a/playkit/src/main/java/com/kaltura/playkit/api/ovp/OvpRequestBuilder.java
+++ b/playkit/src/main/java/com/kaltura/playkit/api/ovp/OvpRequestBuilder.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.api.ovp;
 
 import com.kaltura.netkit.connect.request.RequestBuilder;

--- a/playkit/src/main/java/com/kaltura/playkit/api/ovp/SimpleOvpSessionProvider.java
+++ b/playkit/src/main/java/com/kaltura/playkit/api/ovp/SimpleOvpSessionProvider.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.api.ovp;
 
 import android.text.TextUtils;

--- a/playkit/src/main/java/com/kaltura/playkit/api/ovp/model/FlavorAssetsFilter.java
+++ b/playkit/src/main/java/com/kaltura/playkit/api/ovp/model/FlavorAssetsFilter.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.api.ovp.model;
 
 

--- a/playkit/src/main/java/com/kaltura/playkit/api/ovp/model/KalturaBaseEntryListResponse.java
+++ b/playkit/src/main/java/com/kaltura/playkit/api/ovp/model/KalturaBaseEntryListResponse.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.api.ovp.model;
 
 import com.kaltura.netkit.connect.response.BaseResult;

--- a/playkit/src/main/java/com/kaltura/playkit/api/ovp/model/KalturaEntryContextDataResult.java
+++ b/playkit/src/main/java/com/kaltura/playkit/api/ovp/model/KalturaEntryContextDataResult.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.api.ovp.model;
 
 import com.kaltura.netkit.connect.response.BaseResult;

--- a/playkit/src/main/java/com/kaltura/playkit/api/ovp/model/KalturaEntryType.java
+++ b/playkit/src/main/java/com/kaltura/playkit/api/ovp/model/KalturaEntryType.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.api.ovp.model;
 
 import com.google.gson.annotations.SerializedName;

--- a/playkit/src/main/java/com/kaltura/playkit/api/ovp/model/KalturaFlavorAsset.java
+++ b/playkit/src/main/java/com/kaltura/playkit/api/ovp/model/KalturaFlavorAsset.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.api.ovp.model;
 
 /**

--- a/playkit/src/main/java/com/kaltura/playkit/api/ovp/model/KalturaLiveStreamEntry.java
+++ b/playkit/src/main/java/com/kaltura/playkit/api/ovp/model/KalturaLiveStreamEntry.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.api.ovp.model;
 
 /**

--- a/playkit/src/main/java/com/kaltura/playkit/api/ovp/model/KalturaMediaEntry.java
+++ b/playkit/src/main/java/com/kaltura/playkit/api/ovp/model/KalturaMediaEntry.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.api.ovp.model;
 
 import java.util.Arrays;

--- a/playkit/src/main/java/com/kaltura/playkit/api/ovp/model/KalturaMetadata.java
+++ b/playkit/src/main/java/com/kaltura/playkit/api/ovp/model/KalturaMetadata.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.api.ovp.model;
 
 import com.kaltura.netkit.connect.response.BaseResult;

--- a/playkit/src/main/java/com/kaltura/playkit/api/ovp/model/KalturaMetadataListResponse.java
+++ b/playkit/src/main/java/com/kaltura/playkit/api/ovp/model/KalturaMetadataListResponse.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.api.ovp.model;
 
 import com.kaltura.netkit.connect.response.BaseResult;

--- a/playkit/src/main/java/com/kaltura/playkit/api/ovp/model/KalturaPlaybackContext.java
+++ b/playkit/src/main/java/com/kaltura/playkit/api/ovp/model/KalturaPlaybackContext.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.api.ovp.model;
 
 import com.kaltura.playkit.api.base.model.BasePlaybackContext;

--- a/playkit/src/main/java/com/kaltura/playkit/api/ovp/model/KalturaPlaybackSource.java
+++ b/playkit/src/main/java/com/kaltura/playkit/api/ovp/model/KalturaPlaybackSource.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.api.ovp.model;
 
 import com.kaltura.playkit.api.base.model.BasePlaybackSource;

--- a/playkit/src/main/java/com/kaltura/playkit/api/ovp/model/KalturaSessionInfo.java
+++ b/playkit/src/main/java/com/kaltura/playkit/api/ovp/model/KalturaSessionInfo.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.api.ovp.model;
 
 import com.kaltura.netkit.connect.response.BaseResult;

--- a/playkit/src/main/java/com/kaltura/playkit/api/ovp/model/KalturaStartWidgetSessionResponse.java
+++ b/playkit/src/main/java/com/kaltura/playkit/api/ovp/model/KalturaStartWidgetSessionResponse.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.api.ovp.model;
 
 import com.kaltura.netkit.connect.response.BaseResult;

--- a/playkit/src/main/java/com/kaltura/playkit/api/ovp/model/OvpResultAdapter.java
+++ b/playkit/src/main/java/com/kaltura/playkit/api/ovp/model/OvpResultAdapter.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.api.ovp.model;
 
 import com.google.gson.Gson;

--- a/playkit/src/main/java/com/kaltura/playkit/api/ovp/services/AnalyticsService.java
+++ b/playkit/src/main/java/com/kaltura/playkit/api/ovp/services/AnalyticsService.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.api.ovp.services;
 
 import android.net.Uri;

--- a/playkit/src/main/java/com/kaltura/playkit/api/ovp/services/BaseEntryService.java
+++ b/playkit/src/main/java/com/kaltura/playkit/api/ovp/services/BaseEntryService.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.api.ovp.services;
 
 import com.google.gson.Gson;

--- a/playkit/src/main/java/com/kaltura/playkit/api/ovp/services/LiveStatsService.java
+++ b/playkit/src/main/java/com/kaltura/playkit/api/ovp/services/LiveStatsService.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.api.ovp.services;
 
 import android.net.Uri;

--- a/playkit/src/main/java/com/kaltura/playkit/api/ovp/services/MetaDataService.java
+++ b/playkit/src/main/java/com/kaltura/playkit/api/ovp/services/MetaDataService.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.api.ovp.services;
 
 import com.google.gson.JsonObject;

--- a/playkit/src/main/java/com/kaltura/playkit/api/ovp/services/OvpService.java
+++ b/playkit/src/main/java/com/kaltura/playkit/api/ovp/services/OvpService.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.api.ovp.services;
 
 import com.google.gson.JsonObject;

--- a/playkit/src/main/java/com/kaltura/playkit/api/ovp/services/OvpSessionService.java
+++ b/playkit/src/main/java/com/kaltura/playkit/api/ovp/services/OvpSessionService.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.api.ovp.services;
 
 import com.google.gson.JsonObject;

--- a/playkit/src/main/java/com/kaltura/playkit/api/ovp/services/ResponseProfile.java
+++ b/playkit/src/main/java/com/kaltura/playkit/api/ovp/services/ResponseProfile.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.api.ovp.services;
 
 import com.kaltura.playkit.api.ovp.APIDefines;

--- a/playkit/src/main/java/com/kaltura/playkit/api/ovp/services/StatsService.java
+++ b/playkit/src/main/java/com/kaltura/playkit/api/ovp/services/StatsService.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.api.ovp.services;
 
 import android.net.Uri;

--- a/playkit/src/main/java/com/kaltura/playkit/api/ovp/services/UserService.java
+++ b/playkit/src/main/java/com/kaltura/playkit/api/ovp/services/UserService.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.api.ovp.services;
 
 import android.support.annotation.NonNull;

--- a/playkit/src/main/java/com/kaltura/playkit/api/phoenix/APIDefines.java
+++ b/playkit/src/main/java/com/kaltura/playkit/api/phoenix/APIDefines.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.api.phoenix;
 
 import com.kaltura.playkit.PKMediaEntry;

--- a/playkit/src/main/java/com/kaltura/playkit/api/phoenix/PhoenixConfigs.java
+++ b/playkit/src/main/java/com/kaltura/playkit/api/phoenix/PhoenixConfigs.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.api.phoenix;
 
 import com.kaltura.playkit.PlayKitManager;

--- a/playkit/src/main/java/com/kaltura/playkit/api/phoenix/PhoenixErrorHelper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/api/phoenix/PhoenixErrorHelper.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.api.phoenix;
 
 import com.kaltura.netkit.utils.ErrorElement;

--- a/playkit/src/main/java/com/kaltura/playkit/api/phoenix/PhoenixParser.java
+++ b/playkit/src/main/java/com/kaltura/playkit/api/phoenix/PhoenixParser.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.api.phoenix;
 
 import com.google.gson.GsonBuilder;

--- a/playkit/src/main/java/com/kaltura/playkit/api/phoenix/PhoenixRequestBuilder.java
+++ b/playkit/src/main/java/com/kaltura/playkit/api/phoenix/PhoenixRequestBuilder.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.api.phoenix;
 
 import com.kaltura.netkit.connect.request.RequestBuilder;

--- a/playkit/src/main/java/com/kaltura/playkit/api/phoenix/model/AssetResult.java
+++ b/playkit/src/main/java/com/kaltura/playkit/api/phoenix/model/AssetResult.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.api.phoenix.model;
 
 import com.google.gson.annotations.SerializedName;

--- a/playkit/src/main/java/com/kaltura/playkit/api/phoenix/model/KalturaLicensedUrl.java
+++ b/playkit/src/main/java/com/kaltura/playkit/api/phoenix/model/KalturaLicensedUrl.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.api.phoenix.model;
 
 import android.text.TextUtils;

--- a/playkit/src/main/java/com/kaltura/playkit/api/phoenix/model/KalturaLoginResponse.java
+++ b/playkit/src/main/java/com/kaltura/playkit/api/phoenix/model/KalturaLoginResponse.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.api.phoenix.model;
 
 import com.kaltura.netkit.connect.response.BaseResult;

--- a/playkit/src/main/java/com/kaltura/playkit/api/phoenix/model/KalturaLoginSession.java
+++ b/playkit/src/main/java/com/kaltura/playkit/api/phoenix/model/KalturaLoginSession.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.api.phoenix.model;
 
 import com.kaltura.netkit.connect.response.BaseResult;

--- a/playkit/src/main/java/com/kaltura/playkit/api/phoenix/model/KalturaMediaAsset.java
+++ b/playkit/src/main/java/com/kaltura/playkit/api/phoenix/model/KalturaMediaAsset.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.api.phoenix.model;
 
 import com.kaltura.netkit.connect.response.BaseResult;

--- a/playkit/src/main/java/com/kaltura/playkit/api/phoenix/model/KalturaMediaFile.java
+++ b/playkit/src/main/java/com/kaltura/playkit/api/phoenix/model/KalturaMediaFile.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.api.phoenix.model;
 
 import com.kaltura.netkit.connect.response.BaseResult;

--- a/playkit/src/main/java/com/kaltura/playkit/api/phoenix/model/KalturaOTTUser.java
+++ b/playkit/src/main/java/com/kaltura/playkit/api/phoenix/model/KalturaOTTUser.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.api.phoenix.model;
 
 import com.kaltura.netkit.connect.response.BaseResult;

--- a/playkit/src/main/java/com/kaltura/playkit/api/phoenix/model/KalturaPlaybackContext.java
+++ b/playkit/src/main/java/com/kaltura/playkit/api/phoenix/model/KalturaPlaybackContext.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.api.phoenix.model;
 
 import com.kaltura.playkit.api.base.model.BasePlaybackContext;

--- a/playkit/src/main/java/com/kaltura/playkit/api/phoenix/model/KalturaPlaybackSource.java
+++ b/playkit/src/main/java/com/kaltura/playkit/api/phoenix/model/KalturaPlaybackSource.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.api.phoenix.model;
 
 import com.kaltura.playkit.api.base.model.BasePlaybackSource;

--- a/playkit/src/main/java/com/kaltura/playkit/api/phoenix/model/KalturaSession.java
+++ b/playkit/src/main/java/com/kaltura/playkit/api/phoenix/model/KalturaSession.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.api.phoenix.model;
 
 import com.kaltura.playkit.api.ovp.model.KalturaSessionInfo;

--- a/playkit/src/main/java/com/kaltura/playkit/api/phoenix/model/OttResultAdapter.java
+++ b/playkit/src/main/java/com/kaltura/playkit/api/phoenix/model/OttResultAdapter.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.api.phoenix.model;
 
 import com.google.gson.Gson;

--- a/playkit/src/main/java/com/kaltura/playkit/api/phoenix/services/AssetService.java
+++ b/playkit/src/main/java/com/kaltura/playkit/api/phoenix/services/AssetService.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.api.phoenix.services;
 
 import android.text.TextUtils;

--- a/playkit/src/main/java/com/kaltura/playkit/api/phoenix/services/BookmarkService.java
+++ b/playkit/src/main/java/com/kaltura/playkit/api/phoenix/services/BookmarkService.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.api.phoenix.services;
 
 import com.google.gson.JsonObject;

--- a/playkit/src/main/java/com/kaltura/playkit/api/phoenix/services/LicensedUrlService.java
+++ b/playkit/src/main/java/com/kaltura/playkit/api/phoenix/services/LicensedUrlService.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.api.phoenix.services;
 
 import com.google.gson.JsonObject;

--- a/playkit/src/main/java/com/kaltura/playkit/api/phoenix/services/OttUserService.java
+++ b/playkit/src/main/java/com/kaltura/playkit/api/phoenix/services/OttUserService.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.api.phoenix.services;
 
 import android.support.annotation.NonNull;

--- a/playkit/src/main/java/com/kaltura/playkit/api/phoenix/services/PhoenixService.java
+++ b/playkit/src/main/java/com/kaltura/playkit/api/phoenix/services/PhoenixService.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.api.phoenix.services;
 
 import android.support.annotation.Nullable;

--- a/playkit/src/main/java/com/kaltura/playkit/api/phoenix/services/PhoenixSessionService.java
+++ b/playkit/src/main/java/com/kaltura/playkit/api/phoenix/services/PhoenixSessionService.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.api.phoenix.services;
 
 import com.google.gson.JsonObject;

--- a/playkit/src/main/java/com/kaltura/playkit/api/tvpapi/services/MediaMarkService.java
+++ b/playkit/src/main/java/com/kaltura/playkit/api/tvpapi/services/MediaMarkService.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.api.tvpapi.services;
 
 import com.google.gson.JsonObject;

--- a/playkit/src/main/java/com/kaltura/playkit/drm/DeferredDrmSessionManager.java
+++ b/playkit/src/main/java/com/kaltura/playkit/drm/DeferredDrmSessionManager.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.drm;
 
 import android.os.Handler;

--- a/playkit/src/main/java/com/kaltura/playkit/drm/DeviceUuidFactory.java
+++ b/playkit/src/main/java/com/kaltura/playkit/drm/DeviceUuidFactory.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.drm;
 
 import android.annotation.SuppressLint;

--- a/playkit/src/main/java/com/kaltura/playkit/drm/DrmAdapter.java
+++ b/playkit/src/main/java/com/kaltura/playkit/drm/DrmAdapter.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.drm;
 
 import android.content.Context;

--- a/playkit/src/main/java/com/kaltura/playkit/drm/LocalDrmSessionManager.java
+++ b/playkit/src/main/java/com/kaltura/playkit/drm/LocalDrmSessionManager.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.drm;
 
 import android.media.MediaCryptoException;

--- a/playkit/src/main/java/com/kaltura/playkit/drm/MediaDrmSession.java
+++ b/playkit/src/main/java/com/kaltura/playkit/drm/MediaDrmSession.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.drm;
 
 import android.annotation.TargetApi;

--- a/playkit/src/main/java/com/kaltura/playkit/drm/SimpleDashParser.java
+++ b/playkit/src/main/java/com/kaltura/playkit/drm/SimpleDashParser.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.drm;
 
 import android.net.Uri;

--- a/playkit/src/main/java/com/kaltura/playkit/drm/WidevineClassicAdapter.java
+++ b/playkit/src/main/java/com/kaltura/playkit/drm/WidevineClassicAdapter.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.drm;
 
 import android.content.Context;

--- a/playkit/src/main/java/com/kaltura/playkit/drm/WidevineClassicCompat.java
+++ b/playkit/src/main/java/com/kaltura/playkit/drm/WidevineClassicCompat.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.drm;
 
 import android.annotation.TargetApi;

--- a/playkit/src/main/java/com/kaltura/playkit/drm/WidevineClassicDrm.java
+++ b/playkit/src/main/java/com/kaltura/playkit/drm/WidevineClassicDrm.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.drm;
 
 import android.content.ContentValues;

--- a/playkit/src/main/java/com/kaltura/playkit/drm/WidevineModularAdapter.java
+++ b/playkit/src/main/java/com/kaltura/playkit/drm/WidevineModularAdapter.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.drm;
 
 import android.annotation.TargetApi;

--- a/playkit/src/main/java/com/kaltura/playkit/drm/WidevineNotSupportedException.java
+++ b/playkit/src/main/java/com/kaltura/playkit/drm/WidevineNotSupportedException.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.drm;
 
 /**

--- a/playkit/src/main/java/com/kaltura/playkit/mediaproviders/base/BECallableLoader.java
+++ b/playkit/src/main/java/com/kaltura/playkit/mediaproviders/base/BECallableLoader.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.mediaproviders.base;
 
 

--- a/playkit/src/main/java/com/kaltura/playkit/mediaproviders/base/BEMediaProvider.java
+++ b/playkit/src/main/java/com/kaltura/playkit/mediaproviders/base/BEMediaProvider.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.mediaproviders.base;
 
 import com.kaltura.netkit.connect.executor.APIOkRequestsExecutor;

--- a/playkit/src/main/java/com/kaltura/playkit/mediaproviders/base/FormatsHelper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/mediaproviders/base/FormatsHelper.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.mediaproviders.base;
 
 import com.kaltura.playkit.PKMediaFormat;

--- a/playkit/src/main/java/com/kaltura/playkit/mediaproviders/base/MediaType.java
+++ b/playkit/src/main/java/com/kaltura/playkit/mediaproviders/base/MediaType.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.mediaproviders.base;
 
 import com.kaltura.playkit.PKMediaEntry;

--- a/playkit/src/main/java/com/kaltura/playkit/mediaproviders/base/OnMediaLoadCompletion.java
+++ b/playkit/src/main/java/com/kaltura/playkit/mediaproviders/base/OnMediaLoadCompletion.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.mediaproviders.base;
 
 import com.kaltura.netkit.connect.response.ResultElement;

--- a/playkit/src/main/java/com/kaltura/playkit/mediaproviders/mock/MockMediaProvider.java
+++ b/playkit/src/main/java/com/kaltura/playkit/mediaproviders/mock/MockMediaProvider.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.mediaproviders.mock;
 
 import android.content.Context;

--- a/playkit/src/main/java/com/kaltura/playkit/mediaproviders/ott/PhoenixMediaProvider.java
+++ b/playkit/src/main/java/com/kaltura/playkit/mediaproviders/ott/PhoenixMediaProvider.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.mediaproviders.ott;
 
 import android.net.Uri;

--- a/playkit/src/main/java/com/kaltura/playkit/mediaproviders/ovp/KalturaOvpMediaProvider.java
+++ b/playkit/src/main/java/com/kaltura/playkit/mediaproviders/ovp/KalturaOvpMediaProvider.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.mediaproviders.ovp;
 
 import android.support.annotation.NonNull;

--- a/playkit/src/main/java/com/kaltura/playkit/mediaproviders/ovp/PlaySourceUrlBuilder.java
+++ b/playkit/src/main/java/com/kaltura/playkit/mediaproviders/ovp/PlaySourceUrlBuilder.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.mediaproviders.ovp;
 
 import android.support.annotation.NonNull;

--- a/playkit/src/main/java/com/kaltura/playkit/player/AudioTrack.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/AudioTrack.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.player;
 
 import android.support.annotation.Nullable;

--- a/playkit/src/main/java/com/kaltura/playkit/player/BaseTrack.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/BaseTrack.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.player;
 
 /**

--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerView.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerView.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.player;
 
 import android.content.Context;

--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.player;
 
 import android.content.Context;

--- a/playkit/src/main/java/com/kaltura/playkit/player/MediaPlayerView.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/MediaPlayerView.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.player;
 
 import android.content.Context;

--- a/playkit/src/main/java/com/kaltura/playkit/player/MediaPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/MediaPlayerWrapper.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 
 
 package com.kaltura.playkit.player;

--- a/playkit/src/main/java/com/kaltura/playkit/player/MediaSupport.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/MediaSupport.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.player;
 
 import android.content.Context;

--- a/playkit/src/main/java/com/kaltura/playkit/player/PKMediaSourceConfig.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/PKMediaSourceConfig.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.player;
 
 import android.net.Uri;

--- a/playkit/src/main/java/com/kaltura/playkit/player/PKPlayerErrorType.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/PKPlayerErrorType.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.player;
 
 /**

--- a/playkit/src/main/java/com/kaltura/playkit/player/PKTracks.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/PKTracks.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.player;
 
 import android.support.annotation.NonNull;

--- a/playkit/src/main/java/com/kaltura/playkit/player/PlayerController.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/PlayerController.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.player;
 
 import android.content.Context;

--- a/playkit/src/main/java/com/kaltura/playkit/player/PlayerEngine.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/PlayerEngine.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.player;
 
 import com.kaltura.playkit.PlaybackInfo;

--- a/playkit/src/main/java/com/kaltura/playkit/player/PlayerView.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/PlayerView.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.player;
 
 import android.content.Context;

--- a/playkit/src/main/java/com/kaltura/playkit/player/SourceSelector.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/SourceSelector.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.player;
 
 import android.support.annotation.Nullable;

--- a/playkit/src/main/java/com/kaltura/playkit/player/TextTrack.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/TextTrack.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.player;
 
 import android.support.annotation.Nullable;

--- a/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.player;
 
 

--- a/playkit/src/main/java/com/kaltura/playkit/player/VideoTrack.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/VideoTrack.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.player;
 
 /**

--- a/playkit/src/main/java/com/kaltura/playkit/player/metadata/MetadataConverter.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/metadata/MetadataConverter.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.player.metadata;
 
 import com.google.android.exoplayer2.metadata.Metadata;

--- a/playkit/src/main/java/com/kaltura/playkit/player/metadata/PKApicFrame.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/metadata/PKApicFrame.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.player.metadata;
 
 /**

--- a/playkit/src/main/java/com/kaltura/playkit/player/metadata/PKBinaryFrame.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/metadata/PKBinaryFrame.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.player.metadata;
 
 /**

--- a/playkit/src/main/java/com/kaltura/playkit/player/metadata/PKChapterFrame.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/metadata/PKChapterFrame.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.player.metadata;
 
 import java.util.List;

--- a/playkit/src/main/java/com/kaltura/playkit/player/metadata/PKChapterTocFrame.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/metadata/PKChapterTocFrame.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.player.metadata;
 
 import java.util.List;

--- a/playkit/src/main/java/com/kaltura/playkit/player/metadata/PKCommentFrame.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/metadata/PKCommentFrame.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.player.metadata;
 
 /**

--- a/playkit/src/main/java/com/kaltura/playkit/player/metadata/PKEventMessage.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/metadata/PKEventMessage.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.player.metadata;
 
 /**

--- a/playkit/src/main/java/com/kaltura/playkit/player/metadata/PKGeobFrame.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/metadata/PKGeobFrame.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.player.metadata;
 
 /**

--- a/playkit/src/main/java/com/kaltura/playkit/player/metadata/PKMetadata.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/metadata/PKMetadata.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.player.metadata;
 
 /**

--- a/playkit/src/main/java/com/kaltura/playkit/player/metadata/PKPrivFrame.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/metadata/PKPrivFrame.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.player.metadata;
 
 /**

--- a/playkit/src/main/java/com/kaltura/playkit/player/metadata/PKTextInformationFrame.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/metadata/PKTextInformationFrame.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.player.metadata;
 
 /**

--- a/playkit/src/main/java/com/kaltura/playkit/player/metadata/PKUrlLinkFrame.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/metadata/PKUrlLinkFrame.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.player.metadata;
 
 /**

--- a/playkit/src/main/java/com/kaltura/playkit/plugins/SamplePlugin.java
+++ b/playkit/src/main/java/com/kaltura/playkit/plugins/SamplePlugin.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.plugins;
 
 import android.content.Context;

--- a/playkit/src/main/java/com/kaltura/playkit/plugins/ads/AdCuePoints.java
+++ b/playkit/src/main/java/com/kaltura/playkit/plugins/ads/AdCuePoints.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.plugins.ads;
 
 import java.util.List;

--- a/playkit/src/main/java/com/kaltura/playkit/plugins/ads/AdEvent.java
+++ b/playkit/src/main/java/com/kaltura/playkit/plugins/ads/AdEvent.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.plugins.ads;
 
 import com.kaltura.playkit.PKEvent;

--- a/playkit/src/main/java/com/kaltura/playkit/plugins/ads/AdInfo.java
+++ b/playkit/src/main/java/com/kaltura/playkit/plugins/ads/AdInfo.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.plugins.ads;
 
 import com.kaltura.playkit.ads.PKAdInfo;

--- a/playkit/src/main/java/com/kaltura/playkit/plugins/ads/AdPositionType.java
+++ b/playkit/src/main/java/com/kaltura/playkit/plugins/ads/AdPositionType.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.plugins.ads;
 
 /**

--- a/playkit/src/main/java/com/kaltura/playkit/plugins/ads/AdsProvider.java
+++ b/playkit/src/main/java/com/kaltura/playkit/plugins/ads/AdsProvider.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.plugins.ads;
 
 import com.kaltura.playkit.ads.AdEnabledPlayerController;

--- a/playkit/src/main/java/com/kaltura/playkit/plugins/ads/ima/IMAConfig.java
+++ b/playkit/src/main/java/com/kaltura/playkit/plugins/ads/ima/IMAConfig.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.plugins.ads.ima;
 
 import com.google.gson.Gson;

--- a/playkit/src/main/java/com/kaltura/playkit/plugins/ads/ima/IMAPlugin.java
+++ b/playkit/src/main/java/com/kaltura/playkit/plugins/ads/ima/IMAPlugin.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.plugins.ads.ima;
 
 import android.content.Context;

--- a/playkit/src/main/java/com/kaltura/playkit/plugins/ott/OttEvent.java
+++ b/playkit/src/main/java/com/kaltura/playkit/plugins/ott/OttEvent.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.plugins.ott;
 
 import com.kaltura.playkit.PKEvent;

--- a/playkit/src/main/java/com/kaltura/playkit/plugins/ott/PhoenixAnalyticsConfig.java
+++ b/playkit/src/main/java/com/kaltura/playkit/plugins/ott/PhoenixAnalyticsConfig.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.plugins.ott;
 
 import com.google.gson.JsonObject;

--- a/playkit/src/main/java/com/kaltura/playkit/plugins/ott/PhoenixAnalyticsEvent.java
+++ b/playkit/src/main/java/com/kaltura/playkit/plugins/ott/PhoenixAnalyticsEvent.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.plugins.ott;
 
 import com.kaltura.playkit.PKEvent;

--- a/playkit/src/main/java/com/kaltura/playkit/plugins/ott/PhoenixAnalyticsPlugin.java
+++ b/playkit/src/main/java/com/kaltura/playkit/plugins/ott/PhoenixAnalyticsPlugin.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.plugins.ott;
 
 import android.content.Context;

--- a/playkit/src/main/java/com/kaltura/playkit/plugins/ott/TVPAPIAnalyticsConfig.java
+++ b/playkit/src/main/java/com/kaltura/playkit/plugins/ott/TVPAPIAnalyticsConfig.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.plugins.ott;
 
 import com.google.gson.JsonObject;

--- a/playkit/src/main/java/com/kaltura/playkit/plugins/ott/TVPAPIAnalyticsEvent.java
+++ b/playkit/src/main/java/com/kaltura/playkit/plugins/ott/TVPAPIAnalyticsEvent.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.plugins.ott;
 
 import com.kaltura.playkit.PKEvent;

--- a/playkit/src/main/java/com/kaltura/playkit/plugins/ott/TVPAPIAnalyticsPlugin.java
+++ b/playkit/src/main/java/com/kaltura/playkit/plugins/ott/TVPAPIAnalyticsPlugin.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.plugins.ott;
 
 import android.content.Context;

--- a/playkit/src/main/java/com/kaltura/playkit/plugins/ovp/KalturaAnalyticsPlugin.java
+++ b/playkit/src/main/java/com/kaltura/playkit/plugins/ovp/KalturaAnalyticsPlugin.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.plugins.ovp;
 
 import android.content.Context;

--- a/playkit/src/main/java/com/kaltura/playkit/plugins/ovp/KalturaLiveStatsConfig.java
+++ b/playkit/src/main/java/com/kaltura/playkit/plugins/ovp/KalturaLiveStatsConfig.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.plugins.ovp;
 
 import com.google.gson.JsonObject;

--- a/playkit/src/main/java/com/kaltura/playkit/plugins/ovp/KalturaLiveStatsEvent.java
+++ b/playkit/src/main/java/com/kaltura/playkit/plugins/ovp/KalturaLiveStatsEvent.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.plugins.ovp;
 
 import com.kaltura.playkit.PKEvent;

--- a/playkit/src/main/java/com/kaltura/playkit/plugins/ovp/KalturaLiveStatsPlugin.java
+++ b/playkit/src/main/java/com/kaltura/playkit/plugins/ovp/KalturaLiveStatsPlugin.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.plugins.ovp;
 
 import android.content.Context;

--- a/playkit/src/main/java/com/kaltura/playkit/plugins/ovp/KalturaStatsConfig.java
+++ b/playkit/src/main/java/com/kaltura/playkit/plugins/ovp/KalturaStatsConfig.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.plugins.ovp;
 
 import com.google.gson.JsonObject;

--- a/playkit/src/main/java/com/kaltura/playkit/plugins/ovp/KalturaStatsEvent.java
+++ b/playkit/src/main/java/com/kaltura/playkit/plugins/ovp/KalturaStatsEvent.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.plugins.ovp;
 
 import com.kaltura.playkit.PKEvent;

--- a/playkit/src/main/java/com/kaltura/playkit/plugins/ovp/KalturaStatsPlugin.java
+++ b/playkit/src/main/java/com/kaltura/playkit/plugins/ovp/KalturaStatsPlugin.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.plugins.ovp;
 
 import android.content.Context;

--- a/playkit/src/main/java/com/kaltura/playkit/plugins/playback/KalturaPlaybackRequestAdapter.java
+++ b/playkit/src/main/java/com/kaltura/playkit/plugins/playback/KalturaPlaybackRequestAdapter.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.plugins.playback;
 
 import android.content.Context;

--- a/playkit/src/main/java/com/kaltura/playkit/plugins/youbora/YouboraAdManager.java
+++ b/playkit/src/main/java/com/kaltura/playkit/plugins/youbora/YouboraAdManager.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.plugins.youbora;
 
 import com.kaltura.playkit.MessageBus;

--- a/playkit/src/main/java/com/kaltura/playkit/plugins/youbora/YouboraConfig.java
+++ b/playkit/src/main/java/com/kaltura/playkit/plugins/youbora/YouboraConfig.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.plugins.youbora;
 
 

--- a/playkit/src/main/java/com/kaltura/playkit/plugins/youbora/YouboraEvent.java
+++ b/playkit/src/main/java/com/kaltura/playkit/plugins/youbora/YouboraEvent.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.plugins.youbora;
 
 import com.kaltura.playkit.PKEvent;

--- a/playkit/src/main/java/com/kaltura/playkit/plugins/youbora/YouboraLibraryManager.java
+++ b/playkit/src/main/java/com/kaltura/playkit/plugins/youbora/YouboraLibraryManager.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.plugins.youbora;
 
 import com.kaltura.playkit.MessageBus;

--- a/playkit/src/main/java/com/kaltura/playkit/plugins/youbora/YouboraPlugin.java
+++ b/playkit/src/main/java/com/kaltura/playkit/plugins/youbora/YouboraPlugin.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.plugins.youbora;
 
 import android.content.Context;

--- a/playkit/src/main/java/com/kaltura/playkit/utils/Consts.java
+++ b/playkit/src/main/java/com/kaltura/playkit/utils/Consts.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.utils;
 
 /**

--- a/playkit/src/main/java/com/kaltura/playkit/utils/EventLogger.java
+++ b/playkit/src/main/java/com/kaltura/playkit/utils/EventLogger.java
@@ -1,3 +1,15 @@
+/*
+ * ============================================================================
+ * Copyright (C) 2017 Kaltura Inc.
+ * 
+ * Licensed under the AGPLv3 license, unless a different license for a
+ * particular library is specified in the applicable library path.
+ * 
+ * You may obtain a copy of the License at
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * ============================================================================
+ */
+
 package com.kaltura.playkit.utils;
 
 import android.view.Surface;


### PR DESCRIPTION
The script is also attached, to be run from its directory. 
The script can be executed multiple times, it makes sure a given source file does not already contain the banner.