### PR TITLE
FEC-10626 - break is missing so if selection flag set to multiple tracks it will not override

### DIFF
--- a/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
@@ -509,6 +509,7 @@ class TrackSelectionHelper {
                 int selectionFlag = trackList.get(i).getSelectionFlag();
                 if (selectionFlag == Consts.DEFAULT_TRACK_SELECTION_FLAG_HLS || selectionFlag == Consts.DEFAULT_TRACK_SELECTION_FLAG_DASH) {
                     defaultTrackIndex = i;
+                    break;
                 }
             }
         }


### PR DESCRIPTION
previous value
this may cause out of bound since list may shorter than the index that is selected