### PR TITLE
FEM-2683 - Add player settings to inject custom ABR or Buffer strategy

### DIFF
--- a/playkit/src/main/java/com/kaltura/playkit/Player.java
+++ b/playkit/src/main/java/com/kaltura/playkit/Player.java
@@ -15,6 +15,8 @@ package com.kaltura.playkit;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.kaltura.android.exoplayer2.LoadControl;
+import com.kaltura.android.exoplayer2.upstream.BandwidthMeter;
 import com.kaltura.playkit.player.ABRSettings;
 import com.kaltura.playkit.player.LoadControlBuffers;
 import com.kaltura.playkit.player.PKAspectRatioResizeMode;
@@ -211,6 +213,18 @@ public interface Player {
          * @param vrSettings vr configuration
          */
         Settings setVRSettings(VRSettings vrSettings);
+
+        /**
+         * Set custom BandwidthMeter instance
+         * @param bandwidthMeter custom pre-built BandwidthMeter
+         */
+        Settings setCustomBandwidthMeter(BandwidthMeter bandwidthMeter);
+
+        /**
+         * Set custom LoadControl instance
+         * @param loadControl custom pre-built LoadControl
+         */
+        Settings setCustomLoadControl(LoadControl loadControl);
     }
 
     /**

--- a/playkit/src/main/java/com/kaltura/playkit/Player.java
+++ b/playkit/src/main/java/com/kaltura/playkit/Player.java
@@ -15,8 +15,6 @@ package com.kaltura.playkit;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import com.kaltura.android.exoplayer2.LoadControl;
-import com.kaltura.android.exoplayer2.upstream.BandwidthMeter;
 import com.kaltura.playkit.player.ABRSettings;
 import com.kaltura.playkit.player.LoadControlBuffers;
 import com.kaltura.playkit.player.PKAspectRatioResizeMode;
@@ -215,16 +213,10 @@ public interface Player {
         Settings setVRSettings(VRSettings vrSettings);
 
         /**
-         * Set custom BandwidthMeter instance
-         * @param bandwidthMeter custom pre-built BandwidthMeter
+         * Set custom load control strategy
+         * @param loadControlStrategy object implementing LoadControlStrategy interface
          */
