### PR TITLE
FEM-1995 IMA ad attribution shown twice after change media

### DIFF
--- a/playkit/src/main/java/com/kaltura/playkit/plugins/ads/ima/IMAPlugin.java
+++ b/playkit/src/main/java/com/kaltura/playkit/plugins/ads/ima/IMAPlugin.java
@@ -241,6 +241,10 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
         isAdDisplayed = false;
         isAllAdsCompleted = false;
         isContentEndedBeforeMidroll = false;
+        if (adsManager != null) {
+            adsManager.destroy();
+        }
+        clearAdsLoader();
         imaSetup();
         requestAdsFromIMA(adConfig.getAdTagURL());
     }
@@ -248,14 +252,7 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
     @Override
     protected void onUpdateConfig(Object config) {
         log.d("Start onUpdateConfig");
-        if (adsManager != null) {
-            adsManager.destroy();
-        }
-        clearAdsLoader();
         adConfig = parseConfig(config);
-        isAdRequested = false;
-        isAdDisplayed = false;
-        isAllAdsCompleted = false;
     }
 
     private void clearAdsLoader() {


### PR DESCRIPTION
 -> need to make sure clearing IMA in change media 
since if ChangeMedia was done without calling onUpdateConfig for IMA the clear code was not called and this caused IMA to display ad attribution twice

