### PR TITLE
add default CC subtitles init

### DIFF
--- a/playkit/src/main/java/com/kaltura/playkit/addon/cast/BasicCastBuilder.java
+++ b/playkit/src/main/java/com/kaltura/playkit/addon/cast/BasicCastBuilder.java
@@ -79,6 +79,10 @@ public abstract class BasicCastBuilder<T extends BasicCastBuilder> {
         return (T) this;
     }
 
+    public T setDefaultTextLanguageLabel(String label) {
+        castInfo.setDefaultTextLangaugeLabel(label);
+        return (T) this;
+    }
 
     public T setMwEmbedUrl(@NonNull String mwEmbedUrl) {
         castInfo.setMwEmbedUrl(mwEmbedUrl);

--- a/playkit/src/main/java/com/kaltura/playkit/addon/cast/CastConfigHelper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/addon/cast/CastConfigHelper.java
@@ -31,7 +31,6 @@ abstract class CastConfigHelper {
 
     JSONObject getCustomData(CastInfo castInfo) {
 
-
         String uiConf = castInfo.getUiConfId();
         String fileFormat = castInfo.getFormat();
         String entryId = castInfo.getMediaEntryId();
@@ -39,14 +38,14 @@ abstract class CastConfigHelper {
         String adTagUrl = castInfo.getAdTagUrl();
         String sessionInfo = getSessionInfo(castInfo);
         String mwEmbedUrl = castInfo.getMwEmbedUrl();
+        String textLangaugeLabel = castInfo.getDefaultTextLangaugeLabel();
 
 
         JSONObject customData = new JSONObject();
         JSONObject embedConfig = new JSONObject();
 
 
-        setEmbedConfig(customData, embedConfig, uiConf, fileFormat, entryId, partnerId, adTagUrl, sessionInfo, mwEmbedUrl);
-
+        setEmbedConfig(customData, embedConfig, uiConf, fileFormat, entryId, partnerId, adTagUrl, sessionInfo, mwEmbedUrl, textLangaugeLabel);
 
         return customData;
     }
@@ -55,9 +54,9 @@ abstract class CastConfigHelper {
 
 
     private void setEmbedConfig(JSONObject customData, JSONObject embedConfig, String uiConf,
-                                        String fileFormat, String entryId,
-                                        String partnerId, String adTagUrl, String sessionInfo,
-                                        String mwEmbedUrl) {
+                                String fileFormat, String entryId,
+                                String partnerId, String adTagUrl, String sessionInfo,
+                                String mwEmbedUrl, String textLangaugeLabel) {
 
         try {
 
@@ -73,6 +72,12 @@ abstract class CastConfigHelper {
 
             customData.put("embedConfig", embedConfig);
 
+            //Add default captions language in cast
+            if (!TextUtils.isEmpty(textLangaugeLabel)) {
+                JSONObject receiverConfig = new JSONObject();
+                receiverConfig.put("defaultLanguageKey", textLangaugeLabel);
+                customData.put("receiverConfig", receiverConfig);
+            }
         } catch (JSONException e) {
             log.e(e.getMessage());
         }
@@ -84,7 +89,7 @@ abstract class CastConfigHelper {
 
 
     private void setFlashVars(JSONObject embedConfig, String sessionInfo, String adTagUrl,
-                                           String fileFormat, String entryId) {
+                              String fileFormat, String entryId) {
 
         try {
 
@@ -104,7 +109,7 @@ abstract class CastConfigHelper {
 
 
     private JSONObject getFlashVars(String sessionInfo, String adTagUrl,
-                                           String fileFormat, String entryId) {
+                                    String fileFormat, String entryId) {
 
         JSONObject flashVars = new JSONObject();
 

--- a/playkit/src/main/java/com/kaltura/playkit/addon/cast/CastInfo.java
+++ b/playkit/src/main/java/com/kaltura/playkit/addon/cast/CastInfo.java
@@ -35,6 +35,7 @@ class CastInfo {
     private TextTrackStyle textTrackStyle;
     private String mwEmbedUrl;
     private StreamType streamType;
+    private String defaultTextLangaugeLabel;
 
 
     CastInfo() {
@@ -81,6 +82,10 @@ class CastInfo {
         this.mwEmbedUrl = mwEmbedUrl;
     }
 
+    void setDefaultTextLangaugeLabel(String defaultTextLangaugeLabel) {
+        this.defaultTextLangaugeLabel = defaultTextLangaugeLabel;
+    }
+
     void setStreamType(StreamType streamType) {
         this.streamType = streamType;
     }
@@ -123,6 +128,10 @@ class CastInfo {
 
     String getMwEmbedUrl() {
         return mwEmbedUrl;
+    }
+
+    String getDefaultTextLangaugeLabel() {
+        return defaultTextLangaugeLabel;
     }
 
     StreamType getStreamType() {


### PR DESCRIPTION
### Description of the Changes

added optional API `setDefaultTextLanguageLabel` to cast builder to give CC the default text track language that it should start with (Need to give language code)