### PR TITLE
FEM - 2513 Mid-Roll ad starts playing on change media

### DIFF
--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
@@ -416,7 +416,7 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.EventListener, Met
     }
 
     private void sendEvent(PlayerEvent.Type event) {
-        if (shouldRestorePlayerToPreviousState) {
+        if (shouldRestorePlayerToPreviousState && event != PlayerEvent.Type.DURATION_CHANGE) {
             log.i("Trying to send event " + event.name() + ". Should be blocked from sending now, because the player is restoring to the previous state.");
             return;
         }


### PR DESCRIPTION
- DURATION_CHANGE event was not being fired because of this Ad logic was not working properly.
- Because this event was not being listened start position was not getting reset on Change Media.