### PR TITLE
FEM-2808 add flag that tells if kalturaPlayer is in use in app or not 

### DIFF
--- a/playkit/src/main/java/com/kaltura/playkit/PKDeviceCapabilities.java
+++ b/playkit/src/main/java/com/kaltura/playkit/PKDeviceCapabilities.java
@@ -162,7 +162,7 @@ public class PKDeviceCapabilities {
         try {
             Class.forName( "com.kaltura.tvplayer.KalturaPlayer" );
             return true;
-        } catch( ClassNotFoundException e ) {
+        } catch (Exception e) {
             return false;
         }
     }

--- a/playkit/src/main/java/com/kaltura/playkit/PKDeviceCapabilities.java
+++ b/playkit/src/main/java/com/kaltura/playkit/PKDeviceCapabilities.java
@@ -144,6 +144,7 @@ public class PKDeviceCapabilities {
             JSONObject root = this.root;
             root.put("reportType", "DeviceCapabilities");
             root.put("playkitVersion", PlayKitManager.VERSION_STRING);
+            root.put("kalturaPlayer", isKalturaPlayerAvailable());
             root.put("host", hostInfo());
             root.put("system", systemInfo());
             root.put("drm", drmInfo());
@@ -155,6 +156,15 @@ public class PKDeviceCapabilities {
         }
 
         return root;
+    }
+
+    private boolean isKalturaPlayerAvailable() {
+        try {
+            Class.forName( "com.kaltura.tvplayer.KalturaPlayer" );
+            return true;
+        } catch( ClassNotFoundException e ) {
+            return false;
+        }
     }
 
     private JSONObject hostInfo() throws JSONException {


### PR DESCRIPTION
used in device capabilities report

  "kalturaPlayer": false,

{
  "reportType": "DeviceCapabilities",
  "playkitVersion": "dev.cb322c97",
  **"kalturaPlayer": false,**
  "host": {
    "packageName": "com.kaltura.playkitdemo",
    "versionCode": 1,
    "versionName": "1.0",
    "firstInstallTime": 1580681317647,
    "lastUpdateTime": 1580681317647,
    "playkitVersion": "dev.cb322c97"
  },

Solves FEM-2808

