### PR TITLE
FEM-2580 Playback is stuck after playing preroll only adtag and going to bg/fg during content playback

### DIFF
--- a/playkit/src/main/java/com/kaltura/playkit/ads/AdsDAIPlayerEngineWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/ads/AdsDAIPlayerEngineWrapper.java
@@ -48,7 +48,7 @@ public class AdsDAIPlayerEngineWrapper extends PlayerEngineWrapper implements PK
                 this.mediaSourceConfig = mediaSourceConfig;
             }
             if (adsProvider != null) {
-                if (adsProvider.isAdRequested()) {
+                if (adsProvider.isAdRequested() || adsProvider.isAllAdsCompleted()) {
                     log.d("AdWrapper calling super.prepare");
                     super.load(this.mediaSourceConfig);
                 } else {

--- a/playkit/src/main/java/com/kaltura/playkit/ads/AdsPlayerEngineWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/ads/AdsPlayerEngineWrapper.java
@@ -43,7 +43,7 @@ public class AdsPlayerEngineWrapper extends PlayerEngineWrapper implements PKAdP
     public void load(PKMediaSourceConfig mediaSourceConfig) {
         this.mediaSourceConfig = mediaSourceConfig;
         if (adsProvider != null) {
-            if (adsProvider.isAdRequested()) {
+            if (adsProvider.isAdRequested() || adsProvider.isAllAdsCompleted()) {
                 log.d("AdWrapper calling super.prepare");
                 super.load(mediaSourceConfig);
             } else {


### PR DESCRIPTION
incase all ads completed IMA will be reset so isAdRequested value is set back to false 
after bg/fg the load is not called so playback is not resuming
Now the condition for all ads completed is also reason for load call

