### PR TITLE
FEM-2284 support channelCount to AudioTrack

### DIFF
--- a/playkit/src/main/java/com/kaltura/playkit/player/AudioTrack.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/AudioTrack.java
@@ -23,12 +23,14 @@ public class AudioTrack extends BaseTrack {
     private long bitrate;
     private String label;
     private String language;
+    private int channelCount;
 
-    AudioTrack(String uniqueId, String language, String label, long bitrate, int selectionFlag, boolean isAdaptive) {
+    AudioTrack(String uniqueId, String language, String label, long bitrate, int channelCount, int selectionFlag, boolean isAdaptive) {
         super(uniqueId, selectionFlag, isAdaptive);
         this.label = label;
         this.bitrate = bitrate;
         this.language = language;
+        this.channelCount = channelCount;
     }
 
     /**
@@ -61,5 +63,15 @@ public class AudioTrack extends BaseTrack {
     public @Nullable
     String getLabel() {
         return label;
+    }
+
+    /**
+     * Getter for the track channels count.
+     * Can be -1 if unknown or not applicable.
+     *
+     * @return - the number of channels of the track.
+     */
+    public int getChannelCount() {
+        return channelCount;
     }
 }

--- a/playkit/src/main/java/com/kaltura/playkit/player/PKCodecSupport.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/PKCodecSupport.java
@@ -3,8 +3,6 @@ package com.kaltura.playkit.player;
 import android.media.MediaCodecInfo;
 import android.media.MediaCodecList;
 import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-import android.text.TextUtils;
 
 import com.google.android.exoplayer2.Format;
 import com.google.android.exoplayer2.util.MimeTypes;
@@ -28,7 +26,7 @@ public class PKCodecSupport {
 
     private static boolean isCodecSupportedInternal(String codec, TrackType type) {
         String mimeType = (type == TrackType.AUDIO) ? MimeTypes.getAudioMediaMimeType(codec) :
-                                               MimeTypes.getVideoMediaMimeType(codec);
+                MimeTypes.getVideoMediaMimeType(codec);
 
         for (int i = 0, codecCount = MediaCodecList.getCodecCount(); i < codecCount; i++) {
             final MediaCodecInfo codecInfo = MediaCodecList.getCodecInfoAt(i);
@@ -59,7 +57,7 @@ public class PKCodecSupport {
         return sup;
     }
 
-    public static boolean isFormatSupported(@NonNull Format format, @Nullable TrackType type) {
+    public static boolean isFormatSupported(@NonNull Format format, @NonNull TrackType type) {
 
         if (type == TrackType.TEXT) {
             return true;    // always supported
@@ -69,21 +67,6 @@ public class PKCodecSupport {
             log.w("isFormatSupported: codecs==null, assuming supported");
             return true;
         }
-
-        if (type == null) {
-            // type==null: HLS muxed track with a <video,audio> tuple
-            final String[] split = TextUtils.split(format.codecs, ",");
-            boolean result = true;
-            switch (split.length) {
-                case 0: return false;
-                case 2: result = isCodecSupported(split[1], TrackType.AUDIO);
-                // fallthrough
-                case 1: result &= isCodecSupported(split[0], TrackType.VIDEO);
-            }
-            return result;
-
-        } else {
-            return isCodecSupported(format.codecs, type);
-        }
+        return isCodecSupported(format.codecs, type);
     }
 }

--- a/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
@@ -864,25 +864,36 @@ class TrackSelectionHelper {
                     }
                 } catch (MissingResourceException ex) {
                     log.e(ex.getMessage());
+                    preferredTrackUniqueId = null;
                 }
             }
-            //if user set mode to AUTO and the locale lang is not in the stream and no default text track in the stream so we will not select None but the first text track in the stream
-            if (preferredTrackUniqueId == null && preferredTextLanguageConfig.getPreferredMode() == PKTrackConfig.Mode.AUTO && textTracks != null) {
-                for (TextTrack track : textTracks) {
-                    if (track.getSelectionFlag() == Consts.DEFAULT_TRACK_SELECTION_FLAG) {
-                        preferredTrackUniqueId = track.getUniqueId();
-                        break;
-                    }
-                }
-                if (preferredTrackUniqueId == null && textTracks.size() > 1) {
-                    //take index = 1 since index = 0 is text track "none"
-                    preferredTrackUniqueId = textTracks.get(1).getUniqueId();
-                }
+            if (preferredTrackUniqueId == null) {
+                preferredTrackUniqueId = maybeSetFirstTextTrackAsAutoSelection();
             }
+
         }
         return preferredTrackUniqueId;
     }
 
+    @Nullable
+    private String maybeSetFirstTextTrackAsAutoSelection() {
+        String preferredTrackUniqueId = null;
+        //if user set mode to AUTO and the locale lang is not in the stream and no default text track in the stream so we will not select None but the first text track in the stream
+        if (preferredTextLanguageConfig != null && preferredTextLanguageConfig.getPreferredMode() == PKTrackConfig.Mode.AUTO && textTracks != null) {
+            for (TextTrack track : textTracks) {
+                if (track.getSelectionFlag() == Consts.DEFAULT_TRACK_SELECTION_FLAG) {
+                    preferredTrackUniqueId = track.getUniqueId();
+                    break;
+                }
+            }
+            if (preferredTrackUniqueId == null && textTracks.size() > 1) {
+                //take index = 1 since index = 0 is text track "none"
+                preferredTrackUniqueId = textTracks.get(1).getUniqueId();
+            }
+        }
+        return preferredTrackUniqueId;
+    }
+    
     private String getPreferredAudioTrackUniqueId(int trackType) {
         if (!isValidPreferredAudioConfig()) {
             return null;

--- a/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
@@ -836,10 +836,10 @@ class TrackSelectionHelper {
 
     @Nullable
     private String getPreferredTextTrackUniqueId(int trackType) {
-        String preferredTrackUniqueId = null;
         if (!isValidPreferredTextConfig()) {
             return null;
         }
+        String preferredTrackUniqueId = null;
         String preferredTextISO3Lang = preferredTextLanguageConfig.getTrackLanguage();
         if (preferredTextISO3Lang != null) {
             for (TextTrack track : textTracks) {
@@ -884,10 +884,10 @@ class TrackSelectionHelper {
     }
 
     private String getPreferredAudioTrackUniqueId(int trackType) {
-        String preferredTrackUniqueId = null;
         if (!isValidPreferredAudioConfig()) {
             return null;
         }
+        String preferredTrackUniqueId = null;
         String preferredAudioISO3Lang = preferredAudioLanguageConfig.getTrackLanguage();
         for (AudioTrack track : audioTracks) {
             String trackLang = track.getLanguage();

--- a/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
@@ -179,10 +179,10 @@ class TrackSelectionHelper {
                                 audioTrackLabel = format.label;
                                 if (format.language == null && format.codecs == null) {
                                     if (mpgaAudioFormatEnabled && format.id != null && format.id.matches("\\d+/\\d+")) {
-                                        audioTracks.add(new AudioTrack(uniqueId, format.id, audioTrackLabel, format.bitrate, format.selectionFlags, false));
+                                        audioTracks.add(new AudioTrack(uniqueId, format.id, audioTrackLabel, format.bitrate, format.channelCount, format.selectionFlags, false));
                                     }
                                 } else {
-                                    audioTracks.add(new AudioTrack(uniqueId, getLanguageFromFormat(format), audioTrackLabel, format.bitrate, format.selectionFlags, false));
+                                    audioTracks.add(new AudioTrack(uniqueId, getLanguageFromFormat(format), audioTrackLabel, format.bitrate, format.channelCount, format.selectionFlags, false));
                                 }
                                 break;
                             case TRACK_TYPE_TEXT:
@@ -349,7 +349,7 @@ class TrackSelectionHelper {
                     videoTracks.add(new VideoTrack(uniqueId, 0, 0, 0, format.selectionFlags, true));
                     break;
                 case TRACK_TYPE_AUDIO:
-                    audioTracks.add(new AudioTrack(uniqueId, format.language, format.id, 0, format.selectionFlags, true));
+                    audioTracks.add(new AudioTrack(uniqueId, format.language, format.id, 0, format.channelCount, format.selectionFlags, true));
                     break;
                 case TRACK_TYPE_TEXT:
                     textTracks.add(new TextTrack(uniqueId, format.language, format.id, format.selectionFlags));
@@ -928,4 +928,3 @@ class TrackSelectionHelper {
         this.preferredTextLanguageConfig  = settings.getPreferredTextTrackConfig();
     }
 }
-


### PR DESCRIPTION
Support getChannelCount on AudioTrack object so app can run similar code:

```java
private String buildAudioChannelString(int channelCount) {
        switch (channelCount) {
            case 1:
                return "Mono";
            case 2:
                return "Stereo";
            case 6:
            case 7:
                return "Surround_5.1";
            case 8:
                return "Surround_7.1";
            default:
                return "Surround";
        }
    }

```