### PR TITLE
FEC-10243 no need to clear the tracks in case of auto track is selected

### DIFF
--- a/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
@@ -660,8 +660,6 @@ class TrackSelectionHelper {
 
                         if (videoGroupIndex == groupIndex && videoTrackIndex != TRACK_ADAPTIVE) {
                             adaptiveTrackIndexesList.add(getIndexFromUniqueId(videoTrack.getUniqueId(), TRACK_INDEX));
-                        } else {
-                            return null; // incase of back to auto need to clear the selection override so return null.
                         }
                     }
                     break;


### PR DESCRIPTION
### Description of the Changes

remove code which clear the video ABR selection of the APP once Auto track  is selected 
