### PR TITLE
FEM-2583: Improve cookie handling

### DIFF
--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
@@ -68,6 +68,7 @@ import com.kaltura.playkit.drm.DrmCallback;
 import com.kaltura.playkit.player.metadata.MetadataConverter;
 import com.kaltura.playkit.player.metadata.PKMetadata;
 import com.kaltura.playkit.utils.Consts;
+import com.kaltura.playkit.utils.NativeCookieJarBridge;
 
 import java.net.CookieHandler;
 import java.net.CookieManager;
@@ -88,12 +89,6 @@ import static com.kaltura.playkit.utils.Consts.TRACK_TYPE_TEXT;
 public class ExoPlayerWrapper implements PlayerEngine, Player.EventListener, MetadataOutput, BandwidthMeter.EventListener {
 
     private static final PKLog log = PKLog.get("ExoPlayerWrapper");
-    private static final CookieManager DEFAULT_COOKIE_MANAGER;
-
-    static {
-        DEFAULT_COOKIE_MANAGER = new CookieManager();
-        DEFAULT_COOKIE_MANAGER.setCookiePolicy(CookiePolicy.ACCEPT_ORIGINAL_SERVER);
-    }
 
     private DefaultBandwidthMeter bandwidthMeter;
     @NonNull private PlayerSettings playerSettings;
@@ -166,9 +161,6 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.EventListener, Met
         bandwidthMeter = bandwidthMeterBuilder.build();
         period = new Timeline.Period();
         this.exoPlayerView = exoPlayerView;
-        if (CookieHandler.getDefault() != DEFAULT_COOKIE_MANAGER) {
-            CookieHandler.setDefault(DEFAULT_COOKIE_MANAGER);
-        }
     }
 
     @Override
@@ -351,9 +343,14 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.EventListener, Met
         final String userAgent = getUserAgent(context);
         final boolean crossProtocolRedirectEnabled = playerSettings.crossProtocolRedirectEnabled();
 
+        if (CookieHandler.getDefault() == null) {
+            CookieHandler.setDefault(new CookieManager(null, CookiePolicy.ACCEPT_ORIGINAL_SERVER));
+        }
+
         if (PKHttpClientManager.useOkHttp()) {
 
             final OkHttpClient.Builder builder = PKHttpClientManager.newClientBuilder()
+                    .cookieJar(NativeCookieJarBridge.sharedCookieJar)
                     .followRedirects(true)
                     .followSslRedirects(crossProtocolRedirectEnabled)
                     .connectTimeout(DefaultHttpDataSource.DEFAULT_CONNECT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)
@@ -365,11 +362,13 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.EventListener, Met
             }
 
             httpDataSourceFactory = new OkHttpDataSourceFactory(builder.build(), userAgent);
