### PR TITLE
fix(FEM-2366): make sure DURATION CHANGED sent with correct duration

### DIFF
--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
@@ -426,7 +426,6 @@ class ExoPlayerWrapper implements PlayerEngine, Player.EventListener, MetadataOu
         shouldResetPlayerPosition = (reason == Player.TIMELINE_CHANGE_REASON_DYNAMIC);
     }
 
-
     @Override
     public void onPlayerError(ExoPlaybackException error) {
         log.d("onPlayerError error type => " + error.type);

--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
@@ -388,7 +388,6 @@ class ExoPlayerWrapper implements PlayerEngine, Player.EventListener, MetadataOu
                 break;
             default:
                 break;
-
         }
 
     }

--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
@@ -378,7 +378,6 @@ class ExoPlayerWrapper implements PlayerEngine, Player.EventListener, MetadataOu
                 if (playWhenReady) {
                     sendDistinctEvent(PlayerEvent.Type.PLAYING);
                 }
-
                 break;
             case Player.STATE_ENDED:
                 log.d("onPlayerStateChanged. ENDED. playWhenReady => " + playWhenReady);

--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
@@ -412,11 +412,20 @@ class ExoPlayerWrapper implements PlayerEngine, Player.EventListener, MetadataOu
 
     @Override
     public void onTimelineChanged(Timeline timeline, Object manifest, int reason) {
-        log.d("onTimelineChanged");
-        sendDistinctEvent(PlayerEvent.Type.LOADED_METADATA);
-        sendDistinctEvent(PlayerEvent.Type.DURATION_CHANGE);
-        shouldResetPlayerPosition = reason == Player.TIMELINE_CHANGE_REASON_DYNAMIC;
+        log.d("onTimelineChanged reason = " + reason + " duration = " + getDuration());
+        if (reason == Player.TIMELINE_CHANGE_REASON_PREPARED) {
+            sendDistinctEvent(PlayerEvent.Type.LOADED_METADATA);
+            if (getDuration() != TIME_UNSET) {
+                sendDistinctEvent(PlayerEvent.Type.DURATION_CHANGE);
+            }
+        }
+
+        if (reason == Player.TIMELINE_CHANGE_REASON_DYNAMIC && getDuration() != TIME_UNSET) {
+            sendDistinctEvent(PlayerEvent.Type.DURATION_CHANGE);
+        }
+        shouldResetPlayerPosition = (reason == Player.TIMELINE_CHANGE_REASON_DYNAMIC);
     }
+
 
     @Override
     public void onPlayerError(ExoPlaybackException error) {

--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
@@ -389,7 +389,6 @@ class ExoPlayerWrapper implements PlayerEngine, Player.EventListener, MetadataOu
             default:
                 break;
         }
-
     }
 
     private void pausePlayerAfterEndedEvent() {


### PR DESCRIPTION
for mp4 duration changed is sent with negative duration since it is received only on reason DYNAMIC
so this will cause wrong data to be sent and stop will not be called since flag is not reset on DURATION_CHANGED

validation required - all media type including live and wvc