### PR TITLE
FEC-9956 - autoplay does not work in case of IMA Plugin ad failure 

### DIFF
--- a/playkit/src/main/java/com/kaltura/playkit/PKMediaSource.java
+++ b/playkit/src/main/java/com/kaltura/playkit/PKMediaSource.java
@@ -73,7 +73,6 @@ public class PKMediaSource implements Parcelable {
         return this;
     }
 
-
     public boolean hasDrmParams() {
         return (drmData != null && drmData.size() > 0);
     }
@@ -109,23 +108,19 @@ public class PKMediaSource implements Parcelable {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o)
-            return true;
-        if (o == null || getClass() != o.getClass())
-            return false;
+        if (this == o) return true;
+        if (!(o instanceof PKMediaSource)) return false;
 
         PKMediaSource that = (PKMediaSource) o;
 
-        if (!id.equals(that.id))
-            return false;
-        return url.equals(that.url);
-
+        if (getId() != null ? !getId().equals(that.getId()) : that.getId() != null) return false;
+        return getUrl() != null ? getUrl().equals(that.getUrl()) : that.getUrl() == null;
     }
 
     @Override
     public int hashCode() {
-        int result = id.hashCode();
-        result = 31 * result + url.hashCode();
+        int result = getId() != null ? getId().hashCode() : 0;
+        result = 31 * result + (getUrl() != null ? getUrl().hashCode() : 0);
         return result;
     }
 }

