### PR TITLE
Addendum to the changes in FEM-2326 (#501)

### DIFF
--- a/playkit/src/main/java/com/kaltura/playkit/MessageBus.java
+++ b/playkit/src/main/java/com/kaltura/playkit/MessageBus.java
@@ -15,8 +15,8 @@ package com.kaltura.playkit;
 import android.os.Handler;
 import android.os.Looper;
 import android.support.annotation.Nullable;
-import android.util.Log;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -58,10 +58,11 @@ public class MessageBus {
         }
     }
 
-    private Set<PKEvent.Listener> safeSet(@Nullable Set<PKEvent.Listener> listeners) {
+    private static Set<PKEvent.Listener> safeSet(@Nullable Set<PKEvent.Listener> listeners) {
         return listeners != null ? listeners : Collections.emptySet();
     }
 
+    @Deprecated
     public void remove(PKEvent.Listener listener, Enum... eventTypes) {
         for (Enum eventType : eventTypes) {
             Set<PKEvent.Listener> listenerSet = listeners.get(eventType);
@@ -71,6 +72,10 @@ public class MessageBus {
         }
     }
 
+    /**
+     * Remove the listener regardless of event type.
+     * @param listener Listener to remove.
+     */
     public void removeListener(PKEvent.Listener listener) {
         for (Set<PKEvent.Listener> listenerSet : listeners.values()) {
             Iterator<PKEvent.Listener> iterator = listenerSet.iterator();
@@ -83,6 +88,17 @@ public class MessageBus {
         }
     }
 
+    /**
+     * Remove all listeners in the collection regardless of event type.
+     * @param listeners Collection of listeners to remove.
+     */
+    public void removeListeners(Collection<PKEvent.Listener> listeners) {
+        for (PKEvent.Listener listener : listeners) {
+            removeListener(listener);
+        }
+    }
+
+    @Deprecated
     public PKEvent.Listener listen(PKEvent.Listener listener, Enum... eventTypes) {
         for (Enum eventType : eventTypes) {
             addListener(eventType, listener);
@@ -94,7 +110,7 @@ public class MessageBus {
         addListener((Object)type, listener);
     }
 
-    public <E extends PKEvent> void addListener(Class<E> type, PKEvent.Listener listener) {
+    public <E extends PKEvent> void addListener(Class<E> type, PKEvent.Listener<E> listener) {
         addListener((Object)type, listener);
     }
 

--- a/playkit/src/main/java/com/kaltura/playkit/Player.java
+++ b/playkit/src/main/java/com/kaltura/playkit/Player.java
@@ -21,7 +21,6 @@ import com.kaltura.playkit.player.SubtitleStyleSettings;
 import com.kaltura.playkit.utils.Consts;
 
 import java.util.Collection;
-import java.util.List;
 
 @SuppressWarnings("unused")
 public interface Player {

--- a/playkit/src/main/java/com/kaltura/playkit/Player.java
+++ b/playkit/src/main/java/com/kaltura/playkit/Player.java
@@ -20,6 +20,7 @@ import com.kaltura.playkit.player.PlayerView;
 import com.kaltura.playkit.player.SubtitleStyleSettings;
 import com.kaltura.playkit.utils.Consts;
 
+import java.util.Collection;
 import java.util.List;
 
 @SuppressWarnings("unused")
@@ -353,7 +354,7 @@ public interface Player {
     PKEvent.Listener addListener(Enum type, PKEvent.Listener listener);
 
     /**
-     * remove listener to the player.
+     * Remove listener to the player, regardless of event type.
      *
      * @param listener - event listener / state changed listener
      */
@@ -363,7 +364,7 @@ public interface Player {
      * Remove all listeners in the list, regardless of event type.
      * @param listeners list of listeners to remove
      */
-    default void removeListeners(List<PKEvent.Listener> listeners) {
+    default void removeListeners(Collection<PKEvent.Listener> listeners) {
         for (PKEvent.Listener listener : listeners) {
             removeListener(listener);
         }
@@ -376,19 +377,17 @@ public interface Player {
      * @param events   - events the subscriber interested in.
      * @deprecated It's better to use one listener per event type with {@link #addListener(Class, PKEvent.Listener)}.
      */
-    @SuppressWarnings("DeprecatedIsStillUsed")
     @Deprecated
     PKEvent.Listener addEventListener(@NonNull PKEvent.Listener listener, Enum... events);
 
     /**
-     * Remove event listener to the player.
+     * Remove event listener from the player.
      *
      * @param listener - event listener.
      * @param events   - events the subscriber interested in.
      * @deprecated It's better to use one listener per event type with {@link #addListener(Class, PKEvent.Listener)} and remove
-     * them with {@link #removeListener(PKEvent.Listener)} or {@link #removeListeners(List)}.
+     * them with {@link #removeListener(PKEvent.Listener)} or {@link #removeListeners(Collection)}.
      */
-    @SuppressWarnings("DeprecatedIsStillUsed")
     @Deprecated
     void removeEventListener(@NonNull PKEvent.Listener listener, Enum... events);
 
@@ -398,17 +397,15 @@ public interface Player {
      * @param listener - state changed listener
      * @deprecated Use {@link #addListener(Class, PKEvent.Listener)} with {@link PlayerEvent#stateChanged}.
      */
-    @SuppressWarnings("DeprecatedIsStillUsed")
     @Deprecated
     PKEvent.Listener addStateChangeListener(@NonNull PKEvent.Listener listener);
 
     /**
-     * remove state changed listener to the player.
+     * Remove state changed listener from the player.
      *
      * @param listener - state changed listener
      * @deprecated See {@link #addStateChangeListener(PKEvent.Listener)} and remove with {@link #removeListener(PKEvent.Listener)}.
      */
-    @SuppressWarnings("DeprecatedIsStillUsed")
     @Deprecated
     void removeStateChangeListener(@NonNull PKEvent.Listener listener);
 }

--- a/playkit/src/main/java/com/kaltura/playkit/PlayerLoader.java
+++ b/playkit/src/main/java/com/kaltura/playkit/PlayerLoader.java
@@ -171,21 +171,25 @@ class PlayerLoader extends PlayerDecoratorBase {
         return plugin;
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public PKEvent.Listener addEventListener(@NonNull PKEvent.Listener listener, Enum... events) {
         return messageBus.listen(listener, events);
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public void removeEventListener(@NonNull PKEvent.Listener listener, Enum... events) {
         messageBus.remove(listener, events);
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public PKEvent.Listener addStateChangeListener(@NonNull final PKEvent.Listener listener) {
         return messageBus.listen(listener, PlayerEvent.Type.STATE_CHANGED);
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public void removeStateChangeListener(@NonNull final PKEvent.Listener listener) {
         messageBus.remove(listener, PlayerEvent.Type.STATE_CHANGED);


### PR DESCRIPTION
Add MessageBus.removeListeners()
Add a missing `<E>` in the typed version of MessageBus.addListener()
Change Player.removeListeners() to use Collection instead of List
Minor javadoc fixes.