+
         } else {
 
             httpDataSourceFactory = new DefaultHttpDataSourceFactory(userAgent,
                     DefaultHttpDataSource.DEFAULT_CONNECT_TIMEOUT_MILLIS,
-                    DefaultHttpDataSource.DEFAULT_READ_TIMEOUT_MILLIS, crossProtocolRedirectEnabled);
+                    DefaultHttpDataSource.DEFAULT_READ_TIMEOUT_MILLIS,
+                    crossProtocolRedirectEnabled);
         }
 
         if (headers != null) {

--- a/playkit/src/main/java/com/kaltura/playkit/player/PKHttpClientManager.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/PKHttpClientManager.java
@@ -38,9 +38,6 @@ public class PKHttpClientManager {
 
     private static String httpProviderId;
 
-    static CookieManager sharedCookieManager = new CookieManager();
-
-
     private static final OkHttpClient okClient = new OkHttpClient.Builder()
             .followRedirects(false)     // Only warm up explicitly specified URLs
             .connectionPool(new ConnectionPool(MAX_IDLE_CONNECTIONS, KEEP_ALIVE_DURATION, TimeUnit.MINUTES))

--- a/playkit/src/main/java/com/kaltura/playkit/player/PKHttpClientManager.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/PKHttpClientManager.java
@@ -4,6 +4,7 @@ import com.kaltura.playkit.PKLog;
 import com.kaltura.playkit.PlayKitManager;
 
 import java.io.InputStream;
+import java.net.CookieManager;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.ArrayList;
@@ -37,6 +38,8 @@ public class PKHttpClientManager {
 
     private static String httpProviderId;
 
+    static CookieManager sharedCookieManager = new CookieManager();
+
 
     private static final OkHttpClient okClient = new OkHttpClient.Builder()
             .followRedirects(false)     // Only warm up explicitly specified URLs
@@ -57,7 +60,7 @@ public class PKHttpClientManager {
     }
 
     /**
-     * Set the http provider. Valid options are "system" (use the build-in {@linkplain java.net.HttpURLConnection})
+     * Set the http provider. Valid options are "system" (use the build-in java.net.HttpURLConnection)
      * and "okhttp" (use Square's <a href="https://square.github.io/okhttp/">OkHttp</a> library).
      * @param providerId "system" (default) or "okhttp".
      */

--- a/playkit/src/main/java/com/kaltura/playkit/utils/NativeCookieJarBridge.java
+++ b/playkit/src/main/java/com/kaltura/playkit/utils/NativeCookieJarBridge.java
@@ -1,0 +1,142 @@
+package com.kaltura.playkit.utils;
+
+import android.os.Build;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.text.TextUtils;
+
+import java.net.CookieHandler;
+import java.net.CookieManager;
+import java.net.CookieStore;
+import java.net.HttpCookie;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import okhttp3.Cookie;
+import okhttp3.CookieJar;
+import okhttp3.HttpUrl;
+
+// Bridge between OkHttp's CookieJar and HTTPURLConnection's CookieHandler
+@SuppressWarnings({"ConstantConditions", "NullableProblems"})
+public class NativeCookieJarBridge implements CookieJar {
+
+
+    public static final NativeCookieJarBridge sharedCookieJar = new NativeCookieJarBridge();
+
+    @Nullable
+    private CookieStore explicitCookieStore;
+
+    public NativeCookieJarBridge(@NonNull CookieStore explicitCookieStore) {
+        this.explicitCookieStore = explicitCookieStore;
+    }
+
+    private NativeCookieJarBridge() {}
+
+    private CookieStore cookieStore() {
+
+        if (explicitCookieStore != null) {
+            return explicitCookieStore;
+        }
+
+        final CookieHandler cookieHandler = CookieHandler.getDefault();
+
+        return cookieHandler instanceof CookieManager ?
+                ((CookieManager) cookieHandler).getCookieStore() :
+                null;
+    }
+
+    @Override
+    public void saveFromResponse(HttpUrl url, List<Cookie> cookies) {
+
+        //noinspection ConstantConditions
+        if (url == null || cookies == null || cookies.isEmpty()) {
+            return;
+        }
+
+        final CookieStore cookieStore = cookieStore();
+        if (cookieStore == null) {
+            return;
+        }
+
+        for (Cookie cookie : cookies) {
+
+            final String value = cookie.value();
+            final String name = cookie.name();
+            final String domain = cookie.domain();
+
+            if (TextUtils.isEmpty(name) || TextUtils.isEmpty(value) || TextUtils.isEmpty(domain)) {
+                continue;
+            }
+
+            final HttpCookie hurlCookie = new HttpCookie(name, value);
+            hurlCookie.setDomain(domain);
+
+            final String path = cookie.path();
+            if (path != null && path.startsWith("/")) {
+                hurlCookie.setPath(path);
+            }
+
+            hurlCookie.setSecure(cookie.secure());
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                hurlCookie.setHttpOnly(cookie.httpOnly());
+            }
+
+            cookieStore.add(url.uri(), hurlCookie);
+        }
+    }
+
+    @Override
+    public List<Cookie> loadForRequest(HttpUrl url) {
+
+        if (url == null) {
+            return Collections.emptyList();
+        }
+
+        final CookieStore cookieStore = cookieStore();
+        if (cookieStore == null) {
+            return Collections.emptyList();
+        }
+
+        final List<HttpCookie> httpCookies = cookieStore.get(url.uri());
+        if (httpCookies == null || httpCookies.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        final ArrayList<Cookie> cookies = new ArrayList<>();
+        for (HttpCookie httpCookie : httpCookies) {
+
+            final String name = httpCookie.getName();
+            final String value = httpCookie.getValue();
+            final String domain = httpCookie.getDomain();
+            final String path = httpCookie.getPath();
+
+            if (TextUtils.isEmpty(name) || TextUtils.isEmpty(value) || TextUtils.isEmpty(domain)) {
+                continue;
+            }
+
+            final Cookie.Builder builder = new Cookie.Builder()
+                    .name(name)
+                    .value(value)
+                    .domain(domain);
+
+            if (path != null && path.startsWith("/")) {
+                builder.path(path);
+            }
+
+            if (httpCookie.getSecure()) {
+                builder.secure();
+            }
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                if (httpCookie.isHttpOnly()) {
+                    builder.httpOnly();
+                }
+            }
+
+            cookies.add(builder.build());
+        }
+        return cookies;
+    }
+}


### PR DESCRIPTION
Allow app to set cookies used by the player

The app has to set a CookieManager as CookieHandler.setDefault().
This implementation also includes okhttp support.