### PR TITLE
FEM-2255 - send PLAY Event to messagebus while restoring playback 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,9 +2,9 @@
 
 buildscript {
     repositories {
-        jcenter()
-        maven { url "https://maven.google.com" }
         google()
+        jcenter()
+
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.1'
@@ -16,7 +16,6 @@ allprojects {
     repositories {
         google()
         jcenter()
-        maven { url "https://maven.google.com" }
     }
 }
 

--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
@@ -307,7 +307,7 @@ class ExoPlayerWrapper implements PlayerEngine, Player.EventListener, MetadataOu
     }
 
     private void sendEvent(PlayerEvent.Type event) {
-        if (shouldRestorePlayerToPreviousState) {
+        if (shouldRestorePlayerToPreviousState && event != PlayerEvent.Type.PLAY) {
             log.i("Trying to send event " + event.name() + ". Should be blocked from sending now, because the player is restoring to the previous state.");
             return;
         }


### PR DESCRIPTION
Analytics for PLAY after background resume was not fires since this event was ignored by SDK