### PR TITLE
FEM-2326: make the events API nicer to use

### DIFF
--- a/playkit/src/main/java/com/kaltura/playkit/MessageBus.java
+++ b/playkit/src/main/java/com/kaltura/playkit/MessageBus.java
@@ -47,9 +47,12 @@ public class MessageBus {
             postHandler.post(() -> {
                 for (PKEvent.Listener listener : listenerSet) {
                     try {
+                        // If the listener type does not match event type (programming error),
+                        // there will be a ClassCastException. Log it but don't crash.
+                        //noinspection unchecked
                         listener.onEvent(event);
                     } catch (ClassCastException e) {
-                        Log.e(TAG, "post: ", e);
+                        Log.e(TAG, "Wrong type of listener " + listener.getClass() + " for event (" + event.eventType() + ")", e);
                     }
                 }
             });

--- a/playkit/src/main/java/com/kaltura/playkit/MessageBus.java
+++ b/playkit/src/main/java/com/kaltura/playkit/MessageBus.java
@@ -26,7 +26,9 @@ import java.util.concurrent.ConcurrentHashMap;
 
 @SuppressWarnings("WeakerAccess")
 public class MessageBus {
-    private static final String TAG = "MessageBus";
+
+    private static final PKLog log = PKLog.get("MessageBus");
+
     private Handler postHandler = new Handler(Looper.getMainLooper());
     private Map<Object, Set<PKEvent.Listener>> listeners;
 
@@ -49,7 +51,7 @@ public class MessageBus {
                         //noinspection unchecked
                         listener.onEvent(event);
                     } catch (ClassCastException e) {
-                        Log.e(TAG, "Wrong type of listener " + listener.getClass() + " for event (" + event.eventType() + ")", e);
+                        log.e("Wrong type of listener " + listener.getClass() + " for event (" + event.eventType() + ")", e);
                     }
                 }
             });

