### PR TITLE
FEM-1697

### DIFF
--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
@@ -163,7 +163,10 @@ class ExoPlayerWrapper implements PlayerEngine, ExoPlayer.EventListener, Metadat
     private void preparePlayer(PKMediaSourceConfig sourceConfig) {
         //reset metadata on prepare.
         metadataList.clear();
-        drmSessionManager.setMediaSource(sourceConfig.mediaSource);
+
+        if (sourceConfig.mediaSource.hasDrmParams()) {
+            drmSessionManager.setMediaSource(sourceConfig.mediaSource);
+        }
 
         shouldGetTracksInfo = true;
         trackSelectionHelper.setCea608CaptionsEnabled(sourceConfig.cea608CaptionsEnabled);


### PR DESCRIPTION
Fix mp4 ad failed to play on emulator with widevine not supported exception

### Description of the Changes
        if (sourceConfig.mediaSource.hasDrmParams()) {
            drmSessionManager.setMediaSource(sourceConfig.mediaSource);
        }


