### PR TITLE
FEM-2764 fix the default selection index incase of audio and video tracks

### DIFF
--- a/playkit/src/main/java/com/kaltura/playkit/player/AudioTrack.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/AudioTrack.java
@@ -74,4 +74,9 @@ public class AudioTrack extends BaseTrack {
     public int getChannelCount() {
         return channelCount;
     }
+
+    @Override
+    String getTrackLanguage() {
+        return language;
+    }
 }

--- a/playkit/src/main/java/com/kaltura/playkit/player/AudioTrack.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/AudioTrack.java
@@ -39,6 +39,7 @@ public class AudioTrack extends BaseTrack {
      *
      * @return - the language of the track.
      */
+    @Override
     public @Nullable
     String getLanguage() {
         return language;
@@ -73,10 +74,5 @@ public class AudioTrack extends BaseTrack {
      */
     public int getChannelCount() {
         return channelCount;
-    }
-
-    @Override
-    String getTrackLanguage() {
-        return language;
     }
 }

--- a/playkit/src/main/java/com/kaltura/playkit/player/BaseTrack.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/BaseTrack.java
@@ -59,4 +59,8 @@ public abstract class BaseTrack {
     int getSelectionFlag() {
         return selectionFlag;
     }
+
+    String getTrackLanguage() {
+        return null;
+    }
 }

--- a/playkit/src/main/java/com/kaltura/playkit/player/BaseTrack.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/BaseTrack.java
@@ -60,7 +60,7 @@ public abstract class BaseTrack {
         return selectionFlag;
     }
 
-    String getTrackLanguage() {
+    String getLanguage() {
         return null;
     }
 }

--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
@@ -632,7 +632,7 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.EventListener, Met
         }
         //if the track info new -> map the available tracks. and when ready, notify user about available tracks.
         if (shouldGetTracksInfo) {
-            shouldGetTracksInfo = !trackSelectionHelper.prepareTracks();
+            shouldGetTracksInfo = !trackSelectionHelper.prepareTracks(trackSelections);
         }
 
         trackSelectionHelper.notifyAboutTrackChange(trackSelections);

--- a/playkit/src/main/java/com/kaltura/playkit/player/TextTrack.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/TextTrack.java
@@ -36,6 +36,7 @@ public class TextTrack extends BaseTrack {
      *
      * @return - the language of the track.
      */
+    @Override
     public @Nullable
     String getLanguage() {
         return language;
@@ -52,8 +53,4 @@ public class TextTrack extends BaseTrack {
         return label;
     }
 
-    @Override
-    String getTrackLanguage() {
-        return language;
-    }
 }

--- a/playkit/src/main/java/com/kaltura/playkit/player/TextTrack.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/TextTrack.java
@@ -52,4 +52,8 @@ public class TextTrack extends BaseTrack {
         return label;
     }
 
+    @Override
+    String getTrackLanguage() {
+        return language;
+    }
 }

--- a/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
@@ -340,7 +340,7 @@ class TrackSelectionHelper {
                         }
                     }
                 }
