### PR TITLE
FEM-2081

### DIFF
--- a/playkit/src/main/java/com/kaltura/playkit/mediaproviders/ovp/KalturaOvpMediaProvider.java
+++ b/playkit/src/main/java/com/kaltura/playkit/mediaproviders/ovp/KalturaOvpMediaProvider.java
@@ -380,7 +380,7 @@ public class KalturaOvpMediaProvider extends BEMediaProvider {
         }
 
         private static boolean is360Content(String tags) {
-            return !tags.isEmpty() && Pattern.compile("\\b360\\b").matcher(tags).find();
+            return tags != null && !tags.isEmpty() && Pattern.compile("\\b360\\b").matcher(tags).find();
 
         }
 


### PR DESCRIPTION
+ NPE fix. Playkit might crash if tags in KalturaOvpMediaProvider.java are null

### Description of the Changes

+ NPE fix. Playkit might crash if tags in KalturaOvpMediaProvider.java are null


