### PR TITLE
FEM-2696 use the correct array for index calculation

### DIFF
--- a/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
@@ -222,7 +222,7 @@ class TrackSelectionHelper {
         ArrayList<AudioTrack> filteredAudioTracks = filterAdaptiveAudioTracks();
 
         int defaultVideoTrackIndex = getDefaultTrackIndex(videoTracks, lastSelectedTrackIds[TRACK_TYPE_VIDEO]);
-        int defaultAudioTrackIndex = getDefaultTrackIndex(audioTracks, lastSelectedTrackIds[TRACK_TYPE_AUDIO]);
+        int defaultAudioTrackIndex = getDefaultTrackIndex(filteredAudioTracks, lastSelectedTrackIds[TRACK_TYPE_AUDIO]);
         int defaultTextTrackIndex = getDefaultTrackIndex(textTracks, lastSelectedTrackIds[TRACK_TYPE_TEXT]);
 
         return new PKTracks(videoTracks, filteredAudioTracks, textTracks, defaultVideoTrackIndex, defaultAudioTrackIndex, defaultTextTrackIndex);


### PR DESCRIPTION
this can cause array out of bound exception since the 2 arrays length is different
