### PR TITLE
FEC-10843 - fix DvrLive liveEdge Playback + add seekToLiveDefaultPosition player API

### DIFF
--- a/playkit/src/main/java/com/kaltura/playkit/Player.java
+++ b/playkit/src/main/java/com/kaltura/playkit/Player.java
@@ -466,6 +466,12 @@ public interface Player {
     void seekTo(long position);
 
     /**
+     * Seek player to Live Default Position.
+     *
+     */
+     void seekToLiveDefaultPosition();
+
+    /**
      * Get the Player's SessionId. The SessionId is generated each time new media is set.
      *
      * @return Player's SessionId, as a String object.

--- a/playkit/src/main/java/com/kaltura/playkit/PlayerDecoratorBase.java
+++ b/playkit/src/main/java/com/kaltura/playkit/PlayerDecoratorBase.java
@@ -59,6 +59,11 @@ public class PlayerDecoratorBase implements Player {
     }
 
     @Override
+    public void seekToLiveDefaultPosition() {
+        player.seekToLiveDefaultPosition();
+    }
+
+    @Override
     public <T extends PKController> T getController(Class<T> type) {
         return player.getController(type);
     }

--- a/playkit/src/main/java/com/kaltura/playkit/PlayerEngineWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/PlayerEngineWrapper.java
@@ -97,6 +97,11 @@ public class PlayerEngineWrapper implements PlayerEngine {
     }
 
     @Override
+    public void seekToDefaultPosition() {
+        playerEngine.seekToDefaultPosition();
+    }
+    
+    @Override
     public void startFrom(long position) {
         playerEngine.startFrom(position);
     }

--- a/playkit/src/main/java/com/kaltura/playkit/ads/AdEnabledPlayerController.java
+++ b/playkit/src/main/java/com/kaltura/playkit/ads/AdEnabledPlayerController.java
@@ -84,6 +84,15 @@ public class AdEnabledPlayerController extends PlayerDecorator implements AdCont
     }
 
     @Override
+    public void seekToLiveDefaultPosition() {
+        if (adsProvider.isAdDisplayed()) {
+            log.d("seekToDefaultPosition is not enabled during AD playback");
+            return;
+        }
+        super.seekToLiveDefaultPosition();
+    }
+
+    @Override
     public void setVolume(float volume) {
         if (adsProvider.isAdDisplayed()) {
             adsProvider.setVolume(volume);

--- a/playkit/src/main/java/com/kaltura/playkit/ads/AdsPlayerEngineWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/ads/AdsPlayerEngineWrapper.java
@@ -137,6 +137,12 @@ public class AdsPlayerEngineWrapper extends PlayerEngineWrapper implements PKAdP
     }
 
     @Override
+    public void seekToDefaultPosition() {
+        log.d("AdWrapper seekToDefaultPosition");
+        super.seekToDefaultPosition();
+    }
+
+    @Override
     public boolean isPlaying() {
         log.d("AdWrapper isPlaying");
         return super.isPlaying();

--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
@@ -925,6 +925,14 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.EventListener, Met
     }
 
     @Override
+    public void seekToDefaultPosition() {
+        log.v("seekToDefaultPosition");
+        if (assertPlayerIsNotNull("seekToDefaultPosition()")) {
+            player.seekToDefaultPosition();
+        }
+    }
+
+    @Override
     public long getDuration() {
         log.v("getDuration");
         if (assertPlayerIsNotNull("getDuration()")) {

--- a/playkit/src/main/java/com/kaltura/playkit/player/PlayerController.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/PlayerController.java
@@ -331,6 +331,7 @@ public class PlayerController implements Player {
 
     private void startPlaybackFrom(long startPosition) {
         log.v("startPlaybackFrom " + startPosition);
+
         if (assertPlayerIsNotNull("startPlaybackFrom()")) {
             if (startPosition <= getDuration()) {
                 player.startFrom(startPosition);
@@ -402,6 +403,14 @@ public class PlayerController implements Player {
         if (assertPlayerIsNotNull("seekTo()")) {
             targetSeekPosition = position;
             player.seekTo(position);
+        }
+    }
+
+    @Override
+    public void seekToLiveDefaultPosition() {
+        log.v("seekToLiveDefaultPosition");
+        if (assertPlayerIsNotNull("seekToLiveDefaultPosition()") && player.isLive()) {
+            player.seekToDefaultPosition();
         }
     }
 
@@ -775,6 +784,8 @@ public class PlayerController implements Player {
                                         mediaConfig.getStartPosition() > 0) {
                                     startPlaybackFrom(mediaConfig.getStartPosition() * MILLISECONDS_MULTIPLIER);
                                 }
+                            } else if (isLiveMediaWithDvr() && mediaConfig.getStartPosition() == null) {
+                                player.seekToDefaultPosition();
                             }
                             isNewEntry = false;
                             isPlayerStopped = false;

--- a/playkit/src/main/java/com/kaltura/playkit/player/PlayerEngine.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/PlayerEngine.java
@@ -145,6 +145,12 @@ public interface PlayerEngine {
     void seekTo(long position);
 
     /**
+     * Seek player to Live Default Position.
+     *
+     */
+    default void seekToDefaultPosition() {};
+    
+    /**
      * Start players playback from the specified position.
      * Note! The position is passed in seconds.
      *


### PR DESCRIPTION
fix FEC-10843 - DvrLive media playback is not starting from live edge

Application can call `player.seekToLiveDefaultPosition()` in order to force live edge when needed