### PR TITLE
FEC-10917 Add missing support in media playback with predefined headers on online playback  after exo 2.12 upgrade

### DIFF
--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
@@ -38,7 +38,6 @@ import com.kaltura.android.exoplayer2.mediacodec.MediaCodecUtil;
 import com.kaltura.android.exoplayer2.metadata.Metadata;
 import com.kaltura.android.exoplayer2.metadata.MetadataOutput;
 import com.kaltura.android.exoplayer2.source.BehindLiveWindowException;
-import com.kaltura.android.exoplayer2.source.DefaultMediaSourceFactory;
 import com.kaltura.android.exoplayer2.source.MediaSource;
 import com.kaltura.android.exoplayer2.source.MediaSourceFactory;
 import com.kaltura.android.exoplayer2.source.ProgressiveMediaSource;


### PR DESCRIPTION
For a given request params headers we have to apply the headers on the http requests

```
static class MediaAdapter implements PKRequestParams.Adapter {

        public static Map<String,String> customHeaders;
        @Override
        public PKRequestParams adapt(PKRequestParams requestParams) {
            for (Map.Entry<String,String> entry : customHeaders.entrySet()) {
                requestParams.headers.put(entry.getKey(), entry.getValue());
            }
            return requestParams;
        }

        @Override
        public void updateParams(Player player) {
            // TODO?
        }

        @Override
        public String getApplicationName() {
            return null;
        }
    }

```

```
Map<String,String> headers = new HashMap<>();
headers.put("aaa", "bbb");
headers.put("ccc","ddd");

final MediaAdapter mediaAdapter = new MediaAdapter();
mediaAdapter.customHeaders = headers;
player.getSettings().setContentRequestAdapter(mediaAdapter);
```