### PR TITLE
Call stop() before changing media

### DIFF
--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
@@ -733,6 +733,7 @@ class ExoPlayerWrapper implements PlayerEngine, Player.EventListener, MetadataOu
     @Override
     public void stop() {
         log.d("stop");
+
         shouldResetPlayerPosition = true;
         preferredLanguageWasSelected = false;
         lastKnownVolume = Consts.DEFAULT_VOLUME;
@@ -741,7 +742,7 @@ class ExoPlayerWrapper implements PlayerEngine, Player.EventListener, MetadataOu
         if (trackSelectionHelper != null) {
             trackSelectionHelper.stop();
         }
-        if (player != null) {
+        if (player != null && currentState != PlayerState.IDLE) {
             player.stop(true);
             sendDistinctEvent(PlayerEvent.Type.STOPPED);
         }

--- a/playkit/src/main/java/com/kaltura/playkit/player/MediaPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/MediaPlayerWrapper.java
@@ -394,8 +394,11 @@ class MediaPlayerWrapper implements PlayerEngine, SurfaceHolder.Callback, MediaP
         if (player != null) {
             player.pause();
             player.seekTo(0);
-            player.reset();
-            sendDistinctEvent(PlayerEvent.Type.STOPPED);
+
+            if (currentState != PlayerState.IDLE) {
+                player.reset();
+                sendDistinctEvent(PlayerEvent.Type.STOPPED);
+            }
         }
     }
 

--- a/playkit/src/main/java/com/kaltura/playkit/player/PlayerController.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/PlayerController.java
@@ -179,8 +179,11 @@ public class PlayerController implements Player {
     public boolean setMedia(PKMediaConfig mediaConfig) {
         log.d("setMedia");
 
-        isNewEntry = true;
-
+        if (!isNewEntry) {
+            isNewEntry = true;
+            stop();
+        }
+        
         sessionId = generateSessionId();
         if (playerSettings.getContentRequestAdapter() != null) {
             playerSettings.getContentRequestAdapter().updateParams(this);


### PR DESCRIPTION
- PlayerController.setMedia() calls stop() before switching to a new media.
- ExoPlayerWrapper and MediaPlayerWrapper make sure stop is not called on IDLE state.
