### PR TITLE
FEM-2379 Add player settings API for playing the clear lead in DRM content without keys

### DIFF
--- a/playkit/src/main/java/com/kaltura/playkit/Player.java
+++ b/playkit/src/main/java/com/kaltura/playkit/Player.java
@@ -92,6 +92,14 @@ public interface Player {
         Settings setAllowCrossProtocolRedirect(boolean crossProtocolRedirectEnabled);
 
         /**
+         * Decide if player should play clear lead content
+         *
+         * @param allowClearLead - should enable/disable clear lead playback default false
+         * @return - Player Settings.
+         */
+        Settings allowClearLead(boolean allowClearLead);
+
+        /**
          * Decide if player should use secure rendering on the surface.
          * Known limitation - when useTextureView set to true and isSurfaceSecured set to true -
          * secure rendering will have no effect.

--- a/playkit/src/main/java/com/kaltura/playkit/player/CustomRendererFactory.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/CustomRendererFactory.java
@@ -19,15 +19,17 @@ import java.util.ArrayList;
  */
 
 public class CustomRendererFactory extends DefaultRenderersFactory {
+    private boolean allowClearLead;
 
-    public CustomRendererFactory(Context context, int extensionRendererMode) {
+    public CustomRendererFactory(Context context, int extensionRendererMode, boolean allowClearLead) {
         super(context, extensionRendererMode);
+        this.allowClearLead = allowClearLead;
     }
 
     @Override
     protected void buildVideoRenderers(Context context, @Nullable DrmSessionManager<FrameworkMediaCrypto> drmSessionManager, long allowedVideoJoiningTimeMs, Handler eventHandler, VideoRendererEventListener eventListener, int extensionRendererMode, ArrayList<Renderer> out) {
         out.add(new CustomVideoCodecRenderer(context, MediaCodecSelector.DEFAULT,
-                allowedVideoJoiningTimeMs, drmSessionManager, false, eventHandler, eventListener,
+                allowedVideoJoiningTimeMs, drmSessionManager, allowClearLead, eventHandler, eventListener,
                 MAX_DROPPED_VIDEO_FRAME_COUNT_TO_NOTIFY));
     }
 }

--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
@@ -166,7 +166,7 @@ class ExoPlayerWrapper implements PlayerEngine, Player.EventListener, MetadataOu
 
         final DrmCallback drmCallback = new DrmCallback(httpDataSourceFactory(), playerSettings.getLicenseRequestAdapter());
         drmSessionManager = new DeferredDrmSessionManager(mainHandler, drmCallback, drmSessionListener);
-        CustomRendererFactory renderersFactory = new CustomRendererFactory(context, DefaultRenderersFactory.EXTENSION_RENDERER_MODE_OFF);
+        CustomRendererFactory renderersFactory = new CustomRendererFactory(context, DefaultRenderersFactory.EXTENSION_RENDERER_MODE_OFF, playerSettings.allowClearLead());
 
         player = ExoPlayerFactory.newSimpleInstance(context, renderersFactory, trackSelector, getUpdatedLoadControl(), drmSessionManager, bandwidthMeter);
         window = new Timeline.Window();

--- a/playkit/src/main/java/com/kaltura/playkit/player/PlayerSettings.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/PlayerSettings.java
@@ -24,6 +24,7 @@ public class PlayerSettings implements Player.Settings {
     private boolean cea608CaptionsEnabled;
     private boolean mpgaAudioFormatEnabled;
     private boolean crossProtocolRedirectEnabled;
+    private boolean allowClearLead;
     private boolean adAutoPlayOnResume = true;
     private boolean vrPlayerEnabled = true;
     private LoadControlBuffers loadControlBuffers = new LoadControlBuffers();
@@ -54,6 +55,10 @@ public class PlayerSettings implements Player.Settings {
 
     public boolean crossProtocolRedirectEnabled() {
         return crossProtocolRedirectEnabled;
+    }
+
+    public boolean allowClearLead() {
+        return allowClearLead;
     }
 
     public boolean cea608CaptionsEnabled() {
@@ -166,6 +171,12 @@ public class PlayerSettings implements Player.Settings {
     @Override
     public Player.Settings setAllowCrossProtocolRedirect(boolean crossProtocolRedirectEnabled) {
         this.crossProtocolRedirectEnabled = crossProtocolRedirectEnabled;
+        return this;
+    }
+
+    @Override
+    public Player.Settings allowClearLead(boolean allowClearLead) {
+        this.allowClearLead = allowClearLead;
         return this;
     }
 


### PR DESCRIPTION
        Settings allowClearLead(boolean allowClearLead);

default is false

example:
```
player.getSettings().allowClearLead(true);
```
