### PR TITLE
Fem 1730: Add Widevine Provisioning support to MediaSupport

### DIFF
--- a/playkit/src/main/java/com/kaltura/playkit/LocalAssetsManager.java
+++ b/playkit/src/main/java/com/kaltura/playkit/LocalAssetsManager.java
@@ -99,7 +99,7 @@ public class LocalAssetsManager {
         this.context = context;
         this.localDataStore = localDataStore;
 
-        MediaSupport.initialize(context);
+        MediaSupport.initializeDrm(context, null);
     }
 
     /**

--- a/playkit/src/main/java/com/kaltura/playkit/PlayKitManager.java
+++ b/playkit/src/main/java/com/kaltura/playkit/PlayKitManager.java
@@ -21,9 +21,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class PlayKitManager {
-    
-    private static final PKLog log = PKLog.get("PlayKitManager");
-    
 
     public static final String VERSION_STRING = BuildConfig.VERSION_NAME;
     public static final String CLIENT_TAG = "playkit/android-" + VERSION_STRING;

--- a/playkit/src/main/java/com/kaltura/playkit/PlayKitManager.java
+++ b/playkit/src/main/java/com/kaltura/playkit/PlayKitManager.java
@@ -20,10 +20,10 @@ import com.kaltura.playkit.player.MediaSupport;
 import java.util.HashMap;
 import java.util.Map;
 
-/**
- * Created by Noam Tamim @ Kaltura on 13/10/2016.
- */
 public class PlayKitManager {
+    
+    private static final PKLog log = PKLog.get("PlayKitManager");
+    
 
     public static final String VERSION_STRING = BuildConfig.VERSION_NAME;
     public static final String CLIENT_TAG = "playkit/android-" + VERSION_STRING;
@@ -54,8 +54,8 @@ public class PlayKitManager {
     }
 
     public static Player loadPlayer(Context context, @Nullable PKPluginConfigs pluginConfigs) {
-        
-        MediaSupport.initialize(context);
+
+        MediaSupport.initializeDrm(context, null);
         
         if (shouldSendDeviceCapabilitiesReport) {
             PKDeviceCapabilities.maybeSendReport(context);

--- a/playkit/src/main/java/com/kaltura/playkit/player/MediaSupport.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/MediaSupport.java
@@ -67,6 +67,8 @@ public class MediaSupport {
                             provisionWidevine();
                             runCallback(drmInitCallback, true, null);
                         } catch (Exception e) {
+                            // Send any exception to the callback
+                            log.e("Widevine provisioning has failed", e);
                             runCallback(drmInitCallback, true, e);
                         }
                     }
@@ -226,10 +228,6 @@ public class MediaSupport {
 
             mediaDrm.provideProvisionResponse(response);
             widevineModular = true; // provisioning didn't fail
-            
-        } catch (Exception e) {
-            log.e("Provision Widevine failed", e);
-            throw e;
             
         } finally {
             if (mediaDrm != null) {

--- a/playkit/src/main/java/com/kaltura/playkit/player/MediaSupport.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/MediaSupport.java
@@ -15,11 +15,16 @@ package com.kaltura.playkit.player;
 import android.content.Context;
 import android.drm.DrmManagerClient;
 import android.media.MediaDrm;
+import android.media.NotProvisionedException;
+import android.os.AsyncTask;
 import android.os.Build;
-import android.support.annotation.NonNull;
+import android.support.annotation.RequiresApi;
+import android.util.Base64;
+import android.util.Log;
 
 import com.kaltura.playkit.PKDrmParams;
 import com.kaltura.playkit.PKLog;
+import com.kaltura.playkit.Utils;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -30,27 +35,109 @@ import java.util.UUID;
  */
 public class MediaSupport {
 
+    private static final PKLog log = PKLog.get("MediaSupport");
+    private static boolean initSucceeded;
+    
+    // Should be called by applications that use DRM, to make sure they can handle provision issues.
+    public static void checkDrm(Context context) throws DrmNotProvisionedException {
+        if (widevineClassic == null) {
+            checkWidevineClassic(context);
+        }
+
+        if (widevineModular == null) {
+            checkWidevineModular();
+        }
+    }
+
+    public interface DrmInitCallback {
+        /**
+         * Called when the DRM subsystem is initialized (with possible errors).
+         * @param supportedDrmSchemes   supported DRM schemes
+         * @param provisionPerformed    true if provisioning was required and performed, false otherwise
+         * @param provisionError        null if provisioning is successful, exception otherwise
+         */
+        void onDrmInitComplete(Set<PKDrmParams.Scheme> supportedDrmSchemes, boolean provisionPerformed, Exception provisionError);
+    }
+    
+    /**
+     * Initialize the DRM subsystem, performing provisioning if required. The callback is called
+     * when done. If provisioning was required, it is performed before the callback is called.
+     * @param context           
+     * @param drmInitCallback   callback object that will get the result. See {@link DrmInitCallback}.
+     */
+    public static void initializeDrm(Context context, final DrmInitCallback drmInitCallback) {
+        
+        try {
+            checkWidevineClassic(context);
+            checkWidevineModular();
+
+            initSucceeded = true;
+            
+            runCallback(drmInitCallback, false, null);
+            
+        } catch (DrmNotProvisionedException e) {
+            log.d("Widevine Modular needs provisioning");
+            AsyncTask.execute(new Runnable() {
+                @Override
+                public void run() {
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
+                        try {
+                            provisionWidevine();
+                            runCallback(drmInitCallback, true, null);
+                        } catch (Exception e) {
+                            runCallback(drmInitCallback, true, e);
+                        }
+                    }
+                }
+            });
+        }
+    }
+
+    private static void runCallback(DrmInitCallback drmInitCallback, boolean provisionPerformed, Exception provisionError) {
+
+        final Set<PKDrmParams.Scheme> supportedDrmSchemes = supportedDrmSchemes();
+        if (drmInitCallback != null) {
+            drmInitCallback.onDrmInitComplete(supportedDrmSchemes, provisionPerformed, provisionError);
+            
+        } else if (!initSucceeded) {
+            if (provisionError != null) {
+                log.e("DRM provisioning has failed, but nobody was looking. supportedDrmSchemes may be missing Widevine Modular.");
+            }
+            log.i("Provisioning was" + (provisionPerformed ? " " : " not ") + "performed");
+        }
+        
+        log.i("Supported DRM schemes " + supportedDrmSchemes);
+    }
+
+    public static class DrmNotProvisionedException extends Exception {
+        DrmNotProvisionedException(String message, Exception e) {
+            super(message, e);
+        }
+    }
+    
     public static final UUID WIDEVINE_UUID = UUID.fromString("edef8ba9-79d6-4ace-a3c8-27dcd51d21ed");
 
 
-    private static boolean widevineClassic = false;
-    private static boolean widevineModular = false;
-    private static boolean initialized = false;
+    private static Boolean widevineClassic;
+    private static Boolean widevineModular;
 
-    private static final PKLog log = PKLog.get("MediaSupport");
-
-    public static void initialize(@NonNull final Context context) {
-        if (initialized) {
-            return;
-        }
-        checkWidevineClassic(context);
-        widevineModular();
-        initialized = true;
-    }
-
+    /**
+     * @deprecated This method does not perform possibly required DRM provisioning. Call {@link #initializeDrm(Context, DrmInitCallback)} instead.
+     */
+    @Deprecated
     public static Set<PKDrmParams.Scheme> supportedDrmSchemes(Context context) {
-
-        initialize(context);
+        log.w("Warning: MediaSupport.supportedDrmSchemes(Context) is deprecated");
+        checkWidevineClassic(context);
+        try {
+            checkWidevineModular();
+        } catch (DrmNotProvisionedException e) {
+            log.e("Widevine Modular needs provisioning");
+        }
+        
+        return supportedDrmSchemes();
+    }
+    
+    private static Set<PKDrmParams.Scheme> supportedDrmSchemes() {
 
         HashSet<PKDrmParams.Scheme> schemes = new HashSet<>();
 
@@ -70,6 +157,10 @@ public class MediaSupport {
     }
 
     private static void checkWidevineClassic(Context context) {
+        if (widevineClassic != null) {
+            return;
+        }
+        
         DrmManagerClient drmManagerClient = new DrmManagerClient(context);
         try {
             widevineClassic = drmManagerClient.canHandle("", "video/wvm");
@@ -86,28 +177,51 @@ public class MediaSupport {
             //noinspection deprecation
             drmManagerClient.release();
         }
+        
+        // Still null? that means no.
+        if (widevineClassic == null) {
+            widevineClassic = false;
+        }
     }
 
     public static boolean widevineClassic() {
-        if (initialized) {
-            return widevineClassic;
+        if (widevineClassic == null) {
+            log.w("Widevine Classic DRM is not initialized; assuming not supported");
+            return false;
+        }
+        
+        return widevineClassic;
+    }
+    
+    public static boolean widevineModular() {
+        if (widevineModular == null) {
+            log.w("Widevine Modular DRM is not initialized; assuming not supported");
+            return false;
         }
 
-        log.w("MediaSupport not initialized; assuming no Widevine Classic support");
-        return false;
+        return widevineModular;
     }
 
-    public static boolean widevineModular() {
+    private static void checkWidevineModular() throws DrmNotProvisionedException {
+
+        if (widevineModular != null) {
+            return;
+        }
+        
         // Encrypted dash is only supported in Android v4.3 and up -- needs MediaDrm class.
         // Make sure Widevine is supported
-        if (!initialized && Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2 && MediaDrm.isCryptoSchemeSupported(WIDEVINE_UUID)) {
-
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2 && MediaDrm.isCryptoSchemeSupported(WIDEVINE_UUID)) {
+            
+            // Open a session to check if Widevine needs provisioning.
             MediaDrm mediaDrm = null;
             byte[] session = null;
             try {
                 mediaDrm = new MediaDrm(WIDEVINE_UUID);
                 session = mediaDrm.openSession();
                 widevineModular = true;
+            } catch (NotProvisionedException e) {
+                log.e("Widevine Modular not provisioned");
+                throw new DrmNotProvisionedException("Widevine Modular not provisioned", e);
             } catch (Exception e) {
                 widevineModular = false;
             } finally {
@@ -118,11 +232,39 @@ public class MediaSupport {
                     mediaDrm.release();
                 }
             }
+        } else {
+            widevineModular = false;
         }
-        return widevineModular;
     }
 
     public static boolean playReady() {
-        return Boolean.parseBoolean("false");   // Not yet.
+        return Boolean.FALSE;   // Not yet.
     }
+
+    @RequiresApi(api = Build.VERSION_CODES.JELLY_BEAN_MR2)
+    private static void provisionWidevine() throws Exception {
+        MediaDrm mediaDrm = null;
+        try {
+            mediaDrm = new MediaDrm(WIDEVINE_UUID);
+            MediaDrm.ProvisionRequest provisionRequest = mediaDrm.getProvisionRequest();
+            String url = provisionRequest.getDefaultUrl() + "&signedRequest=" + new String(provisionRequest.getData());
+
+            final byte[] response = Utils.executePost(url, null, null);
+
+            Log.d("RESULT", Base64.encodeToString(response, Base64.NO_WRAP));
+
+            mediaDrm.provideProvisionResponse(response);
+            widevineModular = true; // provisioning didn't fail
+            
+        } catch (Exception e) {
+            log.e("Provision Widevine failed", e);
+            throw e;
+            
+        } finally {
+            if (mediaDrm != null) {
+                mediaDrm.release();
+            }
+        }
+    }
+
 }

--- a/playkit/src/main/java/com/kaltura/playkit/player/MediaSupport.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/MediaSupport.java
@@ -35,34 +35,16 @@ import java.util.UUID;
  */
 public class MediaSupport {
 
+    public static final UUID WIDEVINE_UUID = UUID.fromString("edef8ba9-79d6-4ace-a3c8-27dcd51d21ed");
     private static final PKLog log = PKLog.get("MediaSupport");
     private static boolean initSucceeded;
-    
-    // Should be called by applications that use DRM, to make sure they can handle provision issues.
-    public static void checkDrm(Context context) throws DrmNotProvisionedException {
-        if (widevineClassic == null) {
-            checkWidevineClassic(context);
-        }
+    private static Boolean widevineClassic;
+    private static Boolean widevineModular;
 
-        if (widevineModular == null) {
-            checkWidevineModular();
-        }
-    }
-
-    public interface DrmInitCallback {
-        /**
-         * Called when the DRM subsystem is initialized (with possible errors).
-         * @param supportedDrmSchemes   supported DRM schemes
-         * @param provisionPerformed    true if provisioning was required and performed, false otherwise
-         * @param provisionError        null if provisioning is successful, exception otherwise
-         */
-        void onDrmInitComplete(Set<PKDrmParams.Scheme> supportedDrmSchemes, boolean provisionPerformed, Exception provisionError);
-    }
-    
     /**
      * Initialize the DRM subsystem, performing provisioning if required. The callback is called
      * when done. If provisioning was required, it is performed before the callback is called.
-     * @param context           
+     * @param context           Context
      * @param drmInitCallback   callback object that will get the result. See {@link DrmInitCallback}.
      */
     public static void initializeDrm(Context context, final DrmInitCallback drmInitCallback) {
@@ -92,7 +74,7 @@ public class MediaSupport {
             });
         }
     }
-
+    
     private static void runCallback(DrmInitCallback drmInitCallback, boolean provisionPerformed, Exception provisionError) {
 
         final Set<PKDrmParams.Scheme> supportedDrmSchemes = supportedDrmSchemes();
@@ -109,20 +91,9 @@ public class MediaSupport {
         log.i("Supported DRM schemes " + supportedDrmSchemes);
     }
 
-    public static class DrmNotProvisionedException extends Exception {
-        DrmNotProvisionedException(String message, Exception e) {
-            super(message, e);
-        }
-    }
-    
-    public static final UUID WIDEVINE_UUID = UUID.fromString("edef8ba9-79d6-4ace-a3c8-27dcd51d21ed");
-
-
-    private static Boolean widevineClassic;
-    private static Boolean widevineModular;
-
     /**
      * @deprecated This method does not perform possibly required DRM provisioning. Call {@link #initializeDrm(Context, DrmInitCallback)} instead.
+     * Will be removed in the next version.
      */
     @Deprecated
     public static Set<PKDrmParams.Scheme> supportedDrmSchemes(Context context) {
@@ -136,7 +107,7 @@ public class MediaSupport {
         
         return supportedDrmSchemes();
     }
-    
+
     private static Set<PKDrmParams.Scheme> supportedDrmSchemes() {
 
         HashSet<PKDrmParams.Scheme> schemes = new HashSet<>();
@@ -183,7 +154,7 @@ public class MediaSupport {
             widevineClassic = false;
         }
     }
-
+    
     public static boolean widevineClassic() {
         if (widevineClassic == null) {
             log.w("Widevine Classic DRM is not initialized; assuming not supported");
@@ -192,7 +163,7 @@ public class MediaSupport {
         
         return widevineClassic;
     }
-    
+
     public static boolean widevineModular() {
         if (widevineModular == null) {
             log.w("Widevine Modular DRM is not initialized; assuming not supported");
@@ -236,7 +207,7 @@ public class MediaSupport {
             widevineModular = false;
         }
     }
-
+    
     public static boolean playReady() {
         return Boolean.FALSE;   // Not yet.
     }
@@ -267,4 +238,19 @@ public class MediaSupport {
         }
     }
 
+    public interface DrmInitCallback {
+        /**
+         * Called when the DRM subsystem is initialized (with possible errors).
+         * @param supportedDrmSchemes   supported DRM schemes
+         * @param provisionPerformed    true if provisioning was required and performed, false otherwise
+         * @param provisionError        null if provisioning is successful, exception otherwise
+         */
+        void onDrmInitComplete(Set<PKDrmParams.Scheme> supportedDrmSchemes, boolean provisionPerformed, Exception provisionError);
+    }
+
+    private static class DrmNotProvisionedException extends Exception {
+        DrmNotProvisionedException(String message, Exception e) {
+            super(message, e);
+        }
+    }
 }


### PR DESCRIPTION
### Description of the Changes

 Added Widevine Provisioning support to MediaSupport

The application calls MediaSupport.initializeDrm(context, callback).

Sample:

```
    void initDrm() {
        MediaSupport.initializeDrm(this, new MediaSupport.DrmInitCallback() {
            @Override
            public void onDrmInitComplete(Set<PKDrmParams.Scheme> supportedDrmSchemes, boolean provisionPerformed, Exception provisionError) {
                if (provisionPerformed) {
                    if (provisionError != null) {
                        log.e("DRM Provisioning failed", provisionError);
                    } else {
                        log.d("DRM Provisioning succeeded");
                    }
                }
                log.d("DRM initialized; supported: " + supportedDrmSchemes);

                // Now it's safe to look at `supportedDrmSchemes`
            }
        });
    }
```

PlayKitManager and LocalAssetsManager also call this method, but without a callback (they have nothing to do with the result).

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [x] Docs have been updated
