### PR TITLE
FEC-10693 - Expose new ExoPlayer feature for wakeLock setWakeMode (NONE/LOCAL/NETWORK)

### DIFF
--- a/playkit/src/main/AndroidManifest.xml
+++ b/playkit/src/main/AndroidManifest.xml
@@ -3,5 +3,6 @@
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
 
 </manifest>

--- a/playkit/src/main/java/com/kaltura/playkit/PKWakeMode.java
+++ b/playkit/src/main/java/com/kaltura/playkit/PKWakeMode.java
@@ -1,0 +1,7 @@
+package com.kaltura.playkit;
+
+public enum PKWakeMode {
+    NONE,    // A wake mode that will not cause the player to hold any locks.
+    LOCAL,   // A wake mode that will cause the player to hold a PowerManager.WakeLock during playback.
+    NETWORK  // A wake mode that will cause the player to hold a PowerManager.WakeLock and a WifiManager.WifiLock during playback
+}

--- a/playkit/src/main/java/com/kaltura/playkit/Player.java
+++ b/playkit/src/main/java/com/kaltura/playkit/Player.java
@@ -253,7 +253,16 @@ public interface Player {
         Settings setHandleAudioBecomingNoisy(boolean handleAudioBecomingNoisyEnabled);
 
         /**
-         * Set WakeLock Mode  - Sets whether the player should not handle wakeLock or should handle a wake lock only or both wakeLock & wifiLock
+         * Set WakeLock Mode  - Sets whether the player should not handle wakeLock or should handle a wake lock only or both wakeLock & wifiLock when the screen is off
+         *
+         * <p>It should be used together with a foreground {@link android.app.Service} for use cases where
+         * playback occurs and the screen is off (e.g. background audio playback). It is not useful when
+         * the screen will be kept on during playback (e.g. foreground video playback).
+         *
+         * <p>When enabled, the locks ({@link android.os.PowerManager.WakeLock} / {@link
+         * android.net.wifi.WifiManager.WifiLock}) will be held whenever the player is in the
+         * STATE_READY STATE_BUFFERINGstates with {@code playWhenReady = true}. The locks
+         * held depends on the specified {@link PKWakeMode}.
          * default - NONE - not handling wake lock
          *
          * @param wakeMode

--- a/playkit/src/main/java/com/kaltura/playkit/Player.java
+++ b/playkit/src/main/java/com/kaltura/playkit/Player.java
@@ -253,6 +253,15 @@ public interface Player {
         Settings setHandleAudioBecomingNoisy(boolean handleAudioBecomingNoisyEnabled);
 
         /**
+         * Set WakeLock Mode  - Sets whether the player should not handle wakeLock or should handle a wake lock only or both wakeLock & wifiLock
+         * default - NONE - not handling wake lock
+         *
+         * @param wakeMode
+         * @return - Player Settings
+         */
+        Settings setWakeMode(PKWakeMode wakeMode);
+
+        /**
          * Set HandleAudioFocus - Support for automatic audio focus handling
          *
          * @param handleAudioFocus

--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
@@ -203,6 +203,8 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.EventListener, Met
                 .setBandwidthMeter(bandwidthMeter).build();
         player.setAudioAttributes(AudioAttributes.DEFAULT, /* handleAudioFocus= */ playerSettings.isHandleAudioFocus());
         player.setHandleAudioBecomingNoisy(playerSettings.isHandleAudioBecomingNoisyEnabled());
+        player.setWakeMode(playerSettings.getWakeMode().ordinal());
+
         window = new Timeline.Window();
         setPlayerListeners();
         exoPlayerView.setSurfaceAspectRatioResizeMode(playerSettings.getAspectRatioResizeMode());

--- a/playkit/src/main/java/com/kaltura/playkit/player/PlayerSettings.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/PlayerSettings.java
@@ -16,6 +16,7 @@ import com.kaltura.playkit.PKMediaFormat;
 import com.kaltura.playkit.PKRequestParams;
 import com.kaltura.playkit.PKSubtitlePreference;
 import com.kaltura.playkit.PKTrackConfig;
+import com.kaltura.playkit.PKWakeMode;
 import com.kaltura.playkit.Player;
 import com.kaltura.playkit.player.vr.VRSettings;
 
@@ -35,6 +36,7 @@ public class PlayerSettings implements Player.Settings {
     private AudioCodecSettings preferredAudioCodecSettings = new AudioCodecSettings();
     private boolean isTunneledAudioPlayback;
     private boolean handleAudioBecomingNoisyEnabled;
+    private PKWakeMode wakeMode = PKWakeMode.NONE;
     private boolean handleAudioFocus;
     private PKSubtitlePreference subtitlePreference = PKSubtitlePreference.INTERNAL;
     private Integer maxVideoBitrate;
@@ -167,6 +169,10 @@ public class PlayerSettings implements Player.Settings {
 
     public boolean isHandleAudioBecomingNoisyEnabled() {
         return handleAudioBecomingNoisyEnabled;
+    }
+
+    public PKWakeMode getWakeMode() {
+        return wakeMode;
     }
 
     public boolean isHandleAudioFocus() {
@@ -352,6 +358,14 @@ public class PlayerSettings implements Player.Settings {
     @Override
     public Player.Settings setHandleAudioBecomingNoisy(boolean handleAudioBecomingNoisyEnabled) {
         this.handleAudioBecomingNoisyEnabled = handleAudioBecomingNoisyEnabled;
+        return this;
+    }
+
+    @Override
+    public Player.Settings setWakeMode(PKWakeMode wakeMode) {
+        if (wakeMode != null) {
+            this.wakeMode = wakeMode;
+        }
         return this;
     }
 

--- a/playkit/version.gradle
+++ b/playkit/version.gradle
@@ -1,5 +1,5 @@
 // PlayKit Library Version
-ext.playkitVersion = 'dev'
+ext.playkitVersion = '4.10.0'
 
 // Append short commit hash to dev builds, i.e. "dev.a1b2c3d"
 if (playkitVersion == 'dev') {

--- a/playkit/version.gradle
+++ b/playkit/version.gradle
@@ -1,5 +1,5 @@
 // PlayKit Library Version
-ext.playkitVersion = '4.10.0'
+ext.playkitVersion = 'dev'
 
 // Append short commit hash to dev builds, i.e. "dev.a1b2c3d"
 if (playkitVersion == 'dev') {


### PR DESCRIPTION
### Description of the Changes

add new API for player settings that give ability to change wakeLock mode

This API is in use only for audio playback in bg + service

in order to avoid screen lock after screen timeout 
Most applications should use android.view.WindowManager.LayoutParams#FLAG_KEEP_SCREEN_ON API