### PR TITLE
FEC-10593 [Youbora] Added `isAutoPlay` to the `AdEvent.adRequested` event

### DIFF
--- a/playkit/src/main/java/com/kaltura/playkit/plugins/ads/AdEvent.java
+++ b/playkit/src/main/java/com/kaltura/playkit/plugins/ads/AdEvent.java
@@ -136,10 +136,12 @@ public class AdEvent implements PKEvent {
     public static class AdRequestedEvent extends AdEvent {
 
         public final String adTagUrl;
+        public final boolean isAutoPlay;
 
-        public AdRequestedEvent(String adTagUrl) {
+        public AdRequestedEvent(String adTagUrl, boolean isAutoPlay) {
             super(Type.AD_REQUESTED);
             this.adTagUrl = adTagUrl;
+            this.isAutoPlay = isAutoPlay;
         }
     }
 


### PR DESCRIPTION
- Fixed ping event firing when autoplay is false in Kaltura Player
- It will share Ad autoplay status to `YouboraPlugin` by `IMAPlugin` and `IMADAIPlugin`.