### PR TITLE
FEM-2313 Add missing NPE checks for PlayerController.eventListener

### DIFF
--- a/playkit/src/main/java/com/kaltura/playkit/player/PlayerController.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/PlayerController.java
@@ -521,7 +521,7 @@ public class PlayerController implements Player {
             player.updateSubtitleStyle(subtitleStyleSettings);
         }
     }
-  
+
     private boolean assertPlayerIsNotNull(String methodName) {
         if (player != null) {
             return true;
@@ -548,7 +548,9 @@ public class PlayerController implements Player {
     private void sendErrorMessage(Enum errorType, String errorMessage, @Nullable Exception exception) {
         log.e(errorMessage);
         PlayerEvent errorEvent = new PlayerEvent.Error(new PKError(errorType, errorMessage, exception));
-        eventListener.onEvent(errorEvent);
+        if (eventListener != null) {
+            eventListener.onEvent(errorEvent);
+        }
     }
 
     private void updateProgress() {
@@ -562,7 +564,7 @@ public class PlayerController implements Player {
 
         position = player.getCurrentPosition();
         duration = player.getDuration();
-        if (position > 0 && duration > 0) {
+        if (eventListener != null && position > 0 && duration > 0) {
             eventListener.onEvent(new PlayerEvent.PlayheadUpdated(position, duration));
         }
 


### PR DESCRIPTION
### Description of the Changes

A crash occurs in our real project, see stack-trace below

```
Fatal Exception: java.lang.NullPointerException: Attempt to invoke interface method 'void com.kaltura.playkit.PKEvent$Listener.onEvent(com.kaltura.playkit.PKEvent)' on a null object reference
       at com.kaltura.playkit.player.PlayerController.sendErrorMessage(PlayerController.java:2518)
       at com.kaltura.playkit.PlayerLoader.prepare(PlayerLoader.java:135)
```
As I observed, there are NPE checks for `eventListener` in some places, but in 2 places (`sendErrorMessage()` and `updateProgress()` methods) they are missing. Simple adding NPE checks in these methods should fix the issue.

The issues were introduced in following commits:
 https://github.com/kaltura/playkit-android/commit/d3b95782fa7ee28915813da198d9d3f20a73860f 
 https://github.com/kaltura/playkit-android/commit/c01f769e50c3cec17e4df990ea2f16d354622565