### PR TITLE
FEM-2486 catch MediaDrmStateException --> IllegalStateException

### DIFF
--- a/playkit/src/main/java/com/kaltura/playkit/drm/MediaDrmSession.java
+++ b/playkit/src/main/java/com/kaltura/playkit/drm/MediaDrmSession.java
@@ -79,6 +79,8 @@ class MediaDrmSession {
             return mMediaDrm.provideKeyResponse(mSessionId, keyResponse);
         } catch (NotProvisionedException e) {
             throw new WidevineNotSupportedException(e);
+        } catch (IllegalStateException e) {
+            throw new WidevineNotSupportedException(e);
         }
     }
 }


### PR DESCRIPTION
Handle :

Fatal Exception: android.media.MediaDrm$MediaDrmStateException
Failed to handle key response: General DRM error
android.media.MediaDrm.provideKeyResponse (MediaDrm.java)
com.google.android.exoplayer2.drm.FrameworkMediaDrm.provideKeyResponse (FrameworkMediaDrm.java:160)
com.kaltura.playkit.drm.MediaDrmSession.provideKeyResponse (MediaDrmSession.java:79)
com.kaltura.playkit.drm.WidevineModularAdapter.registerAsset (WidevineModularAdapter.java:121)
com.kaltura.playkit.drm.WidevineModularAdapter.registerAsset (WidevineModularAdapter.java:68)
com.kaltura.playkit.LocalAssetsManager$1.run (LocalAssetsManager.java:156)
java.lang.Thread.run (Thread.java:818)