### PR TITLE
FEM-1986

### DIFF
--- a/playkit/src/main/java/com/kaltura/playkit/drm/WidevineModularAdapter.java
+++ b/playkit/src/main/java/com/kaltura/playkit/drm/WidevineModularAdapter.java
@@ -222,7 +222,14 @@ class WidevineModularAdapter extends DrmAdapter {
                 listener.onStatus(localAssetPath, 0, 0, false);
             }
             return false;
+        } catch (IllegalStateException e) { // FEM-1986 in case MediaDrm.MediaDrmStateException is thrown (wrong date on device for example) need to catch this exception and inform that status is expired
+            if (listener != null) {
+                listener.onStatus(localAssetPath, 0, 0, true);
+            }
+            log.e("DRM State Error", e);
+            return false;
         }
+
 
         return true;
     }


### PR DESCRIPTION
IllegalStateException was thrown and was not handled by playkit WidevineModularAdapter 
incase asset is registered and date is not correct on device --> today ++++
and checkAssetStatus was called by app/dtg 