### PR TITLE
Fem 1730: Added Widevine Provisioning support to MediaSupport

### DIFF
--- a/playkit/src/main/java/com/kaltura/playkit/LocalAssetsManager.java
+++ b/playkit/src/main/java/com/kaltura/playkit/LocalAssetsManager.java
@@ -99,7 +99,7 @@ public class LocalAssetsManager {
         this.context = context;
         this.localDataStore = localDataStore;
 
-        MediaSupport.initialize(context);
+        MediaSupport.initializeDrmQuiet(context);
     }
 
     /**

--- a/playkit/src/main/java/com/kaltura/playkit/LocalAssetsManager.java
+++ b/playkit/src/main/java/com/kaltura/playkit/LocalAssetsManager.java
@@ -99,7 +99,7 @@ public class LocalAssetsManager {
         this.context = context;
         this.localDataStore = localDataStore;
 
-        MediaSupport.initializeDrmQuiet(context);
+        MediaSupport.initializeDrm(context, null);
     }
 
     /**

--- a/playkit/src/main/java/com/kaltura/playkit/PlayKitManager.java
+++ b/playkit/src/main/java/com/kaltura/playkit/PlayKitManager.java
@@ -20,10 +20,10 @@ import com.kaltura.playkit.player.MediaSupport;
 import java.util.HashMap;
 import java.util.Map;
 
-/**
- * Created by Noam Tamim @ Kaltura on 13/10/2016.
- */
 public class PlayKitManager {
+    
+    private static final PKLog log = PKLog.get("PlayKitManager");
+    
 
     public static final String VERSION_STRING = BuildConfig.VERSION_NAME;
     public static final String CLIENT_TAG = "playkit/android-" + VERSION_STRING;
@@ -55,7 +55,7 @@ public class PlayKitManager {
 
     public static Player loadPlayer(Context context, @Nullable PKPluginConfigs pluginConfigs) {
         
-        MediaSupport.initialize(context);
+        MediaSupport.initializeDrmQuiet(context);
         
         if (shouldSendDeviceCapabilitiesReport) {
             PKDeviceCapabilities.maybeSendReport(context);

--- a/playkit/src/main/java/com/kaltura/playkit/PlayKitManager.java
+++ b/playkit/src/main/java/com/kaltura/playkit/PlayKitManager.java
@@ -54,8 +54,8 @@ public class PlayKitManager {
     }
 
     public static Player loadPlayer(Context context, @Nullable PKPluginConfigs pluginConfigs) {
-        
-        MediaSupport.initializeDrmQuiet(context);
+
+        MediaSupport.initializeDrm(context, null);
         
         if (shouldSendDeviceCapabilitiesReport) {
             PKDeviceCapabilities.maybeSendReport(context);

--- a/playkitdemo/src/main/java/com/kaltura/playkitdemo/MainActivity.java
+++ b/playkitdemo/src/main/java/com/kaltura/playkitdemo/MainActivity.java
@@ -45,6 +45,7 @@ import com.kaltura.playkit.mediaproviders.ott.PhoenixMediaProvider;
 import com.kaltura.playkit.mediaproviders.ovp.KalturaOvpMediaProvider;
 import com.kaltura.playkit.player.AudioTrack;
 import com.kaltura.playkit.player.BaseTrack;
+import com.kaltura.playkit.player.MediaSupport;
 import com.kaltura.playkit.player.PKTracks;
 import com.kaltura.playkit.player.TextTrack;
 import com.kaltura.playkit.player.VideoTrack;
@@ -102,6 +103,9 @@ public class MainActivity extends AppCompatActivity implements AdapterView.OnIte
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+
+        checkDRM();
+
         mOrientationManager = new OrientationManager(this, SensorManager.SENSOR_DELAY_NORMAL, this);
         mOrientationManager.enable();
         setContentView(R.layout.activity_main);
@@ -157,6 +161,26 @@ public class MainActivity extends AppCompatActivity implements AdapterView.OnIte
                 setRequestedOrientation(orient);
             }
         });
+    }
+
+    private void checkDRM() {
+        try {
+            MediaSupport.initializeDrm(this);
+            log.d("DRM support: " + MediaSupport.widevineModular());
+        } catch (MediaSupport.DrmNotProvisionedException e) {
+            log.d("DRM not provisioned, try to provision");
+            MediaSupport.attemptDrmProvision(this, new MediaSupport.DrmProvisionCallback() {
+                @Override
+                public void onDrmProvisionComplete(Exception e) {
+                    if (e == null) {
+                        log.d("Provision successful");
+                        log.d("DRM support: " + MediaSupport.widevineModular());
+                    } else {
+                        log.e("Provision failed", e);
+                    }
+                }
+            });
+        }
     }
 
     private PKMediaEntry simpleMediaEntry(String id, String contentUrl, String licenseUrl, PKDrmParams.Scheme scheme) {


### PR DESCRIPTION
### Description of the Changes

 Added Widevine Provisioning support to MediaSupport

The application calls MediaSupport.initializeDrm(context, callback).

Sample:

```
    void initDrm() {
        MediaSupport.initializeDrm(this, new MediaSupport.DrmInitCallback() {
            @Override
            public void onDrmInitComplete(Set<PKDrmParams.Scheme> supportedDrmSchemes, boolean provisionPerformed, Exception provisionError) {
                if (provisionPerformed) {
                    if (provisionError != null) {
                        log.e("DRM Provisioning failed", provisionError);
                    } else {
                        log.d("DRM Provisioning succeeded");
                    }
                }
                log.d("DRM initialized; supported: " + supportedDrmSchemes);

                // Now it's safe to look at `supportedDrmSchemes`
            }
        });
    }
```

PlayKitManager and LocalAssetsManager also call this method, but without a callback (they have nothing to do with the result).

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
