### PR TITLE
FEM-2411 - block destroy player on ad playback if live IMA DAI

### DIFF
--- a/playkit/src/main/java/com/kaltura/playkit/ads/AdsDAIPlayerEngineWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/ads/AdsDAIPlayerEngineWrapper.java
@@ -196,9 +196,9 @@ public class AdsDAIPlayerEngineWrapper extends PlayerEngineWrapper implements PK
     @Override
     public void release() {
         if (adsProvider != null && adsProvider.isAdDisplayed() && (adsProvider.getCuePoints() == null || (adsProvider.getCuePoints().getAdCuePoints() != null && adsProvider.getCuePoints().getAdCuePoints().isEmpty()))) {
-           adsProvider.pause();
-           destroyLive = true;
-           return;
+            adsProvider.pause();
+            destroyLive = true;
+            return;
         }
         super.release();
     }

--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
@@ -185,8 +185,10 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.EventListener, Met
         player = ExoPlayerFactory.newSimpleInstance(context, renderersFactory, trackSelector, getUpdatedLoadControl(), drmSessionManager, bandwidthMeter);
         window = new Timeline.Window();
         setPlayerListeners();
-        exoPlayerView.setSurfaceAspectRatioResizeMode(playerSettings.getAspectRatioResizeMode());
-        exoPlayerView.setPlayer(player, useTextureView, isSurfaceSecured);
+        if (exoPlayerView != null) {
+            exoPlayerView.setSurfaceAspectRatioResizeMode(playerSettings.getAspectRatioResizeMode());
+            exoPlayerView.setPlayer(player, useTextureView, isSurfaceSecured);
+        }
 
         player.setPlayWhenReady(false);
     }


### PR DESCRIPTION
add null protections

support pause on live DAI since destroy during ad will loose ad context
