### PR TITLE
Remove Player.prepareNext() and .skip()

### DIFF
--- a/playkit/src/main/java/com/kaltura/playkit/Player.java
+++ b/playkit/src/main/java/com/kaltura/playkit/Player.java
@@ -150,18 +150,7 @@ public interface Player {
      */
     void prepare(@NonNull PKMediaConfig playerConfig);
 
-    /**
-     * Prepare for playing the next entry. If config.shouldAutoPlay is true, the entry will automatically
-     * play when it's ready and the current entry is ended.
-     */
-    void prepareNext(@NonNull PKMediaConfig mediaConfig);
-
     void updatePluginConfig(@NonNull String pluginName, @Nullable Object pluginConfig);
-
-    /**
-     * Load the entry that was prepared with {@link #prepareNext(PKMediaConfig)}.
-     */
-    void skip();
 
     /**
      * Player lifecycle method. Should be used when the application went to onPause();

--- a/playkit/src/main/java/com/kaltura/playkit/PlayerDecorator.java
+++ b/playkit/src/main/java/com/kaltura/playkit/PlayerDecorator.java
@@ -30,11 +30,6 @@ public abstract class PlayerDecorator extends PlayerDecoratorBase {
     }
 
     @Override
-    final public void skip() {
-        super.skip();
-    }
-
-    @Override
     final public void addEventListener(@NonNull PKEvent.Listener listener, Enum... events) {
         super.addEventListener(listener, events);
     }

--- a/playkit/src/main/java/com/kaltura/playkit/PlayerDecoratorBase.java
+++ b/playkit/src/main/java/com/kaltura/playkit/PlayerDecoratorBase.java
@@ -100,11 +100,6 @@ public class PlayerDecoratorBase implements Player {
     }
 
     @Override
-    public void prepareNext(@NonNull PKMediaConfig mediaConfig) {
-        player.prepareNext(mediaConfig);
-    }
-
-    @Override
     public long getBufferedPosition() {
         return player.getBufferedPosition();
     }
@@ -122,11 +117,6 @@ public class PlayerDecoratorBase implements Player {
     @Override
     public PlayerView getView() {
         return player.getView();
-    }
-
-    @Override
-    public void skip() {
-        player.skip();
     }
 
     @Override

--- a/playkit/src/main/java/com/kaltura/playkit/player/PlayerController.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/PlayerController.java
@@ -397,16 +397,6 @@ public class PlayerController implements Player {
     }
 
     @Override
-    public void prepareNext(@NonNull PKMediaConfig mediaConfig) {
-        Assert.failState("Not implemented");
-    }
-
-    @Override
-    public void skip() {
-        Assert.failState("Not implemented");
-    }
-
-    @Override
     public void addEventListener(@NonNull PKEvent.Listener listener, Enum... events) {
         Assert.shouldNeverHappen();
     }


### PR DESCRIPTION
They were never implemented and they probably never will be.

## BREAKING CHANGE
If a plugin has implemented these methods in a subclass of PlayerDecorator, they compiler will generate an error (the methods will have the `@Override` annotation but not override anything).

Nothing will break because until now these methods would crash the application (not implemented error) so nobody uses them. The overrides will simply have to be deleted.
