### PR TITLE
FEM-2203 live live edge is not set by default after player pause action 

### DIFF
--- a/playkit/src/main/java/com/kaltura/playkit/player/PKMediaSourceConfig.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/PKMediaSourceConfig.java
@@ -28,6 +28,7 @@ public class PKMediaSourceConfig {
 
     PKMediaSource mediaSource;
     PKMediaEntry.MediaEntryType mediaEntryType;
+    Boolean dvrStatus;
     PlayerSettings playerSettings;
     private VRSettings vrSettings;
 
@@ -35,6 +36,14 @@ public class PKMediaSourceConfig {
     PKMediaSourceConfig(PKMediaConfig mediaConfig, PKMediaSource source, PlayerSettings playerSettings, VRSettings vrSettings) {
         this.mediaSource = source;
         this.mediaEntryType = mediaConfig.getMediaEntry().getMediaType();
+        if (mediaConfig.getMediaEntry().getMetadata() != null &&
+                mediaConfig.getMediaEntry().getMetadata().containsKey("dvrStatus")) {
+            if ("0".equals(mediaConfig.getMediaEntry().getMetadata().get("dvrStatus"))) {
+                this.dvrStatus = false;
+            } else {
+                this.dvrStatus = true;
+            }
+        }
         this.playerSettings = playerSettings;
         this.vrSettings = vrSettings;
     }

--- a/playkit/src/main/java/com/kaltura/playkit/player/PlayerController.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/PlayerController.java
@@ -575,11 +575,7 @@ public class PlayerController implements Player {
                         case DURATION_CHANGE:
                             event = new PlayerEvent.DurationChanged(getDuration());
                             if (getDuration() != Consts.TIME_UNSET && isNewEntry) {
-                                //For live entry it is possible to configure mediaConfig to start with an offset from live edge.
-                                //In this case startPosition in PKMediaConfig must be negative value which describes the amount of desired offset.
-                                if (PKMediaEntry.MediaEntryType.Live.equals(sourceConfig.mediaEntryType) && mediaConfig.getStartPosition() < 0) {
-                                    startPlaybackFrom(getDuration() + (mediaConfig.getStartPosition() * MILLISECONDS_MULTIPLIER));
-                                } else {
+                                if (mediaConfig.getStartPosition() > 0) {
                                     startPlaybackFrom(mediaConfig.getStartPosition() * MILLISECONDS_MULTIPLIER);
                                 }
                                 isNewEntry = false;


### PR DESCRIPTION
fix live media stuck after behidLiveWindowException
fix play behavior so player will seek to live edge after user pauses or go to fg/bg in live media