-        Settings setCustomBandwidthMeter(BandwidthMeter bandwidthMeter);
-
-        /**
-         * Set custom LoadControl instance
-         * @param loadControl custom pre-built LoadControl
-         */
-        Settings setCustomLoadControl(LoadControl loadControl);
+        Settings setCustomLoadControlStrategy(Object loadControlStrategy);
     }
 
     /**

--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
@@ -156,7 +156,7 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.EventListener, Met
         playerSettings = settings != null ? settings : new PlayerSettings();
         rootView = rootPlayerView;
 
-        LoadControlStrategy customLoadControlStrategy = (LoadControlStrategy) playerSettings.getCustomLoadControlStrategy();
+        LoadControlStrategy customLoadControlStrategy = getCustomLoadControlStrategy();
         if (customLoadControlStrategy != null && customLoadControlStrategy.getCustomBandwidthMeter() != null) {
             bandwidthMeter = customLoadControlStrategy.getCustomBandwidthMeter();
         } else {
@@ -174,6 +174,15 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.EventListener, Met
 
         period = new Timeline.Period();
         this.exoPlayerView = exoPlayerView;
+    }
+
+    private LoadControlStrategy getCustomLoadControlStrategy() {
+        Object loadControlStrategyObj = playerSettings.getCustomLoadControlStrategy();
+        if (loadControlStrategyObj != null && loadControlStrategyObj instanceof LoadControlStrategy) {
+            return ((LoadControlStrategy) loadControlStrategyObj);
+        } else {
+            return null;
+        }
     }
 
     @Override
@@ -201,7 +210,7 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.EventListener, Met
 
     @NonNull
     private LoadControl getUpdatedLoadControl() {
-        LoadControlStrategy customLoadControlStrategy = (LoadControlStrategy) playerSettings.getCustomLoadControlStrategy();
+        LoadControlStrategy customLoadControlStrategy = getCustomLoadControlStrategy();
         if (customLoadControlStrategy != null && customLoadControlStrategy.getCustomLoadControl() != null) {
             return customLoadControlStrategy.getCustomLoadControl();
         } else {

--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
@@ -170,7 +170,9 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.EventListener, Met
 
             bandwidthMeter = bandwidthMeterBuilder.build();
         }
-        bandwidthMeter.addEventListener(mainHandler, this);
+        if (bandwidthMeter != null) {
+            bandwidthMeter.addEventListener(mainHandler, this);
+        }
 
         period = new Timeline.Period();
         this.exoPlayerView = exoPlayerView;

--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
@@ -88,6 +88,10 @@ import static com.kaltura.playkit.utils.Consts.TRACK_TYPE_TEXT;
 
 
 public class ExoPlayerWrapper implements PlayerEngine, Player.EventListener, MetadataOutput, BandwidthMeter.EventListener {
+    public interface LoadControlStrategy {
+        LoadControl getCustomLoadControl();
+        BandwidthMeter getCustomBandwidthMeter();
+    }
 
     private static final PKLog log = PKLog.get("ExoPlayerWrapper");
 
@@ -151,8 +155,10 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.EventListener, Met
 
         playerSettings = settings != null ? settings : new PlayerSettings();
         rootView = rootPlayerView;
-        if (playerSettings.getCustomBandwidthMeter() != null) {
-            bandwidthMeter = playerSettings.getCustomBandwidthMeter();
+
+        LoadControlStrategy customLoadControlStrategy = (LoadControlStrategy) playerSettings.getCustomLoadControlStrategy();
+        if (customLoadControlStrategy != null && customLoadControlStrategy.getCustomBandwidthMeter() != null) {
+            bandwidthMeter = customLoadControlStrategy.getCustomBandwidthMeter();
         } else {
             DefaultBandwidthMeter.Builder bandwidthMeterBuilder = new DefaultBandwidthMeter.Builder(context);
 
@@ -195,8 +201,9 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.EventListener, Met
 
     @NonNull
     private LoadControl getUpdatedLoadControl() {
-        if (playerSettings.getCustomLoadControl() != null) {
-            return playerSettings.getCustomLoadControl();
+        LoadControlStrategy customLoadControlStrategy = (LoadControlStrategy) playerSettings.getCustomLoadControlStrategy();
+        if (customLoadControlStrategy != null && customLoadControlStrategy.getCustomLoadControl() != null) {
+            return customLoadControlStrategy.getCustomLoadControl();
         } else {
             final LoadControlBuffers loadControl = playerSettings.getLoadControlBuffers();
             int backBufferDurationMs = loadControl.getBackBufferDurationMs();

--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
@@ -169,8 +169,8 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.EventListener, Met
             }
 
             bandwidthMeter = bandwidthMeterBuilder.build();
-            bandwidthMeter.addEventListener(mainHandler, this);
         }
+        bandwidthMeter.addEventListener(mainHandler, this);
 
         period = new Timeline.Period();
         this.exoPlayerView = exoPlayerView;

--- a/playkit/src/main/java/com/kaltura/playkit/player/PlayerSettings.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/PlayerSettings.java
@@ -12,8 +12,6 @@
 
 package com.kaltura.playkit.player;
 
-import com.kaltura.android.exoplayer2.LoadControl;
-import com.kaltura.android.exoplayer2.upstream.BandwidthMeter;
 import com.kaltura.playkit.PKMediaFormat;
 import com.kaltura.playkit.PKRequestParams;
 import com.kaltura.playkit.PKTrackConfig;
@@ -54,8 +52,7 @@ public class PlayerSettings implements Player.Settings {
     /**
      * Streamroot-added settings
      */
