### PR TITLE
FEM-2516 Player Position is reset  for stop api in ExoPlayerWrapper

### DIFF
--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
@@ -959,6 +959,9 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.EventListener, Met
         if (trackSelectionHelper != null) {
             trackSelectionHelper.stop();
         }
+
+        playerPosition = TIME_UNSET;
+
         if (assertPlayerIsNotNull("stop()")) {
             player.setPlayWhenReady(false);
             player.stop(true);

--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
@@ -124,6 +124,7 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.EventListener, Met
     private boolean shouldResetPlayerPosition;
     private boolean preferredLanguageWasSelected;
     private boolean shouldRestorePlayerToPreviousState;
+    private boolean isPlayerReleased;
 
     private int playerWindow;
     private long playerPosition = TIME_UNSET;
@@ -768,6 +769,7 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.EventListener, Met
             trackSelectionHelper.release();
             trackSelectionHelper = null;
         }
+        isPlayerReleased = true;
         shouldRestorePlayerToPreviousState = true;
     }
 
@@ -783,8 +785,14 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.EventListener, Met
         if (playerPosition == TIME_UNSET || isLiveMediaWithoutDvr()) {
             player.seekToDefaultPosition();
         } else {
-            player.seekTo(playerWindow, playerPosition);
+            if (isPlayerReleased) {
+                player.seekTo(playerWindow, playerPosition);
+            } else {
+                playerPosition = TIME_UNSET;
+            }
         }
+
+        isPlayerReleased = false;
     }
 
     private boolean isLiveMediaWithoutDvr() {


### PR DESCRIPTION
player position should be reset incase stop is called so restore will not use previous value which is incorrect

incase restore is called and release was not called before we should not seek to last position since it is not clear what is the value that should be restored and we should reset the value to be in safe state