### PR TITLE
FEC-10554 Logic change for external/internal subtitles' selection

### DIFF
--- a/playkit/src/main/java/com/kaltura/playkit/PKSubtitlePreference.java
+++ b/playkit/src/main/java/com/kaltura/playkit/PKSubtitlePreference.java
@@ -1,0 +1,13 @@
+package com.kaltura.playkit;
+
+public enum PKSubtitlePreference {
+    INTERNAL(1),
+    EXTERNAL(2),
+    OFF(3);
+
+    public final int subtitlePreference;
+
+    PKSubtitlePreference(int subtitlePreference) {
+        this.subtitlePreference = subtitlePreference;
+    }
+}

--- a/playkit/src/main/java/com/kaltura/playkit/PKSubtitlePreference.java
+++ b/playkit/src/main/java/com/kaltura/playkit/PKSubtitlePreference.java
@@ -1,13 +1,7 @@
 package com.kaltura.playkit;
 
 public enum PKSubtitlePreference {
-    INTERNAL(1),
-    EXTERNAL(2),
-    OFF(3);
-
-    public final int subtitlePreference;
-
-    PKSubtitlePreference(int subtitlePreference) {
-        this.subtitlePreference = subtitlePreference;
-    }
+    INTERNAL,
+    EXTERNAL,
+    OFF
 }

--- a/playkit/src/main/java/com/kaltura/playkit/PKSubtitlePreference.java
+++ b/playkit/src/main/java/com/kaltura/playkit/PKSubtitlePreference.java
@@ -1,7 +1,7 @@
 package com.kaltura.playkit;
 
 public enum PKSubtitlePreference {
+    OFF,
     INTERNAL,
-    EXTERNAL,
-    OFF
+    EXTERNAL
 }