-    private BandwidthMeter customBandwidthMeter = null;
-    private LoadControl customLoadControl = null;
+    private Object customLoadControlStrategy = null;
 
     public PKRequestParams.Adapter getContentRequestAdapter() {
         return contentRequestAdapter;
@@ -141,12 +138,8 @@ public class PlayerSettings implements Player.Settings {
         return forceSinglePlayerEngine;
     }
 
-    public BandwidthMeter getCustomBandwidthMeter() {
-        return customBandwidthMeter;
-    }
-
-    public LoadControl getCustomLoadControl() {
-        return customLoadControl;
+    public Object getCustomLoadControlStrategy() {
+        return customLoadControlStrategy;
     }
 
     @Override
@@ -277,14 +270,8 @@ public class PlayerSettings implements Player.Settings {
     }
 
     @Override
-    public Player.Settings setCustomBandwidthMeter(BandwidthMeter bandwidthMeter) {
-        this.customBandwidthMeter = bandwidthMeter;
-        return this;
-    }
-
-    @Override
-    public Player.Settings setCustomLoadControl(LoadControl loadControl) {
-        this.customLoadControl = loadControl;
+    public Player.Settings setCustomLoadControlStrategy(Object customLoadControlStrategy) {
+        this.customLoadControlStrategy = customLoadControlStrategy;
         return this;
     }
 }

--- a/playkit/src/main/java/com/kaltura/playkit/player/PlayerSettings.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/PlayerSettings.java
@@ -49,9 +49,6 @@ public class PlayerSettings implements Player.Settings {
     private PKRequestParams.Adapter contentRequestAdapter;
     private PKRequestParams.Adapter licenseRequestAdapter;
 
-    /**
-     * Streamroot-added settings
-     */
     private Object customLoadControlStrategy = null;
 
     public PKRequestParams.Adapter getContentRequestAdapter() {

--- a/playkit/src/main/java/com/kaltura/playkit/player/PlayerSettings.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/PlayerSettings.java
@@ -12,6 +12,8 @@
 
 package com.kaltura.playkit.player;
 
+import com.kaltura.android.exoplayer2.LoadControl;
+import com.kaltura.android.exoplayer2.upstream.BandwidthMeter;
 import com.kaltura.playkit.PKMediaFormat;
 import com.kaltura.playkit.PKRequestParams;
 import com.kaltura.playkit.PKTrackConfig;
@@ -48,6 +50,12 @@ public class PlayerSettings implements Player.Settings {
 
     private PKRequestParams.Adapter contentRequestAdapter;
     private PKRequestParams.Adapter licenseRequestAdapter;
+
+    /**
+     * Streamroot-added settings
+     */
+    private BandwidthMeter customBandwidthMeter = null;
+    private LoadControl customLoadControl = null;
 
     public PKRequestParams.Adapter getContentRequestAdapter() {
         return contentRequestAdapter;
@@ -131,6 +139,14 @@ public class PlayerSettings implements Player.Settings {
 
     public boolean isForceSinglePlayerEngine() {
         return forceSinglePlayerEngine;
+    }
+
+    public BandwidthMeter getCustomBandwidthMeter() {
+        return customBandwidthMeter;
+    }
+
+    public LoadControl getCustomLoadControl() {
+        return customLoadControl;
     }
 
     @Override
@@ -257,6 +273,18 @@ public class PlayerSettings implements Player.Settings {
     @Override
     public Player.Settings setVRSettings(VRSettings vrSettings) {
         this.vrSettings = vrSettings;
+        return this;
+    }
+
+    @Override
+    public Player.Settings setCustomBandwidthMeter(BandwidthMeter bandwidthMeter) {
+        this.customBandwidthMeter = bandwidthMeter;
+        return this;
+    }
+
+    @Override
+    public Player.Settings setCustomLoadControl(LoadControl loadControl) {
+        this.customLoadControl = loadControl;
         return this;
     }
 }


### PR DESCRIPTION
Example usage for Streamroot's use case:

```
PlayKitCustomBandwidthMeter bandwidthListener = new PlayKitCustomBandwidthMeter();
LoadControl loadControl = new DefaultLoadControl.Builder().createDefaultLoadControl();
PlayerInteractor playerInteractor = new PlayKitInteractor(player, loadControl);

player.getSettings().setCustomLoadControl(loadControl);
player.getSettings().setCustomBandwidthMeter(bandwidthListener);
```