--- a/playkit/src/main/java/com/kaltura/playkit/MessageBus.java
+++ b/playkit/src/main/java/com/kaltura/playkit/MessageBus.java
@@ -24,9 +24,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
-/**
- * Created by Noam Tamim @ Kaltura on 07/11/2016.
- */
 @SuppressWarnings("WeakerAccess")
 public class MessageBus {
     private static final String TAG = "MessageBus";

--- a/playkit/src/main/java/com/kaltura/playkit/PKEvent.java
+++ b/playkit/src/main/java/com/kaltura/playkit/PKEvent.java
@@ -18,5 +18,9 @@ public interface PKEvent {
     interface Listener<E extends PKEvent> {
         void onEvent(E event);
     }
+
+    interface RawListener {
+        void onEvent(PKEvent event);
+    }
 }
 

--- a/playkit/src/main/java/com/kaltura/playkit/PKEvent.java
+++ b/playkit/src/main/java/com/kaltura/playkit/PKEvent.java
@@ -15,8 +15,8 @@ package com.kaltura.playkit;
 public interface PKEvent {
     Enum eventType();
 
-    interface Listener {
-        void onEvent(PKEvent event);
+    interface Listener<E extends PKEvent> {
+        void onEvent(E event);
     }
 }
 

--- a/playkit/src/main/java/com/kaltura/playkit/Player.java
+++ b/playkit/src/main/java/com/kaltura/playkit/Player.java
@@ -14,15 +14,15 @@ package com.kaltura.playkit;
 
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.util.Log;
 
 import com.kaltura.playkit.player.LoadControlBuffers;
 import com.kaltura.playkit.player.PlayerView;
 import com.kaltura.playkit.player.SubtitleStyleSettings;
 import com.kaltura.playkit.utils.Consts;
 
-/**
- * Created by Noam Tamim @ Kaltura on 18/09/2016.
- */
+import java.util.List;
+
 public interface Player {
 
     /**
@@ -255,45 +255,6 @@ public interface Player {
     boolean isPlaying();
 
     /**
-     * Add event listener to the player.
-     *
-     * @param listener - event listener.
-     * @param events   - events the subscriber interested in.
-     */
-    PKEvent.Listener addEventListener(@NonNull PKEvent.Listener listener, Enum... events);
-
-    /**
-     * Remove event listener to the player.
-     *
-     * @param listener - event listener.
-     * @param events   - events the subscriber interested in.
-     */
-    void removeEventListener(@NonNull PKEvent.Listener listener, Enum... events);
-
-    /**
-     * Add state changed listener to the player.
-     *
-     * @param listener - state changed listener
-     */
-    PKEvent.Listener addStateChangeListener(@NonNull PKEvent.Listener listener);
-
-    /**
-     * remove state changed listener to the player.
-     *
-     * @param listener - state changed listener
-     */
-    void removeStateChangeListener(@NonNull PKEvent.Listener listener);
-
-
-    /**
-     * remove listener to the player.
-     *
-     * @param listener - event listener / state changed listener
-     */
-    void removeListener(@NonNull PKEvent.Listener listener);
-
-
-    /**
      * Change current track, with specified one by uniqueId.
      * If uniqueId is not valid or null, this will throw {@link IllegalArgumentException}.
      * Example of the valid uniqueId for regular video track: Video:0,0,1.
@@ -357,11 +318,93 @@ public interface Player {
 
 
 
-
+    /**
+     * Add listener by event type as Class object. This generics-based method allows the caller to
+     * avoid the otherwise required cast.
+     *
+     * Sample usage:
+     * <pre>
+     *   player.addListener(PlayerEvent.stateChanged,
+     *      event -> Log.d(TAG, "Player state change: " + event.oldState + " => " + event.newState));
+     * </pre>
+     * @param type A typed {@link Class} object. The class type must extend PKEvent.
+     * @param listener a typed {@link PKEvent.Listener}. Must match the type given as the first parameter.
+     * @param <E> Event type.
+     * @return the given event.
+     */
     @SuppressWarnings("UnusedReturnValue")
     <E extends PKEvent> PKEvent.Listener<E> addListener(Class<E> type, PKEvent.Listener<E> listener);
 
+    /**
+     * Add listener by event type as enum, for use with events that don't have payloads.
+     *
+     * Sample usage:
+     * <pre>
+     *   player.addListener(PlayerEvent.canPlay, event -> {
+     *       Log.d(TAG, "Player can play");
+     *   });
+     * </pre>
+     * @param type event type
+     * @param listener listener
+     * @return the given event
+     */
     @SuppressWarnings("UnusedReturnValue")
     PKEvent.Listener addListener(Enum type, PKEvent.Listener listener);
+
+    /**
+     * remove listener to the player.
+     *
+     * @param listener - event listener / state changed listener
+     */
+    void removeListener(@NonNull PKEvent.Listener listener);
+
+    /**
+     * Remove all listeners in the list, regardless of event type.
+     * @param listeners list of listeners to remove
+     */
+    default void removeListeners(List<PKEvent.Listener> listeners) {
+        for (PKEvent.Listener listener : listeners) {
+            removeListener(listener);
+        }
+    }
+
+    /**
+     * Add event listener to the player.
+     *
+     * @param listener - event listener.
+     * @param events   - events the subscriber interested in.
+     * @deprecated It's better to use one listener per event type with {@link #addListener(Class, PKEvent.Listener)}.
+     */
+    @Deprecated
+    PKEvent.Listener addEventListener(@NonNull PKEvent.Listener listener, Enum... events);
+
+    /**
+     * Remove event listener to the player.
+     *
+     * @param listener - event listener.
+     * @param events   - events the subscriber interested in.
+     * @deprecated It's better to use one listener per event type with {@link #addListener(Class, PKEvent.Listener)} and remove
+     * them with {@link #removeListener(PKEvent.Listener)} or {@link #removeListeners(List)}.
+     */
+    @Deprecated
+    void removeEventListener(@NonNull PKEvent.Listener listener, Enum... events);
+
+    /**
+     * Add state changed listener to the player.
+     *
+     * @param listener - state changed listener
+     * @deprecated Use {@link #addListener(Class, PKEvent.Listener)} with {@link PlayerEvent#stateChanged}.
+     */
+    @Deprecated
+    PKEvent.Listener addStateChangeListener(@NonNull PKEvent.Listener listener);
+
+    /**
+     * remove state changed listener to the player.
+     *
+     * @param listener - state changed listener
+     * @deprecated See {@link #addStateChangeListener(PKEvent.Listener)} and remove with {@link #removeListener(PKEvent.Listener)}.
+     */
+    @Deprecated
+    void removeStateChangeListener(@NonNull PKEvent.Listener listener);
 }
 

--- a/playkit/src/main/java/com/kaltura/playkit/Player.java
+++ b/playkit/src/main/java/com/kaltura/playkit/Player.java
@@ -14,7 +14,6 @@ package com.kaltura.playkit;
 
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-import android.util.Log;
 
 import com.kaltura.playkit.player.LoadControlBuffers;
 import com.kaltura.playkit.player.PlayerView;
@@ -23,11 +22,13 @@ import com.kaltura.playkit.utils.Consts;
 
 import java.util.List;
 
+@SuppressWarnings("unused")
 public interface Player {
 
     /**
      * Interface used for setting optional Player settings.
      */
+    @SuppressWarnings({"UnusedReturnValue", "unused"})
     interface Settings {
         /**
          * Set the Player's contentRequestAdapter.
@@ -375,6 +376,7 @@ public interface Player {
      * @param events   - events the subscriber interested in.
      * @deprecated It's better to use one listener per event type with {@link #addListener(Class, PKEvent.Listener)}.
      */
+    @SuppressWarnings("DeprecatedIsStillUsed")
     @Deprecated
     PKEvent.Listener addEventListener(@NonNull PKEvent.Listener listener, Enum... events);
 
@@ -386,6 +388,7 @@ public interface Player {
      * @deprecated It's better to use one listener per event type with {@link #addListener(Class, PKEvent.Listener)} and remove
      * them with {@link #removeListener(PKEvent.Listener)} or {@link #removeListeners(List)}.
      */
+    @SuppressWarnings("DeprecatedIsStillUsed")
     @Deprecated
     void removeEventListener(@NonNull PKEvent.Listener listener, Enum... events);
 
@@ -395,6 +398,7 @@ public interface Player {
      * @param listener - state changed listener
      * @deprecated Use {@link #addListener(Class, PKEvent.Listener)} with {@link PlayerEvent#stateChanged}.
      */
+    @SuppressWarnings("DeprecatedIsStillUsed")
     @Deprecated
     PKEvent.Listener addStateChangeListener(@NonNull PKEvent.Listener listener);
 
@@ -404,6 +408,7 @@ public interface Player {
      * @param listener - state changed listener
      * @deprecated See {@link #addStateChangeListener(PKEvent.Listener)} and remove with {@link #removeListener(PKEvent.Listener)}.
      */
+    @SuppressWarnings("DeprecatedIsStillUsed")
     @Deprecated
     void removeStateChangeListener(@NonNull PKEvent.Listener listener);
 }

--- a/playkit/src/main/java/com/kaltura/playkit/Player.java
+++ b/playkit/src/main/java/com/kaltura/playkit/Player.java
@@ -355,5 +355,13 @@ public interface Player {
      */
     void updateSubtitleStyle(SubtitleStyleSettings subtitleStyleSettings);
 
+
+
+
+    @SuppressWarnings("UnusedReturnValue")
+    <E extends PKEvent> PKEvent.Listener<E> addListener(Class<E> type, PKEvent.Listener<E> listener);
+
+    @SuppressWarnings("UnusedReturnValue")
+    PKEvent.Listener addListener(Enum type, PKEvent.Listener listener);
 }
 

--- a/playkit/src/main/java/com/kaltura/playkit/PlayerDecoratorBase.java
+++ b/playkit/src/main/java/com/kaltura/playkit/PlayerDecoratorBase.java
@@ -185,4 +185,13 @@ public class PlayerDecoratorBase implements Player {
         player.updateSubtitleStyle(subtitleStyleSettings);
     }
 
+    @Override
+    public <E extends PKEvent> PKEvent.Listener<E> addListener(Class<E> type, PKEvent.Listener<E> listener) {
+        return player.addListener(type, listener);
+    }
+
+    @Override
+    public PKEvent.Listener addListener(Enum type, PKEvent.Listener listener) {
+        return player.addListener(type, listener);
+    }
 }

--- a/playkit/src/main/java/com/kaltura/playkit/PlayerEvent.java
+++ b/playkit/src/main/java/com/kaltura/playkit/PlayerEvent.java
@@ -20,11 +20,7 @@ import com.kaltura.playkit.player.metadata.PKMetadata;
 
 import java.util.List;
 
-/**
- * Created by Noam Tamim @ Kaltura on 24/10/2016.
- */
-
-
+@SuppressWarnings("unused")
 public class PlayerEvent implements PKEvent {
 
     public static class Generic extends PlayerEvent {
@@ -32,6 +28,31 @@ public class PlayerEvent implements PKEvent {
             super(type);
         }
     }
+    public static final Class<Error> error = Error.class;
+    public static final Class<StateChanged> stateChanged = StateChanged.class;
+    public static final Class<DurationChanged> durationChanged = DurationChanged.class;
+    public static final Class<TracksAvailable> tracksAvailable = TracksAvailable.class;
+    public static final Class<VolumeChanged> volumeChanged = VolumeChanged.class;
+    public static final Class<PlaybackInfoUpdated> playbackInfoUpdated = PlaybackInfoUpdated.class;
+    public static final Class<MetadataAvailable> metadataAvailable = MetadataAvailable.class;
+    public static final Class<SourceSelected> sourceSelected = SourceSelected.class;
+    public static final Class<PlayheadUpdated> playheadUpdated = PlayheadUpdated.class;
+    public static final Class<Seeking> seeking = Seeking.class;
+    public static final Class<VideoTrackChanged> videoTrackChanged = VideoTrackChanged.class;
+    public static final Class<AudioTrackChanged> audioTrackChanged = AudioTrackChanged.class;
+    public static final Class<TextTrackChanged> textTrackChanged = TextTrackChanged.class;
+    public static final Class<PlaybackRateChanged> playbackRateChanged = PlaybackRateChanged.class;
+    public static final Class<SubtitlesStyleChanged> subtitlesStyleChanged = SubtitlesStyleChanged.class;
+
+    public static final PlayerEvent.Type canPlay = Type.CAN_PLAY;
+    public static final PlayerEvent.Type ended = Type.ENDED;
+    public static final PlayerEvent.Type loadedMetadata = Type.LOADED_METADATA;
+    public static final PlayerEvent.Type pause = Type.PAUSE;
+    public static final PlayerEvent.Type play = Type.PLAY;
+    public static final PlayerEvent.Type playing = Type.PLAYING;
+    public static final PlayerEvent.Type seeked = Type.SEEKED;
+    public static final PlayerEvent.Type replay = Type.REPLAY;
+    public static final PlayerEvent.Type stopped = Type.STOPPED;
 
     public static class StateChanged extends PlayerEvent {
         public final PlayerState newState;
@@ -225,7 +246,5 @@ public class PlayerEvent implements PKEvent {
         return this.type;
     }
 
-    public interface Listener {
-        void onPlayerEvent(Player player, Type event);
-    }
+
 }

--- a/playkit/src/main/java/com/kaltura/playkit/PlayerEvent.java
+++ b/playkit/src/main/java/com/kaltura/playkit/PlayerEvent.java
@@ -20,14 +20,9 @@ import com.kaltura.playkit.player.metadata.PKMetadata;
 
 import java.util.List;
 
-@SuppressWarnings("unused")
+@SuppressWarnings({"unused", "WeakerAccess"})
 public class PlayerEvent implements PKEvent {
 
-    public static class Generic extends PlayerEvent {
-        public Generic(Type type) {
-            super(type);
-        }
-    }
     public static final Class<Error> error = Error.class;
     public static final Class<StateChanged> stateChanged = StateChanged.class;
     public static final Class<DurationChanged> durationChanged = DurationChanged.class;
@@ -53,6 +48,12 @@ public class PlayerEvent implements PKEvent {
     public static final PlayerEvent.Type seeked = Type.SEEKED;
     public static final PlayerEvent.Type replay = Type.REPLAY;
     public static final PlayerEvent.Type stopped = Type.STOPPED;
+
+    public static class Generic extends PlayerEvent {
+        public Generic(Type type) {
+            super(type);
+        }
+    }
 
     public static class StateChanged extends PlayerEvent {
         public final PlayerState newState;

--- a/playkit/src/main/java/com/kaltura/playkit/PlayerLoader.java
+++ b/playkit/src/main/java/com/kaltura/playkit/PlayerLoader.java
@@ -202,4 +202,16 @@ class PlayerLoader extends PlayerDecoratorBase {
     public void removeListener(@NonNull PKEvent.Listener listener) {
         messageBus.removeListener(listener);
     }
+
+    @Override
+    public <E extends PKEvent> PKEvent.Listener<E> addListener(Class<E> type, PKEvent.Listener<E> listener) {
+        messageBus.addListener(type, listener);
+        return listener;
+    }
+
+    @Override
+    public PKEvent.Listener addListener(Enum type, PKEvent.Listener listener) {
+        messageBus.addListener(type, listener);
+        return listener;
+    }
 }

--- a/playkit/src/main/java/com/kaltura/playkit/PlayerLoader.java
+++ b/playkit/src/main/java/com/kaltura/playkit/PlayerLoader.java
@@ -34,11 +34,9 @@ class LoadedPlugin {
 
     PKPlugin plugin;
     PlayerDecorator decorator;
-
 }
 
 class PlayerLoader extends PlayerDecoratorBase {
-
 
     private static final PKLog log = PKLog.get("PlayerLoader");
 
@@ -60,12 +58,7 @@ class PlayerLoader extends PlayerDecoratorBase {
         // By default, set Kaltura decorator.
         KalturaPlaybackRequestAdapter.install(playerController, context.getPackageName());
 
-        playerController.setEventListener(new PKEvent.Listener() {
-            @Override
-            public void onEvent(PKEvent event) {
-                messageBus.post(event);
-            }
-        });
+        playerController.setEventListener(messageBus::post);
 
         Player player = playerController;
 

--- a/playkit/src/main/java/com/kaltura/playkit/player/PlayerController.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/PlayerController.java
@@ -531,6 +531,18 @@ public class PlayerController implements Player {
         }
     }
 
+    @Override
+    public <E extends PKEvent> PKEvent.Listener<E> addListener(Class<E> type, PKEvent.Listener<E> listener) {
+        Assert.shouldNeverHappen();
+        return null;
+    }
+
+    @Override
+    public PKEvent.Listener addListener(Enum type, PKEvent.Listener listener) {
+        Assert.shouldNeverHappen();
+        return null;
+    }
+
     private boolean assertPlayerIsNotNull(String methodName) {
         if (player != null) {
             return true;

--- a/playkit/src/main/java/com/kaltura/playkit/player/PlayerController.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/PlayerController.java
@@ -28,13 +28,11 @@ import com.kaltura.playkit.PKMediaFormat;
 import com.kaltura.playkit.PKMediaSource;
 import com.kaltura.playkit.Player;
 import com.kaltura.playkit.PlayerEvent;
-import com.kaltura.playkit.PlayerState;
 import com.kaltura.playkit.player.vr.VRPKMediaEntry;
 import com.kaltura.playkit.utils.Consts;
 
 import java.util.UUID;
 
-import static com.kaltura.playkit.PKMediaFormat.wvm;
 import static com.kaltura.playkit.utils.Consts.MILLISECONDS_MULTIPLIER;
 
 /**
@@ -299,7 +297,7 @@ public class PlayerController implements Player {
             if (startPosition <= getDuration()) {
                 player.startFrom(startPosition);
             } else {
-                log.w("The start position is grater then duration of the video! Start position " + startPosition + ", duration " + mediaConfig.getMediaEntry().getDuration());
+                log.w("The start position is grater then duration of the video! Start position " + startPosition + ", duration " + getDuration());
             }
         }
     }
@@ -550,14 +548,6 @@ public class PlayerController implements Player {
         String nullPlayerMsgFormat = "Attempt to invoke '%s' on null instance of the player engine";
         log.w(String.format(nullPlayerMsgFormat, methodName));
         return false;
-    }
-
-    private boolean shouldSwitchBetweenPlayers(PKMediaSource newSource) {
-
-        PKMediaFormat currentMediaFormat = newSource.getMediaFormat();
-        return currentMediaFormat != wvm && player instanceof MediaPlayerWrapper ||
-                currentMediaFormat == wvm && player instanceof ExoPlayerWrapper;
-
     }
 
     private void removePlayerView() {

--- a/playkit/src/main/java/com/kaltura/playkit/player/PlayerController.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/PlayerController.java
@@ -64,7 +64,7 @@ public class PlayerController implements Player {
     private boolean isPlayerStopped;
 
 
-    private PKEvent.Listener eventListener;
+    private PKEvent.RawListener eventListener;
     private PlayerEngine.EventListener eventTrigger = initEventListener();
     private PlayerEngine.StateChangedListener stateChangedTrigger = initStateChangeListener();
 
@@ -596,12 +596,7 @@ public class PlayerController implements Player {
     }
 
     private Runnable initProgressAction() {
-        return new Runnable() {
-            @Override
-            public void run() {
-                updateProgress();
-            }
-        };
+        return this::updateProgress;
     }
 
     private void cancelUpdateProgress() {
@@ -610,91 +605,87 @@ public class PlayerController implements Player {
         }
     }
 
-    public void setEventListener(PKEvent.Listener eventListener) {
+    public void setEventListener(PKEvent.RawListener eventListener) {
         this.eventListener = eventListener;
     }
 
     private PlayerEngine.EventListener initEventListener() {
-        return new PlayerEngine.EventListener() {
+        return eventType -> {
+            if (eventListener != null) {
 
-            @Override
-            public void onEvent(PlayerEvent.Type eventType) {
-                if (eventListener != null) {
-
-                    PKEvent event;
-                    switch (eventType) {
-                        case PLAYING:
-                            updateProgress();
-                            event = new PlayerEvent.Generic(eventType);
-                            break;
-                        case PAUSE:
-                        case ENDED:
-                            event = new PlayerEvent.Generic(eventType);
-                            cancelUpdateProgress();
-                            break;
-                        case DURATION_CHANGE:
-                            event = new PlayerEvent.DurationChanged(getDuration());
-                            if (getDuration() != Consts.TIME_UNSET && isNewEntry) {
-                                if (mediaConfig.getStartPosition() != null &&
-                                        ((isLiveMediaWithDvr() && mediaConfig.getStartPosition() == 0) ||
-                                                mediaConfig.getStartPosition() > 0)) {
-                                    startPlaybackFrom(mediaConfig.getStartPosition() * MILLISECONDS_MULTIPLIER);
-                                }
-                                isNewEntry = false;
-                                isPlayerStopped = false;
+                PKEvent event;
+                switch (eventType) {
+                    case PLAYING:
+                        updateProgress();
+                        event = new PlayerEvent.Generic(eventType);
+                        break;
+                    case PAUSE:
+                    case ENDED:
+                        event = new PlayerEvent.Generic(eventType);
+                        cancelUpdateProgress();
+                        break;
+                    case DURATION_CHANGE:
+                        event = new PlayerEvent.DurationChanged(getDuration());
+                        if (getDuration() != Consts.TIME_UNSET && isNewEntry) {
+                            if (mediaConfig.getStartPosition() != null &&
+                                    ((isLiveMediaWithDvr() && mediaConfig.getStartPosition() == 0) ||
+                                            mediaConfig.getStartPosition() > 0)) {
+                                startPlaybackFrom(mediaConfig.getStartPosition() * MILLISECONDS_MULTIPLIER);
                             }
-                            break;
-                        case TRACKS_AVAILABLE:
-                            event = new PlayerEvent.TracksAvailable(player.getPKTracks());
-                            break;
-                        case VOLUME_CHANGED:
-                            event = new PlayerEvent.VolumeChanged(player.getVolume());
-                            break;
-                        case PLAYBACK_INFO_UPDATED:
-                            event = new PlayerEvent.PlaybackInfoUpdated(player.getPlaybackInfo());
-                            break;
-                        case ERROR:
-                            if (player.getCurrentError() == null) {
-                                log.e("can not send error event");
-                                return;
-                            }
-                            event = new PlayerEvent.Error(player.getCurrentError());
-                            cancelUpdateProgress();
-                            break;
-                        case METADATA_AVAILABLE:
-                            if (player.getMetadata() == null || player.getMetadata().isEmpty()) {
-                                log.w("METADATA_AVAILABLE event received, but player engine have no metadata.");
-                                return;
-                            }
-                            event = new PlayerEvent.MetadataAvailable(player.getMetadata());
-                            break;
-                        case SOURCE_SELECTED:
-                            event = new PlayerEvent.SourceSelected(sourceConfig.mediaSource);
-                            break;
-                        case SEEKING:
-                            event = new PlayerEvent.Seeking(targetSeekPosition);
-                            break;
-                        case VIDEO_TRACK_CHANGED:
-                            event = new PlayerEvent.VideoTrackChanged((VideoTrack) player.getLastSelectedTrack(Consts.TRACK_TYPE_VIDEO));
-                            break;
-                        case AUDIO_TRACK_CHANGED:
-                            event = new PlayerEvent.AudioTrackChanged((AudioTrack) player.getLastSelectedTrack(Consts.TRACK_TYPE_AUDIO));
-                            break;
-                        case TEXT_TRACK_CHANGED:
-                            event = new PlayerEvent.TextTrackChanged((TextTrack) player.getLastSelectedTrack(Consts.TRACK_TYPE_TEXT));
-                            break;
-                        case PLAYBACK_RATE_CHANGED:
-                            event = new PlayerEvent.PlaybackRateChanged(player.getPlaybackRate());
-                            break;
-                        case SUBTITLE_STYLE_CHANGED:
-                            event = new PlayerEvent.SubtitlesStyleChanged(playerSettings.getSubtitleStyleSettings().getStyleName());
-                            break;
-                        default:
-                            event = new PlayerEvent.Generic(eventType);
-                    }
-
-                    eventListener.onEvent(event);
+                            isNewEntry = false;
+                            isPlayerStopped = false;
+                        }
+                        break;
+                    case TRACKS_AVAILABLE:
+                        event = new PlayerEvent.TracksAvailable(player.getPKTracks());
+                        break;
+                    case VOLUME_CHANGED:
+                        event = new PlayerEvent.VolumeChanged(player.getVolume());
+                        break;
+                    case PLAYBACK_INFO_UPDATED:
+                        event = new PlayerEvent.PlaybackInfoUpdated(player.getPlaybackInfo());
+                        break;
+                    case ERROR:
+                        if (player.getCurrentError() == null) {
+                            log.e("can not send error event");
+                            return;
+                        }
+                        event = new PlayerEvent.Error(player.getCurrentError());
+                        cancelUpdateProgress();
+                        break;
+                    case METADATA_AVAILABLE:
+                        if (player.getMetadata() == null || player.getMetadata().isEmpty()) {
+                            log.w("METADATA_AVAILABLE event received, but player engine have no metadata.");
+                            return;
+                        }
+                        event = new PlayerEvent.MetadataAvailable(player.getMetadata());
+                        break;
+                    case SOURCE_SELECTED:
+                        event = new PlayerEvent.SourceSelected(sourceConfig.mediaSource);
+                        break;
+                    case SEEKING:
+                        event = new PlayerEvent.Seeking(targetSeekPosition);
+                        break;
+                    case VIDEO_TRACK_CHANGED:
+                        event = new PlayerEvent.VideoTrackChanged((VideoTrack) player.getLastSelectedTrack(Consts.TRACK_TYPE_VIDEO));
+                        break;
+                    case AUDIO_TRACK_CHANGED:
+                        event = new PlayerEvent.AudioTrackChanged((AudioTrack) player.getLastSelectedTrack(Consts.TRACK_TYPE_AUDIO));
+                        break;
+                    case TEXT_TRACK_CHANGED:
+                        event = new PlayerEvent.TextTrackChanged((TextTrack) player.getLastSelectedTrack(Consts.TRACK_TYPE_TEXT));
+                        break;
+                    case PLAYBACK_RATE_CHANGED:
+                        event = new PlayerEvent.PlaybackRateChanged(player.getPlaybackRate());
+                        break;
+                    case SUBTITLE_STYLE_CHANGED:
+                        event = new PlayerEvent.SubtitlesStyleChanged(playerSettings.getSubtitleStyleSettings().getStyleName());
+                        break;
+                    default:
+                        event = new PlayerEvent.Generic(eventType);
                 }
+
+                eventListener.onEvent(event);
             }
         };
     }
@@ -704,12 +695,9 @@ public class PlayerController implements Player {
     }
 
     private PlayerEngine.StateChangedListener initStateChangeListener() {
-        return new PlayerEngine.StateChangedListener() {
-            @Override
-            public void onStateChanged(PlayerState oldState, PlayerState newState) {
-                if (eventListener != null) {
-                    eventListener.onEvent(new PlayerEvent.StateChanged(newState, oldState));
-                }
+        return (oldState, newState) -> {
+            if (eventListener != null) {
+                eventListener.onEvent(new PlayerEvent.StateChanged(newState, oldState));
             }
         };
     }

--- a/playkit/src/main/java/com/kaltura/playkit/plugins/ads/AdEvent.java
+++ b/playkit/src/main/java/com/kaltura/playkit/plugins/ads/AdEvent.java
@@ -15,11 +15,42 @@ package com.kaltura.playkit.plugins.ads;
 import com.kaltura.playkit.PKError;
 import com.kaltura.playkit.PKEvent;
 
-/**
- * Created by gilad.nadav on 22/11/2016.
- */
-
+@SuppressWarnings("unused")
 public class AdEvent implements PKEvent {
+
+    public static final Class<AdLoadedEvent> loaded = AdLoadedEvent.class;
+    public static final Class<AdStartedEvent> started = AdStartedEvent.class;
+    public static final Class<AdPausedEvent> paused = AdPausedEvent.class;
+    public static final Class<AdResumedEvent> resumed = AdResumedEvent.class;
+    public static final Class<AdSkippedEvent> skipped = AdSkippedEvent.class;
+    public static final Class<AdCuePointsUpdateEvent> cuepointsChanged = AdCuePointsUpdateEvent.class;
+    public static final Class<AdPlayHeadEvent> playHeadChanged = AdPlayHeadEvent.class;
+    public static final Class<AdRequestedEvent> adRequested = AdRequestedEvent.class;
+    public static final Class<AdBufferStart> adBufferStart = AdBufferStart.class;
+    public static final Class<AdBufferEnd> adBufferEnd = AdBufferEnd.class;
+    public static final Class<AdPlaybackInfoUpdated> adPlaybackInfoUpdated = AdPlaybackInfoUpdated.class;
+    public static final Class<Error> error = Error.class;
+
+    public static final AdEvent.Type adFirstPlay = Type.AD_FIRST_PLAY;
+    public static final AdEvent.Type adDisplayedAfterContentPause = Type.AD_DISPLAYED_AFTER_CONTENT_PAUSE;
+    public static final AdEvent.Type completed = Type.COMPLETED;
+    public static final AdEvent.Type firstQuartile = Type.FIRST_QUARTILE;
+    public static final AdEvent.Type midpoint = Type.MIDPOINT;
+    public static final AdEvent.Type thirdQuartile = Type.THIRD_QUARTILE;
+    public static final AdEvent.Type skippableStateChanged = Type.SKIPPABLE_STATE_CHANGED;
+    public static final AdEvent.Type clicked = Type.CLICKED;
+    public static final AdEvent.Type tapped = Type.TAPPED;
+    public static final AdEvent.Type iconTapped = Type.ICON_TAPPED;
+    public static final AdEvent.Type adBreakReady = Type.AD_BREAK_READY;
+    public static final AdEvent.Type adProgress = Type.AD_PROGRESS;
+    public static final AdEvent.Type adBreakStarted = Type.AD_BREAK_STARTED;
+    public static final AdEvent.Type adBreakEnded = Type.AD_BREAK_ENDED;
+    public static final AdEvent.Type adBreakIgnored = Type.AD_BREAK_IGNORED;
+    public static final AdEvent.Type contentPauseRequested = Type.CONTENT_PAUSE_REQUESTED;
+    public static final AdEvent.Type contentResumeRequested = Type.CONTENT_RESUME_REQUESTED;
+    public static final AdEvent.Type allAdsCompleted = Type.ALL_ADS_COMPLETED;
+    public static final AdEvent.Type adLoadTimeoutTimerStarted = Type.AD_LOAD_TIMEOUT_TIMER_STARTED;
+
 
     public Type type;
 


### PR DESCRIPTION
- Add two new `addListener` methods to Player that encourage using one listener per event
- Add static members to `PlayerEvent` and `AdEvent` that make it really easy to use those new methods (see Javadoc)
- Some Java8 Lambda cleanups