### PR TITLE
FEM-2319 - prevent calling applicationPause/resume api afterplayer stop was done

### DIFF
--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
@@ -398,10 +398,13 @@ class ExoPlayerWrapper implements PlayerEngine, Player.EventListener, MetadataOu
 
     @Override
     public void onTimelineChanged(Timeline timeline, Object manifest, int reason) {
-        log.d("onTimelineChanged");
-        sendDistinctEvent(PlayerEvent.Type.LOADED_METADATA);
-        sendDistinctEvent(PlayerEvent.Type.DURATION_CHANGE);
-        shouldResetPlayerPosition = reason == Player.TIMELINE_CHANGE_REASON_DYNAMIC;
+        log.d("onTimelineChanged reason = " + reason);
+        if (reason == Player.TIMELINE_CHANGE_REASON_PREPARED) {
+            sendDistinctEvent(PlayerEvent.Type.LOADED_METADATA);
+            sendDistinctEvent(PlayerEvent.Type.DURATION_CHANGE);
+        }
+
+        shouldResetPlayerPosition = (reason == Player.TIMELINE_CHANGE_REASON_DYNAMIC);
     }
 
     @Override

--- a/playkit/src/main/java/com/kaltura/playkit/player/PlayerController.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/PlayerController.java
@@ -438,6 +438,7 @@ public class PlayerController implements Player {
     public void onApplicationPaused() {
         log.d("onApplicationPaused");
         if (isPlayerStopped) {
+            log.e("onApplicationPaused called during player state = STOPPED - return");
             return;
         }
         if (assertPlayerIsNotNull("onApplicationPaused()")) {
@@ -454,6 +455,7 @@ public class PlayerController implements Player {
     public void onApplicationResumed() {
         log.d("onApplicationResumed");
         if (isPlayerStopped) {
+            log.e("onApplicationResumed called during player state = STOPPED - return");
             return;
         }
         if (assertPlayerIsNotNull("onApplicationResumed()")) {

--- a/playkit/src/main/java/com/kaltura/playkit/player/PlayerController.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/PlayerController.java
@@ -436,7 +436,10 @@ public class PlayerController implements Player {
 
     @Override
     public void onApplicationPaused() {
-        log.v("onApplicationPaused");
+        log.d("onApplicationPaused");
+        if (isPlayerStopped) {
+            return;
+        }
         if (assertPlayerIsNotNull("onApplicationPaused()")) {
             if (player.isPlaying()) {
                 player.pause();
@@ -449,7 +452,10 @@ public class PlayerController implements Player {
 
     @Override
     public void onApplicationResumed() {
-        log.v("onApplicationResumed");
+        log.d("onApplicationResumed");
+        if (isPlayerStopped) {
+            return;
+        }
         if (assertPlayerIsNotNull("onApplicationResumed()")) {
             player.restore();
             updateProgress();


### PR DESCRIPTION
1. send metadata loaded event and duration change only in stream load…and not during other cases

2. block onApplicationPause/onApplicationResume to function during player is stopped