-            } else if (trackList.get(0) instanceof AudioTrack) {
+            } else if (trackList.get(0) instanceof TextTrack) {
                 if (trackSelectionArray != null && trackSelectionArray.length >= TRACK_TYPE_TEXT) {
                     TrackSelection trackSelection = trackSelectionArray.get(TRACK_TYPE_TEXT);
                     if (trackSelection != null) {

--- a/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
@@ -339,8 +339,8 @@ class TrackSelectionHelper {
 
             if (trackType != TRACK_TYPE_UNKNOWN && trackSelectionArray != null && trackSelectionArray.length >= trackType) {
                 TrackSelection trackSelection = trackSelectionArray.get(trackType);
-                if (trackSelection != null) {
-                    defaultTrackIndex = findDefaultTrackIndex(trackSelection, trackList, defaultTrackIndex);
+                if (trackSelection != null && trackSelection.getSelectedFormat() != null) {
+                    defaultTrackIndex = findDefaultTrackIndex(trackSelection.getSelectedFormat().language, trackList, defaultTrackIndex);
                 }
             }
         }
@@ -348,24 +348,19 @@ class TrackSelectionHelper {
         return defaultTrackIndex;
     }
 
-    private int findDefaultTrackIndex(TrackSelection trackSelection, List<? extends BaseTrack> trackList, int defaultTrackIndex) {
-        if (trackList == null || trackSelection == null) {
-            return defaultTrackIndex;
-        }
+    private int findDefaultTrackIndex(String selectedFormatLanguage, List<? extends BaseTrack> trackList, int defaultTrackIndex) {
+        if (trackList != null && selectedFormatLanguage != null) {
 
-        for (int i = 0; i < trackList.size(); i++) {
-            Format selectedFormat = trackSelection.getSelectedFormat();
-            if (selectedFormat != null) {
-                if (selectedFormat.language != null && trackList.get(i) != null && selectedFormat.language.equals(trackList.get(i).getLanguage())) {
-                    defaultTrackIndex = i;
-                    break;
-                }
+            for (int i = 0; i < trackList.size(); i++) {
+                    if (trackList.get(i) != null && selectedFormatLanguage.equals(trackList.get(i).getLanguage())) {
+                        defaultTrackIndex = i;
+                        break;
+                    }
             }
         }
 
         return defaultTrackIndex;
-}
-
+    }
 
     /**
      * Will restore last selected track, only if there was actual selection and it is

--- a/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
@@ -337,7 +337,7 @@ class TrackSelectionHelper {
                 trackType = TRACK_TYPE_TEXT;
             }
 
-            if (trackType != TRACK_TYPE_UNKNOWN && trackSelectionArray != null && trackSelectionArray.length >= trackType) {
+            if (trackType != TRACK_TYPE_UNKNOWN && trackSelectionArray != null && trackType < trackSelectionArray.length) {
                 TrackSelection trackSelection = trackSelectionArray.get(trackType);
                 if (trackSelection != null && trackSelection.getSelectedFormat() != null) {
                     defaultTrackIndex = findDefaultTrackIndex(trackSelection.getSelectedFormat().language, trackList, defaultTrackIndex);

--- a/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
@@ -323,46 +323,39 @@ class TrackSelectionHelper {
             }
         }
 
-        if (!trackList.isEmpty()) {
-            defaultTrackIndex = getUpdatedDefaultTrackIndex(trackList, defaultTrackIndex);
-        }
-
-        return restoreLastSelectedTrack(trackList, lastSelectedTrackId, defaultTrackIndex);
+        return restoreLastSelectedTrack(trackList, lastSelectedTrackId, getUpdatedDefaultTrackIndex(trackList, defaultTrackIndex));
     }
 
     private int getUpdatedDefaultTrackIndex(List<? extends BaseTrack> trackList, int defaultTrackIndex) {
-        if (trackList.get(0) instanceof AudioTrack) {
-            defaultTrackIndex = findDefaultTrackIndex(TRACK_TYPE_AUDIO, trackList, defaultTrackIndex);
-        } else if (trackList.get(0) instanceof TextTrack) {
-            defaultTrackIndex = findDefaultTrackIndex(TRACK_TYPE_TEXT, trackList, defaultTrackIndex);
+
+        if (!trackList.isEmpty()) {
+            if (trackList.get(0) instanceof AudioTrack) {
+                defaultTrackIndex = findDefaultTrackIndex(TRACK_TYPE_AUDIO, trackList, defaultTrackIndex);
+            } else if (trackList.get(0) instanceof TextTrack) {
+                defaultTrackIndex = findDefaultTrackIndex(TRACK_TYPE_TEXT, trackList, defaultTrackIndex);
+            }
         }
+
         return defaultTrackIndex;
     }
 
     private int findDefaultTrackIndex(int trackType, List<? extends BaseTrack> trackList, int defaultTrackIndex) {
+
         for (int i = 0; i < trackList.size(); i++) {
             if (trackSelectionArray != null && trackSelectionArray.length >= trackType) {
                 TrackSelection trackSelection = trackSelectionArray.get(trackType);
                 if (trackSelection != null) {
                     Format selectedFormat = trackSelection.getSelectedFormat();
                     if (selectedFormat != null) {
-                        if (trackType == TRACK_TYPE_AUDIO) {
-                            AudioTrack audioTrack = (AudioTrack) trackList.get(i);
-                            if (selectedFormat.language != null && audioTrack != null && selectedFormat.language.equals(audioTrack.getLanguage())) {
-                                defaultTrackIndex = i;
-                                break;
-                            }
-                        } else if (trackType == TRACK_TYPE_TEXT) {
-                            TextTrack textTrack = (TextTrack) trackList.get(i);
-                            if (selectedFormat.language != null && textTrack != null && selectedFormat.language.equals(textTrack.getLanguage())) {
-                                defaultTrackIndex = i;
-                                break;
-                            }
+                        if (selectedFormat.language != null && trackList.get(i) != null && selectedFormat.language.equals(trackList.get(i).getTrackLanguage())) {
+                            defaultTrackIndex = i;
+                            break;
                         }
                     }
                 }
             }
         }
+
         return defaultTrackIndex;
     }
 

--- a/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
@@ -42,6 +42,7 @@ import java.util.MissingResourceException;
 
 import static com.kaltura.playkit.utils.Consts.TRACK_TYPE_AUDIO;
 import static com.kaltura.playkit.utils.Consts.TRACK_TYPE_TEXT;
+import static com.kaltura.playkit.utils.Consts.TRACK_TYPE_UNKNOWN;
 import static com.kaltura.playkit.utils.Consts.TRACK_TYPE_VIDEO;
 
 /**
@@ -329,38 +330,41 @@ class TrackSelectionHelper {
     private int getUpdatedDefaultTrackIndex(List<? extends BaseTrack> trackList, int defaultTrackIndex) {
 
         if (!trackList.isEmpty()) {
+            int trackType = TRACK_TYPE_UNKNOWN;
             if (trackList.get(0) instanceof AudioTrack) {
-                defaultTrackIndex = findDefaultTrackIndex(TRACK_TYPE_AUDIO, trackList, defaultTrackIndex);
+                trackType = TRACK_TYPE_AUDIO;
             } else if (trackList.get(0) instanceof TextTrack) {
-                defaultTrackIndex = findDefaultTrackIndex(TRACK_TYPE_TEXT, trackList, defaultTrackIndex);
+                trackType = TRACK_TYPE_TEXT;
             }
-        }
 
-        return defaultTrackIndex;
-    }
-
-    private int findDefaultTrackIndex(int trackType, List<? extends BaseTrack> trackList, int defaultTrackIndex) {
-        if (trackList == null) {
-            return  defaultTrackIndex;
-        }
-
-        for (int i = 0; i < trackList.size(); i++) {
-            if (trackSelectionArray != null && trackSelectionArray.length >= trackType) {
+            if (trackType != TRACK_TYPE_UNKNOWN && trackSelectionArray != null && trackSelectionArray.length >= trackType) {
                 TrackSelection trackSelection = trackSelectionArray.get(trackType);
                 if (trackSelection != null) {
-                    Format selectedFormat = trackSelection.getSelectedFormat();
-                    if (selectedFormat != null) {
-                        if (selectedFormat.language != null && trackList.get(i) != null && selectedFormat.language.equals(trackList.get(i).getTrackLanguage())) {
-                            defaultTrackIndex = i;
-                            break;
-                        }
-                    }
+                    defaultTrackIndex = findDefaultTrackIndex(trackSelection, trackList, defaultTrackIndex);
                 }
             }
         }
 
         return defaultTrackIndex;
     }
+
+    private int findDefaultTrackIndex(TrackSelection trackSelection, List<? extends BaseTrack> trackList, int defaultTrackIndex) {
+        if (trackList == null || trackSelection == null) {
+            return defaultTrackIndex;
+        }
+
+        for (int i = 0; i < trackList.size(); i++) {
+            Format selectedFormat = trackSelection.getSelectedFormat();
+            if (selectedFormat != null) {
+                if (selectedFormat.language != null && trackList.get(i) != null && selectedFormat.language.equals(trackList.get(i).getLanguage())) {
+                    defaultTrackIndex = i;
+                    break;
+                }
+            }
+        }
+
+        return defaultTrackIndex;
+}
 
 
     /**

--- a/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
@@ -324,43 +324,48 @@ class TrackSelectionHelper {
         }
 
         if (!trackList.isEmpty()) {
-            if (trackList.get(0) instanceof AudioTrack) {
-                for (int i = 0; i < trackList.size(); i++) {
-                    AudioTrack audioTrack = (AudioTrack) trackList.get(i);
-                    if (trackSelectionArray != null && trackSelectionArray.length >= TRACK_TYPE_AUDIO) {
-                        TrackSelection trackSelection = trackSelectionArray.get(TRACK_TYPE_AUDIO);
-                        if (trackSelection != null) {
-                            Format selectedFormat = trackSelection.getSelectedFormat();
-                            if (selectedFormat != null) {
-                                if (selectedFormat.language != null && selectedFormat.language.equals(audioTrack.getLanguage())) {
-                                    defaultTrackIndex = i;
-                                    break;
-                                }
+            defaultTrackIndex = getUpdatedDefaultTrackIndex(trackList, defaultTrackIndex);
+        }
+
+        return restoreLastSelectedTrack(trackList, lastSelectedTrackId, defaultTrackIndex);
+    }
+
+    private int getUpdatedDefaultTrackIndex(List<? extends BaseTrack> trackList, int defaultTrackIndex) {
+        if (trackList.get(0) instanceof AudioTrack) {
+            defaultTrackIndex = findDefaultTrackIndex(TRACK_TYPE_AUDIO, trackList, defaultTrackIndex);
+        } else if (trackList.get(0) instanceof TextTrack) {
+            defaultTrackIndex = findDefaultTrackIndex(TRACK_TYPE_TEXT, trackList, defaultTrackIndex);
+        }
+        return defaultTrackIndex;
+    }
+
+    private int findDefaultTrackIndex(int trackType, List<? extends BaseTrack> trackList, int defaultTrackIndex) {
+        for (int i = 0; i < trackList.size(); i++) {
+            if (trackSelectionArray != null && trackSelectionArray.length >= trackType) {
+                TrackSelection trackSelection = trackSelectionArray.get(trackType);
+                if (trackSelection != null) {
+                    Format selectedFormat = trackSelection.getSelectedFormat();
+                    if (selectedFormat != null) {
+                        if (trackType == TRACK_TYPE_AUDIO) {
+                            AudioTrack audioTrack = (AudioTrack) trackList.get(i);
+                            if (selectedFormat.language != null && audioTrack != null && selectedFormat.language.equals(audioTrack.getLanguage())) {
+                                defaultTrackIndex = i;
+                                break;
                             }
-                        }
-                    }
-                }
-            } else if (trackList.get(0) instanceof TextTrack) {
-                if (trackSelectionArray != null && trackSelectionArray.length >= TRACK_TYPE_TEXT) {
-                    TrackSelection trackSelection = trackSelectionArray.get(TRACK_TYPE_TEXT);
-                    if (trackSelection != null) {
-                        Format selectedFormat = trackSelection.getSelectedFormat();
-                        if (selectedFormat != null) {
-                            for (int i = 0; i < trackList.size(); i++) {
-                                TextTrack textTrack = (TextTrack) trackList.get(i);
-                                if (selectedFormat.language != null && selectedFormat.language.equals(textTrack.getLanguage())) {
-                                    defaultTrackIndex = i;
-                                    break;
-                                }
+                        } else if (trackType == TRACK_TYPE_TEXT) {
+                            TextTrack textTrack = (TextTrack) trackList.get(i);
+                            if (selectedFormat.language != null && textTrack != null && selectedFormat.language.equals(textTrack.getLanguage())) {
+                                defaultTrackIndex = i;
+                                break;
                             }
                         }
                     }
                 }
             }
         }
-
-        return restoreLastSelectedTrack(trackList, lastSelectedTrackId, defaultTrackIndex);
+        return defaultTrackIndex;
     }
+
 
     /**
      * Will restore last selected track, only if there was actual selection and it is

--- a/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
@@ -340,6 +340,9 @@ class TrackSelectionHelper {
     }
 
     private int findDefaultTrackIndex(int trackType, List<? extends BaseTrack> trackList, int defaultTrackIndex) {
+        if (trackList == null) {
+            return  defaultTrackIndex;
+        }
 
         for (int i = 0; i < trackList.size(); i++) {
             if (trackSelectionArray != null && trackSelectionArray.length >= trackType) {

--- a/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
@@ -131,10 +131,12 @@ class TrackSelectionHelper {
      * Prepare {@link PKTracks} object for application.
      * When the object is created, notify {@link ExoPlayerWrapper} about that,
      * and pass the {@link PKTracks} as parameter.
+     * @param trackSelections the selected tracks.
      *
      * @return - true if tracks data created successful, if mappingTrackInfo not ready return false.
      */
-    protected boolean prepareTracks() {
+    protected boolean prepareTracks(TrackSelectionArray trackSelections) {
+        trackSelectionArray = trackSelections;
         mappedTrackInfo = selector.getCurrentMappedTrackInfo();
         if (mappedTrackInfo == null) {
             log.w("Trying to get current MappedTrackInfo returns null");
@@ -317,6 +319,42 @@ class TrackSelectionHelper {
                 int selectionFlag = trackList.get(i).getSelectionFlag();
                 if (selectionFlag == Consts.DEFAULT_TRACK_SELECTION_FLAG_HLS || selectionFlag == Consts.DEFAULT_TRACK_SELECTION_FLAG_DASH) {
                     defaultTrackIndex = i;
+                }
+            }
+        }
+
+        if (!trackList.isEmpty()) {
+            if (trackList.get(0) instanceof AudioTrack) {
+                for (int i = 0; i < trackList.size(); i++) {
+                    AudioTrack audioTrack = (AudioTrack) trackList.get(i);
+                    if (trackSelectionArray != null && trackSelectionArray.length >= TRACK_TYPE_AUDIO) {
+                        TrackSelection trackSelection = trackSelectionArray.get(TRACK_TYPE_AUDIO);
+                        if (trackSelection != null) {
+                            Format selectedFormat = trackSelection.getSelectedFormat();
+                            if (selectedFormat != null) {
+                                if (selectedFormat.language != null && selectedFormat.language.equals(audioTrack.getLanguage())) {
+                                    defaultTrackIndex = i;
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
+            } else if (trackList.get(0) instanceof AudioTrack) {
+                if (trackSelectionArray != null && trackSelectionArray.length >= TRACK_TYPE_TEXT) {
+                    TrackSelection trackSelection = trackSelectionArray.get(TRACK_TYPE_TEXT);
+                    if (trackSelection != null) {
+                        Format selectedFormat = trackSelection.getSelectedFormat();
+                        if (selectedFormat != null) {
+                            for (int i = 0; i < trackList.size(); i++) {
+                                TextTrack textTrack = (TextTrack) trackList.get(i);
+                                if (selectedFormat.language != null && selectedFormat.language.equals(textTrack.getLanguage())) {
+                                    defaultTrackIndex = i;
+                                    break;
+                                }
+                            }
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
### Description of the Changes
Sine Exo 2.10.x the tracks are also selected by the locale
till then if no selection flag is available the default selection is index 0
now we have to calculate it according to the list exposed by exo player
