### PR TITLE
WidevineModularAdapter: Move session.close() to `finally` block

### DIFF
--- a/playkit/src/main/java/com/kaltura/playkit/drm/WidevineModularAdapter.java
+++ b/playkit/src/main/java/com/kaltura/playkit/drm/WidevineModularAdapter.java
@@ -112,6 +112,7 @@ class WidevineModularAdapter extends DrmAdapter {
             try {
                 keyResponse = executeKeyRequest(licenseUri, keyRequest);
                 log.d("registerAsset: response data (b64): " + toBase64(keyResponse));
+
             } catch (Exception e) {
                 throw new RegisterException("Can't send key request for registration", e);
             }
@@ -120,14 +121,18 @@ class WidevineModularAdapter extends DrmAdapter {
             try {
                 byte[] offlineKeyId = session.provideKeyResponse(keyResponse);
                 localDataStore.save(toBase64(initData), offlineKeyId);
+
             } catch (DeniedByServerException e) {
                 throw new RegisterException("Request denied by server", e);
             }
+
         } catch (WidevineNotSupportedException e) {
             throw new RegisterException("Can't execute KeyRequest", e);
+
+        } finally {
+            session.close();
         }
 
-        session.close();
 
         return true;
     }


### PR DESCRIPTION
This should prevent MediaDrm session leak that would happen if registration fails.