--- a/playkit/src/main/java/com/kaltura/playkit/Player.java
+++ b/playkit/src/main/java/com/kaltura/playkit/Player.java
@@ -257,11 +257,12 @@ public interface Player {
          * Set preference to choose internal subtitles over external subtitles (Only in the case if the same language is present
          * in both Internal and External subtitles) - Default is true (Internal is preferred)
          *
-         * @param preferInternalSubtitles if true, Internal will be present and External subtitle will be discarded
-         *                   if false, External will be present and Internal subtitle will be discarded
+         * @param subtitlePreference PKSubtitlePreference.INTERNAL, Internal will be present and External subtitle will be discarded
+         *                    PKSubtitlePreference.EXTERNAL, External will be present and Internal subtitle will be discarded
+         *                   PKSubtitlePreference.OFF, Both internal and external subtitles will be there
          * @return - Player Settings
          */
-        Settings setSubtitlePreference(boolean preferInternalSubtitles);
+        Settings setSubtitlePreference(PKSubtitlePreference subtitlePreference);
 
         /**
          * Sets the maximum allowed video width and height.

--- a/playkit/src/main/java/com/kaltura/playkit/player/PlayerSettings.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/PlayerSettings.java
@@ -355,9 +355,9 @@ public class PlayerSettings implements Player.Settings {
     public Player.Settings setSubtitlePreference(PKSubtitlePreference subtitlePreference) {
         if (subtitlePreference == null) {
             this.subtitlePreference = PKSubtitlePreference.OFF;
-            return this;
+        } else {
+            this.subtitlePreference = subtitlePreference;
         }
-        this.subtitlePreference = subtitlePreference;
         return this;
     }
 

--- a/playkit/src/main/java/com/kaltura/playkit/player/PlayerSettings.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/PlayerSettings.java
@@ -353,6 +353,10 @@ public class PlayerSettings implements Player.Settings {
 
     @Override
     public Player.Settings setSubtitlePreference(PKSubtitlePreference subtitlePreference) {
+        if (subtitlePreference == null) {
+            this.subtitlePreference = PKSubtitlePreference.OFF;
+            return this;
+        }
         this.subtitlePreference = subtitlePreference;
         return this;
     }

--- a/playkit/src/main/java/com/kaltura/playkit/player/PlayerSettings.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/PlayerSettings.java
@@ -14,6 +14,7 @@ package com.kaltura.playkit.player;
 
 import com.kaltura.playkit.PKMediaFormat;
 import com.kaltura.playkit.PKRequestParams;
+import com.kaltura.playkit.PKSubtitlePreference;
 import com.kaltura.playkit.PKTrackConfig;
 import com.kaltura.playkit.Player;
 import com.kaltura.playkit.player.vr.VRSettings;
@@ -34,7 +35,7 @@ public class PlayerSettings implements Player.Settings {
     private AudioCodecSettings preferredAudioCodecSettings = new AudioCodecSettings();
     private boolean isTunneledAudioPlayback;
     private boolean handleAudioBecomingNoisyEnabled;
-    private boolean preferInternalSubtitles = true;
+    private PKSubtitlePreference subtitlePreference = PKSubtitlePreference.INTERNAL;
     private Integer maxVideoBitrate;
     private Integer maxAudioBitrate;
     private int maxAudioChannelCount = -1;
@@ -166,8 +167,8 @@ public class PlayerSettings implements Player.Settings {
 
     public boolean isHandleAudioBecomingNoisyEnabled() { return handleAudioBecomingNoisyEnabled; }
 
-    public boolean isPreferInternalSubtitles() {
-        return preferInternalSubtitles;
+    public PKSubtitlePreference getSubtitlePreference() {
+        return subtitlePreference;
     }
 
     public PKMaxVideoSize getMaxVideoSize() { return maxVideoSize; }
@@ -351,8 +352,8 @@ public class PlayerSettings implements Player.Settings {
     }
 
     @Override
-    public Player.Settings setSubtitlePreference(boolean preferInternalSubtitles) {
-        this.preferInternalSubtitles = preferInternalSubtitles;
+    public Player.Settings setSubtitlePreference(PKSubtitlePreference subtitlePreference) {
+        this.subtitlePreference = subtitlePreference;
         return this;
     }
 

--- a/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
@@ -32,6 +32,7 @@ import com.kaltura.android.exoplayer2.trackselection.TrackSelectionArray;
 import com.kaltura.playkit.PKAudioCodec;
 import com.kaltura.playkit.PKError;
 import com.kaltura.playkit.PKLog;
+import com.kaltura.playkit.PKSubtitlePreference;
 import com.kaltura.playkit.PKTrackConfig;
 import com.kaltura.playkit.PKVideoCodec;
 import com.kaltura.playkit.utils.Consts;
@@ -326,18 +327,22 @@ class TrackSelectionHelper {
     private boolean ignoreTextTrackOnPreference(Format format) {
         String languageName = format.language;
         boolean isExternalSubtitle = isExternalSubtitle(format);
-        boolean isPreferInternalSubtitles = playerSettings.isPreferInternalSubtitles();
+        PKSubtitlePreference subtitlePreference = playerSettings.getSubtitlePreference();
+
+        if (subtitlePreference == PKSubtitlePreference.OFF) {
+            return false;
+        }
 
         if (isExternalSubtitle) {
             languageName = getExternalSubtitleLanguage(format);
         }
 
         if (subtitleListMap.containsKey(languageName) && subtitleListMap.get(languageName).size() > 1) {
-            if ((isPreferInternalSubtitles && isExternalSubtitle) ||
-                    (!isPreferInternalSubtitles && !isExternalSubtitle)) {
+            if ((subtitlePreference == PKSubtitlePreference.INTERNAL && isExternalSubtitle) ||
+                    (subtitlePreference == PKSubtitlePreference.EXTERNAL && !isExternalSubtitle)) {
                 return true;
-            } else if ((!isPreferInternalSubtitles && isExternalSubtitle) ||
-                    (isPreferInternalSubtitles && !isExternalSubtitle)) {
+            } else if ((subtitlePreference == PKSubtitlePreference.EXTERNAL && isExternalSubtitle) ||
+                    (subtitlePreference == PKSubtitlePreference.INTERNAL && !isExternalSubtitle)) {
                 return false;
             }
         }

--- a/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
@@ -252,7 +252,7 @@ class TrackSelectionHelper {
                                 }
                                 break;
                             case TRACK_TYPE_TEXT:
-                                if (format.language != null && hasExternalSubtitles && ignoreTextTrackOnPreference(format)) {
+                                if (format.language != null && hasExternalSubtitles && discardTextTrackOnPreference(format)) {
                                     continue;
                                 }
 
@@ -324,17 +324,22 @@ class TrackSelectionHelper {
         }
     }
 
-    private boolean ignoreTextTrackOnPreference(Format format) {
-        String languageName = format.language;
-        boolean isExternalSubtitle = isExternalSubtitle(format);
+    private boolean discardTextTrackOnPreference(Format format) {
         PKSubtitlePreference subtitlePreference = playerSettings.getSubtitlePreference();
-
         if (subtitlePreference == PKSubtitlePreference.OFF) {
             return false;
         }
 
+        String languageName = format.language;
+        boolean isExternalSubtitle = isExternalSubtitle(format);
+
         if (isExternalSubtitle) {
             languageName = getExternalSubtitleLanguage(format);
+            if (subtitlePreference == PKSubtitlePreference.INTERNAL && !subtitleListMap.get(languageName).containsKey(languageName)) {
+                // If there is no internal subtitle and the preference is PKSubtitlePreference.Internal from App
+                // then we are not discarding this text track.
+                return false;
+            }
         }
 
         if (subtitleListMap.containsKey(languageName) && subtitleListMap.get(languageName).size() > 1) {

--- a/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
@@ -335,7 +335,8 @@ class TrackSelectionHelper {
 
         if (isExternalSubtitle) {
             languageName = getExternalSubtitleLanguage(format);
-            if (subtitlePreference == PKSubtitlePreference.INTERNAL && !subtitleListMap.get(languageName).containsKey(languageName)) {
+            Map<String, List<Format>> languageNameMap = subtitleListMap.get(languageName);
+            if (subtitlePreference == PKSubtitlePreference.INTERNAL && languageNameMap != null && !languageNameMap.containsKey(languageName)) {
                 // If there is no internal subtitle and the preference is PKSubtitlePreference.Internal from App
                 // then we are not discarding this text track.
                 return false;


### PR DESCRIPTION
Added new `PKSubtitlePreference`. 

`PKSubtitlePreference.INTERNAL, Internal will be present and External subtitle will be discarded
  PKSubtitlePreference.EXTERNAL, External will be present and Internal subtitle will be discarded
  PKSubtitlePreference.OFF, Both internal and external subtitles will be there`

Application needs to set the preference,
Example:  `player.getSettings().setSubtitlePreference(AppPreference);`