--- a/playkit/src/main/java/com/kaltura/playkit/ads/AdsDAIPlayerEngineWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/ads/AdsDAIPlayerEngineWrapper.java
@@ -44,9 +44,13 @@ public class AdsDAIPlayerEngineWrapper extends PlayerEngineWrapper implements PK
     @Override
     public void load(PKMediaSourceConfig mediaSourceConfig) {
         if (adsProvider != null) {
-            if (!adsProvider.isContentPrepared() || adsProvider.isAdError()) {
+            if (!adsProvider.isContentPrepared() || adsProvider.isAdError() || (mediaSourceConfig != null && !mediaSourceConfig.equals(this.mediaSourceConfig))) {
+                if ((mediaSourceConfig != null && !mediaSourceConfig.equals(this.mediaSourceConfig)) && !adsProvider.isAdRequested()) {
+                    adsProvider.resetPluginFlags() ;
+                }
                 this.mediaSourceConfig = mediaSourceConfig;
             }
+
             if (adsProvider != null) {
                 if (adsProvider.isAdRequested() || adsProvider.isAllAdsCompleted()) {
                     log.d("AdWrapper calling super.prepare");

--- a/playkit/src/main/java/com/kaltura/playkit/ads/AdsDAIPlayerEngineWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/ads/AdsDAIPlayerEngineWrapper.java
@@ -44,8 +44,8 @@ public class AdsDAIPlayerEngineWrapper extends PlayerEngineWrapper implements PK
     @Override
     public void load(PKMediaSourceConfig mediaSourceConfig) {
         if (adsProvider != null) {
-            if (!adsProvider.isContentPrepared() || adsProvider.isAdError() || (mediaSourceConfig != null && !mediaSourceConfig.equals(this.mediaSourceConfig))) {
-                if ((mediaSourceConfig != null && !mediaSourceConfig.equals(this.mediaSourceConfig)) && !adsProvider.isAdRequested()) {
+            if (!adsProvider.isContentPrepared() || adsProvider.isAdError() || (this.mediaSourceConfig != null && !this.mediaSourceConfig.equals(mediaSourceConfig))) {
+                if ((this.mediaSourceConfig != null && !this.mediaSourceConfig.equals(mediaSourceConfig)) && !adsProvider.isAdRequested()) {
                     adsProvider.resetPluginFlags() ;
                 }
                 this.mediaSourceConfig = mediaSourceConfig;

--- a/playkit/src/main/java/com/kaltura/playkit/ads/AdsPlayerEngineWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/ads/AdsPlayerEngineWrapper.java
@@ -41,7 +41,7 @@ public class AdsPlayerEngineWrapper extends PlayerEngineWrapper implements PKAdP
 
     @Override
     public void load(PKMediaSourceConfig mediaSourceConfig) {
-        if (mediaSourceConfig != null && !mediaSourceConfig.equals(this.mediaSourceConfig)) {
+        if (this.mediaSourceConfig != null && !this.mediaSourceConfig.equals(mediaSourceConfig)) {
             log.d("AdWrapper Load New Media");
             adsProvider.resetPluginFlags();
         }

--- a/playkit/src/main/java/com/kaltura/playkit/ads/AdsPlayerEngineWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/ads/AdsPlayerEngineWrapper.java
@@ -41,11 +41,9 @@ public class AdsPlayerEngineWrapper extends PlayerEngineWrapper implements PKAdP
 
     @Override
     public void load(PKMediaSourceConfig mediaSourceConfig) {
-        if (mediaSourceConfig != null) {
-            if (!mediaSourceConfig.equals(this.mediaSourceConfig)) {
-                log.d("AdWrapper Change Media");
-                adsProvider.resetPluginFlags();
-            }
+        if (mediaSourceConfig != null && !mediaSourceConfig.equals(this.mediaSourceConfig)) {
+            log.d("AdWrapper Load New Media");
+            adsProvider.resetPluginFlags();
         }
 
         this.mediaSourceConfig = mediaSourceConfig;

--- a/playkit/src/main/java/com/kaltura/playkit/ads/AdsPlayerEngineWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/ads/AdsPlayerEngineWrapper.java
@@ -41,6 +41,13 @@ public class AdsPlayerEngineWrapper extends PlayerEngineWrapper implements PKAdP
 
     @Override
     public void load(PKMediaSourceConfig mediaSourceConfig) {
+        if (mediaSourceConfig != null) {
+            if (!mediaSourceConfig.equals(this.mediaSourceConfig)) {
+                log.d("AdWrapper Change Media");
+                adsProvider.resetPluginFlags();
+            }
+        }
+
         this.mediaSourceConfig = mediaSourceConfig;
         if (adsProvider != null) {
             //incase no ads provided - need to prepare so treating load state as ad was requested
@@ -146,8 +153,6 @@ public class AdsPlayerEngineWrapper extends PlayerEngineWrapper implements PKAdP
         log.d("AdWrapper stop");
         if (adsProvider != null) {
             adsProvider.setAdRequested(false);
-            adsProvider.setAdError(false);
-            adsProvider.setAllAdsCompleted(false);
             adsProvider.destroyAdsManager();
         }
         super.stop();

--- a/playkit/src/main/java/com/kaltura/playkit/ads/AdsPlayerEngineWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/ads/AdsPlayerEngineWrapper.java
@@ -45,7 +45,7 @@ public class AdsPlayerEngineWrapper extends PlayerEngineWrapper implements PKAdP
         if (adsProvider != null) {
             //incase no ads provided - need to prepare so treating load state as ad was requested
             if (adsProvider.getCuePoints() != null && adsProvider.getCuePoints().getAdCuePoints() != null && adsProvider.getCuePoints().getAdCuePoints().size() == 0) {
-                adsProvider.setAdRequested(true); // need to prepare immeidatly
+                adsProvider.setAdRequested(true); // need to prepare immediately
             }
 
             if (preparePlayerForPlayback()) {
@@ -146,6 +146,8 @@ public class AdsPlayerEngineWrapper extends PlayerEngineWrapper implements PKAdP
         log.d("AdWrapper stop");
         if (adsProvider != null) {
             adsProvider.setAdRequested(false);
+            adsProvider.setAdError(false);
+            adsProvider.setAllAdsCompleted(false);
             adsProvider.destroyAdsManager();
         }
         super.stop();

--- a/playkit/src/main/java/com/kaltura/playkit/plugins/ads/AdsProvider.java
+++ b/playkit/src/main/java/com/kaltura/playkit/plugins/ads/AdsProvider.java
@@ -58,9 +58,7 @@ public interface AdsProvider {
 
     void setAdRequested(boolean isAdRequested);
 
-    void setAdError(boolean isAdError);
-
-    void setAllAdsCompleted(boolean isAllAdsCompleted);
+    void resetPluginFlags();
 
     void removeAdProviderListener();
 

--- a/playkit/src/main/java/com/kaltura/playkit/plugins/ads/AdsProvider.java
+++ b/playkit/src/main/java/com/kaltura/playkit/plugins/ads/AdsProvider.java
@@ -58,6 +58,10 @@ public interface AdsProvider {
 
     void setAdRequested(boolean isAdRequested);
 
+    void setAdError(boolean isAdError);
+
+    void setAllAdsCompleted(boolean isAllAdsCompleted);
+
     void removeAdProviderListener();
 
     void skipAd();


### PR DESCRIPTION
case is happening if we have change media 2 times 
with 2 ad error
first time it is playing ok
next change media asError or allAdsCompleted flags were not rest so auto play logic was not called