### PR TITLE
FEM-2100 - Avoid java.lang.IllegalArgumentException in change media and Multi tracks 

### DIFF
--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
@@ -687,6 +687,7 @@ class ExoPlayerWrapper implements PlayerEngine, Player.EventListener, MetadataOu
         log.d("stop");
         lastKnownVolume = Consts.DEFAULT_VOLUME;
         lastKnownPlaybackRate = Consts.DEFAULT_PLAYBACK_RATE_SPEED;
+        lastSelectedTrackIds = new String[]{TrackSelectionHelper.NONE, TrackSelectionHelper.NONE, TrackSelectionHelper.NONE};
 
         if (player != null) {
             player.setPlayWhenReady(false);

--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
@@ -687,8 +687,10 @@ class ExoPlayerWrapper implements PlayerEngine, Player.EventListener, MetadataOu
         log.d("stop");
         lastKnownVolume = Consts.DEFAULT_VOLUME;
         lastKnownPlaybackRate = Consts.DEFAULT_PLAYBACK_RATE_SPEED;
-        lastSelectedTrackIds = new String[]{TrackSelectionHelper.NONE, TrackSelectionHelper.NONE, TrackSelectionHelper.NONE};
-
+        lastSelectedTrackIds = new String[] {TrackSelectionHelper.NONE, TrackSelectionHelper.NONE, TrackSelectionHelper.NONE};
+        if (trackSelectionHelper != null) {
+            trackSelectionHelper.stop();
+        }
         if (player != null) {
             player.setPlayWhenReady(false);
             player.seekTo(0);

--- a/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
@@ -83,6 +83,7 @@ class TrackSelectionHelper {
     private boolean cea608CaptionsEnabled; //Flag that indicates if application interested in receiving cea-608 text track format.
 
     private TracksInfoListener tracksInfoListener;
+
     interface TracksInfoListener {
 
         void onTracksInfoReady(PKTracks PKTracks);
@@ -769,6 +770,12 @@ class TrackSelectionHelper {
 
     void setCea608CaptionsEnabled(boolean cea608CaptionsEnabled) {
         this.cea608CaptionsEnabled = cea608CaptionsEnabled;
+    }
+
+    // clean previous selection
+    void stop() {
+        lastSelectedTrackIds = new String[]{NONE, NONE, NONE};
+        requestedChangeTrackIds = new String[]{NONE, NONE, NONE};
     }
 }
 


### PR DESCRIPTION
### Description of the Changes

clear lastTracksSelected in ExoPlayer Wrapper and in TrackSelectionHelper to avoid mismatch in tracks after change media done and tracks in 2 medias are not the same 