### PR TITLE
FEC-10923 Expose config to forceWidevineL3 on device

### DIFF
--- a/playkit/src/main/java/com/kaltura/playkit/LocalAssetsManager.java
+++ b/playkit/src/main/java/com/kaltura/playkit/LocalAssetsManager.java
@@ -37,6 +37,7 @@ public class LocalAssetsManager {
 
     private static final PKLog log = PKLog.get("LocalAssetsManager");
     private final LocalAssetsManagerHelper helper;
+    private boolean isForceWidevineL3Playback = false;
 
     public LocalAssetsManager(Context context, LocalDataStore localDataStore) {
         helper = new LocalAssetsManagerHelper(context, localDataStore);
@@ -48,6 +49,10 @@ public class LocalAssetsManager {
 
     public void setLicenseRequestAdapter(PKRequestParams.Adapter licenseRequestAdapter) {
         helper.setLicenseRequestAdapter(licenseRequestAdapter);
+    }
+
+    public void forceWidevineL3Playback(boolean isForceWidevineL3Playback) {
+        this.isForceWidevineL3Playback = isForceWidevineL3Playback;
     }
 
     /**
@@ -167,7 +172,7 @@ public class LocalAssetsManager {
         }
 
         if (drmParams != null) {
-            registerDrmAsset(localAssetPath, assetId, mediaFormat, drmParams, listener);
+            registerDrmAsset(localAssetPath, assetId, mediaFormat, drmParams, listener, isForceWidevineL3Playback);
         } else {
             registerClearAsset(localAssetPath, assetId, mediaFormat, listener);
         }
@@ -176,19 +181,20 @@ public class LocalAssetsManager {
     /**
      * Will register the drm asset and store the keyset id and {@link PKMediaFormat} in local storage.
      *
-     * @param localAssetPath - the local asset path of the asset.
-     * @param assetId        - the asset id.
-     * @param mediaFormat    - the media format converted to byte[].
-     * @param drmParams      - drm params of the media.
-     * @param listener       - notify about the success/fail after the completion of the registration process.
+     * @param localAssetPath                - the local asset path of the asset.
+     * @param assetId                       - the asset id.
+     * @param mediaFormat                   - the media format converted to byte[].
+     * @param drmParams                     - drm params of the media.
+     * @param listener                      - notify about the success/fail after the completion of the registration process.
+     * @param isForceWidevineL3Playback     - if the device codec is known to fail if security level L1 is used then set flag to true, it will force the player to use Widevine L3
      */
-    private void registerDrmAsset(final String localAssetPath, final String assetId, final PKMediaFormat mediaFormat, final PKDrmParams drmParams, final AssetRegistrationListener listener) {
+    private void registerDrmAsset(final String localAssetPath, final String assetId, final PKMediaFormat mediaFormat, final PKDrmParams drmParams, final AssetRegistrationListener listener, boolean isForceWidevineL3Playback) {
         doInBackground(() -> {
             try {
                 DrmAdapter drmAdapter = DrmAdapter.getDrmAdapter(drmParams.getScheme(), helper.context, helper.localDataStore);
                 String licenseUri = drmParams.getLicenseUri();
 
-                boolean isRegistered = drmAdapter.registerAsset(localAssetPath, assetId, licenseUri, helper.licenseRequestParamAdapter, listener);
+                boolean isRegistered = drmAdapter.registerAsset(localAssetPath, assetId, licenseUri, helper.licenseRequestParamAdapter, listener, isForceWidevineL3Playback);
                 if (isRegistered) {
                     helper.saveMediaFormat(assetId, mediaFormat, drmParams.getScheme());
                 }

--- a/playkit/src/main/java/com/kaltura/playkit/LocalAssetsManagerExo.java
+++ b/playkit/src/main/java/com/kaltura/playkit/LocalAssetsManagerExo.java
@@ -48,9 +48,9 @@ public class LocalAssetsManagerExo {
         }
     }
 
-    public void registerWidevineDashAsset(String assetId, String licenseUri, byte[] drmInitData) throws LocalAssetsManager.RegisterException {
+    public void registerWidevineDashAsset(String assetId, String licenseUri, byte[] drmInitData, boolean isForceWidevineL3Playback) throws LocalAssetsManager.RegisterException {
         final WidevineModularAdapter widevine = new WidevineModularAdapter(helper.context, helper.localDataStore);
-        widevine.registerAsset(drmInitData, "video/mp4", licenseUri, helper.licenseRequestParamAdapter);
+        widevine.registerAsset(drmInitData, "video/mp4", licenseUri, helper.licenseRequestParamAdapter, isForceWidevineL3Playback);
         helper.saveMediaFormat(assetId, PKMediaFormat.dash, PKDrmParams.Scheme.WidevineCENC);
     }
 

--- a/playkit/src/main/java/com/kaltura/playkit/LocalAssetsManagerExo.java
+++ b/playkit/src/main/java/com/kaltura/playkit/LocalAssetsManagerExo.java
@@ -48,9 +48,9 @@ public class LocalAssetsManagerExo {
         }
     }
 
-    public void registerWidevineDashAsset(String assetId, String licenseUri, byte[] drmInitData, boolean isForceWidevineL3Playback) throws LocalAssetsManager.RegisterException {
+    public void registerWidevineDashAsset(String assetId, String licenseUri, byte[] drmInitData, boolean forceWidevineL3Playback) throws LocalAssetsManager.RegisterException {
         final WidevineModularAdapter widevine = new WidevineModularAdapter(helper.context, helper.localDataStore);
-        widevine.registerAsset(drmInitData, "video/mp4", licenseUri, helper.licenseRequestParamAdapter, isForceWidevineL3Playback);
+        widevine.registerAsset(drmInitData, "video/mp4", licenseUri, helper.licenseRequestParamAdapter, forceWidevineL3Playback);
         helper.saveMediaFormat(assetId, PKMediaFormat.dash, PKDrmParams.Scheme.WidevineCENC);
     }
 
@@ -87,7 +87,7 @@ public class LocalAssetsManagerExo {
         return new LocalAssetsManager.LocalMediaSource(helper.localDataStore, localAssetPath, assetId, helper.getLocalAssetScheme(assetId));
     }
 
-    public LocalAssetsManager.AssetStatus getDrmStatus(String assetId, byte[] drmInitData) {
+    public LocalAssetsManager.AssetStatus getDrmStatus(String assetId, byte[] drmInitData, boolean forceWidevineL3Playback) {
         final PKDrmParams.Scheme scheme = helper.getLocalAssetScheme(assetId);
         if (scheme != PKDrmParams.Scheme.WidevineCENC) {
             return LocalAssetsManager.AssetStatus.invalid;
@@ -95,7 +95,7 @@ public class LocalAssetsManagerExo {
 
         final WidevineModularAdapter adapter = new WidevineModularAdapter(helper.context, helper.localDataStore);
         try {
-            Map<String, String> map = adapter.checkAssetStatus(drmInitData);
+            Map<String, String> map = adapter.checkAssetStatus(drmInitData, forceWidevineL3Playback);
             return assetStatusFromWidevineMap(map);
         } catch (LocalAssetsManager.RegisterException e) {
             return LocalAssetsManager.AssetStatus.invalid;

--- a/playkit/src/main/java/com/kaltura/playkit/Player.java
+++ b/playkit/src/main/java/com/kaltura/playkit/Player.java
@@ -334,6 +334,16 @@ public interface Player {
          * @return - Player Settings
          */
         Settings setMaxAudioChannelCount(int maxAudioChannelCount);
+
+        /**
+         * If the device codec is known to fail if security level L1 is used
+         * then set flag to true, it will force the player to use Widevine L3
+         * Will work only SDK level 18 or above
+         *
+         * @param isForceWidevineL3Playback - force the L3 Playback. Default is false
+         * @return - Player Settings
+         */
+        Settings setForceWidevineL3Playback(boolean isForceWidevineL3Playback);
     }
 
     /**

--- a/playkit/src/main/java/com/kaltura/playkit/Player.java
+++ b/playkit/src/main/java/com/kaltura/playkit/Player.java
@@ -340,10 +340,10 @@ public interface Player {
          * then set flag to true, it will force the player to use Widevine L3
          * Will work only SDK level 18 or above
          *
-         * @param isForceWidevineL3Playback - force the L3 Playback. Default is false
+         * @param forceWidevineL3Playback - force the L3 Playback. Default is false
          * @return - Player Settings
          */
-        Settings setForceWidevineL3Playback(boolean isForceWidevineL3Playback);
+        Settings forceWidevineL3Playback(boolean forceWidevineL3Playback);
     }
 
     /**

--- a/playkit/src/main/java/com/kaltura/playkit/drm/DeferredDrmSessionManager.java
+++ b/playkit/src/main/java/com/kaltura/playkit/drm/DeferredDrmSessionManager.java
@@ -36,6 +36,7 @@ import com.kaltura.playkit.PKDrmParams;
 import com.kaltura.playkit.PKError;
 import com.kaltura.playkit.PKLog;
 import com.kaltura.playkit.PKMediaSource;
+import com.kaltura.playkit.Utils;
 import com.kaltura.playkit.player.MediaSupport;
 import com.kaltura.playkit.player.PKPlayerErrorType;
 
@@ -52,9 +53,10 @@ import static com.kaltura.playkit.Utils.toBase64;
 public class DeferredDrmSessionManager implements DrmSessionManager, DrmSessionEventListener {
 
     private static final PKLog log = PKLog.get("DeferredDrmSessionManager");
-    private static final String WIDEVINE_SECURITY_LEVEL_1 = "L1";
-    private static final String WIDEVINE_SECURITY_LEVEL_3 = "L3";
-    private static final String SECURITY_LEVEL_PROPERTY = "securityLevel";
+
+    private String WIDEVINE_SECURITY_LEVEL_1 = "L1";
+    private String WIDEVINE_SECURITY_LEVEL_3 = "L3";
+    private String SECURITY_LEVEL_PROPERTY = "securityLevel";
 
     private Handler mainHandler;
     private final DrmCallback drmCallback;

--- a/playkit/src/main/java/com/kaltura/playkit/drm/DeferredDrmSessionManager.java
+++ b/playkit/src/main/java/com/kaltura/playkit/drm/DeferredDrmSessionManager.java
@@ -62,13 +62,15 @@ public class DeferredDrmSessionManager implements DrmSessionManager, DrmSessionE
     private LocalAssetsManager.LocalMediaSource localMediaSource = null;
     private DrmSessionManager drmSessionManager;
     private boolean allowClearLead;
+    private boolean isForceWidevineL3Playback;
 
     public DeferredDrmSessionManager(Handler mainHandler, DrmCallback drmCallback, DrmSessionListener drmSessionListener, boolean allowClearLead, boolean isForceWidevineL3Playback) {
         this.mainHandler = mainHandler;
         this.drmCallback = drmCallback;
         this.drmSessionListener = drmSessionListener;
         this.allowClearLead = allowClearLead;
-        this.drmSessionManager = getDRMSessionManager(drmCallback, allowClearLead, isForceWidevineL3Playback);
+        this.isForceWidevineL3Playback = isForceWidevineL3Playback;
+        this.drmSessionManager = getDRMSessionManager(drmCallback);
     }
 
     public interface DrmSessionListener {
@@ -85,6 +87,12 @@ public class DeferredDrmSessionManager implements DrmSessionManager, DrmSessionE
             return;
         }
 
+        drmSessionManager = new DefaultDrmSessionManager.Builder()
+                .setUuidAndExoMediaDrmProvider(MediaSupport.WIDEVINE_UUID, FrameworkMediaDrm.DEFAULT_PROVIDER)
+                .setMultiSession(true) // key rotation
+                .setPlayClearSamplesWithoutKeys(allowClearLead)
+                .build(drmCallback);
+
         if (mediaSource instanceof LocalAssetsManager.LocalMediaSource) {
             localMediaSource = (LocalAssetsManager.LocalMediaSource) mediaSource;
         } else {
@@ -97,7 +105,12 @@ public class DeferredDrmSessionManager implements DrmSessionManager, DrmSessionE
             drmSessionManager = null;
             return;
         }
-        drmCallback.setLicenseUrl(license);
+
+        if (drmCallback != null) {
+            drmCallback.setLicenseUrl(license);
+        } else {
+            log.d("DrmCallback is null");
+        }
     }
 
     @Nullable
@@ -129,12 +142,11 @@ public class DeferredDrmSessionManager implements DrmSessionManager, DrmSessionE
         return drmSessionManager.acquireSession(playbackLooper, eventDispatcher, format);
     }
 
-    private DrmSessionManager getDRMSessionManager(DrmCallback drmCallback, boolean allowClearLead, boolean isForceWidevineL3Playback) {
+    private DrmSessionManager getDRMSessionManager(DrmCallback drmCallback) {
         DrmSessionManager drmSessionManager;
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2 && isForceWidevineL3Playback) {
             drmSessionManager = new DefaultDrmSessionManager.Builder()
-                    //.setUuidAndExoMediaDrmProvider(MediaSupport.WIDEVINE_UUID, FrameworkMediaDrm.DEFAULT_PROVIDER) // Not using default provider
                     .setMultiSession(true) // key rotation
                     .setPlayClearSamplesWithoutKeys(allowClearLead)
                     .setUuidAndExoMediaDrmProvider(

--- a/playkit/src/main/java/com/kaltura/playkit/drm/DeferredDrmSessionManager.java
+++ b/playkit/src/main/java/com/kaltura/playkit/drm/DeferredDrmSessionManager.java
@@ -152,7 +152,8 @@ public class DeferredDrmSessionManager implements DrmSessionManager, DrmSessionE
                                 frameworkMediaDrm.setPropertyString(SECURITY_LEVEL_PROPERTY, WIDEVINE_SECURITY_LEVEL_3);
                                 return frameworkMediaDrm;
                             } catch (UnsupportedDrmException e) {
-                                throw new IllegalStateException(e);
+                                log.d("ForceWidevineL3Playback failed due to " + e.getMessage());
+                                return FrameworkMediaDrm.DEFAULT_PROVIDER.acquireExoMediaDrm(MediaSupport.WIDEVINE_UUID);
                             }
                         });
             } else {

--- a/playkit/src/main/java/com/kaltura/playkit/drm/DeferredDrmSessionManager.java
+++ b/playkit/src/main/java/com/kaltura/playkit/drm/DeferredDrmSessionManager.java
@@ -152,7 +152,7 @@ public class DeferredDrmSessionManager implements DrmSessionManager, DrmSessionE
                                 frameworkMediaDrm.setPropertyString(SECURITY_LEVEL_PROPERTY, WIDEVINE_SECURITY_LEVEL_3);
                                 return frameworkMediaDrm;
                             } catch (UnsupportedDrmException e) {
-                                log.d("ForceWidevineL3Playback failed due to " + e.getMessage());
+                                log.e("ForceWidevineL3Playback failed due to " + e.getMessage());
                                 return FrameworkMediaDrm.DEFAULT_PROVIDER.acquireExoMediaDrm(MediaSupport.WIDEVINE_UUID);
                             }
                         });

--- a/playkit/src/main/java/com/kaltura/playkit/drm/DeferredDrmSessionManager.java
+++ b/playkit/src/main/java/com/kaltura/playkit/drm/DeferredDrmSessionManager.java
@@ -36,7 +36,6 @@ import com.kaltura.playkit.PKDrmParams;
 import com.kaltura.playkit.PKError;
 import com.kaltura.playkit.PKLog;
 import com.kaltura.playkit.PKMediaSource;
-import com.kaltura.playkit.Utils;
 import com.kaltura.playkit.player.MediaSupport;
 import com.kaltura.playkit.player.PKPlayerErrorType;
 
@@ -64,14 +63,14 @@ public class DeferredDrmSessionManager implements DrmSessionManager, DrmSessionE
     private LocalAssetsManager.LocalMediaSource localMediaSource = null;
     private DrmSessionManager drmSessionManager;
     private boolean allowClearLead;
-    private boolean isForceWidevineL3Playback;
+    private boolean forceWidevineL3Playback;
 
-    public DeferredDrmSessionManager(Handler mainHandler, DrmCallback drmCallback, DrmSessionListener drmSessionListener, boolean allowClearLead, boolean isForceWidevineL3Playback) {
+    public DeferredDrmSessionManager(Handler mainHandler, DrmCallback drmCallback, DrmSessionListener drmSessionListener, boolean allowClearLead, boolean forceWidevineL3Playback) {
         this.mainHandler = mainHandler;
         this.drmCallback = drmCallback;
         this.drmSessionListener = drmSessionListener;
         this.allowClearLead = allowClearLead;
-        this.isForceWidevineL3Playback = isForceWidevineL3Playback;
+        this.forceWidevineL3Playback = forceWidevineL3Playback;
         this.drmSessionManager = getDRMSessionManager(drmCallback);
     }
 
@@ -144,7 +143,7 @@ public class DeferredDrmSessionManager implements DrmSessionManager, DrmSessionE
             drmSessionManagerBuilder.setMultiSession(true) // key rotation
                     .setPlayClearSamplesWithoutKeys(allowClearLead);
 
-            if (isForceWidevineL3Playback) {
+            if (forceWidevineL3Playback) {
                 drmSessionManagerBuilder.setUuidAndExoMediaDrmProvider(
                         MediaSupport.WIDEVINE_UUID,
                         uuid -> {

--- a/playkit/src/main/java/com/kaltura/playkit/drm/DrmAdapter.java
+++ b/playkit/src/main/java/com/kaltura/playkit/drm/DrmAdapter.java
@@ -52,17 +52,17 @@ public abstract class DrmAdapter {
         return new NullDrmAdapter();
     }
 
-    public abstract boolean registerAsset(final String localAssetPath, final String assetId, final String licenseUri, PKRequestParams.Adapter adapter, final LocalAssetsManager.AssetRegistrationListener listener, boolean isForceWidevineL3Playback) throws IOException;
+    public abstract boolean registerAsset(final String localAssetPath, final String assetId, final String licenseUri, PKRequestParams.Adapter adapter, final LocalAssetsManager.AssetRegistrationListener listener, boolean forceWidevineL3Playback) throws IOException;
 
-    public abstract boolean refreshAsset(final String localAssetPath, final String assetId, final String licenseUri, PKRequestParams.Adapter adapter, final LocalAssetsManager.AssetRegistrationListener listener, boolean isForceWidevineL3Playback);
+    public abstract boolean refreshAsset(final String localAssetPath, final String assetId, final String licenseUri, PKRequestParams.Adapter adapter, final LocalAssetsManager.AssetRegistrationListener listener, boolean forceWidevineL3Playback);
 
-    public abstract boolean unregisterAsset(final String localAssetPath, final String assetId, final LocalAssetsManager.AssetRemovalListener listener);
+    public abstract boolean unregisterAsset(final String localAssetPath, final String assetId, final LocalAssetsManager.AssetRemovalListener listener, boolean forceWidevineL3Playback);
 
-    public abstract boolean checkAssetStatus(final String localAssetPath, final String assetId, final LocalAssetsManager.AssetStatusListener listener);
+    public abstract boolean checkAssetStatus(final String localAssetPath, final String assetId, final LocalAssetsManager.AssetStatusListener listener, boolean forceWidevineL3Playback);
 
     private static class NullDrmAdapter extends DrmAdapter {
         @Override
-        public boolean checkAssetStatus(String localAssetPath, String assetId, LocalAssetsManager.AssetStatusListener listener) {
+        public boolean checkAssetStatus(String localAssetPath, String assetId, LocalAssetsManager.AssetStatusListener listener, boolean forceWidevineL3Playback) {
             if (listener != null) {
                 listener.onStatus(localAssetPath, -1, -1, false);
             }
@@ -70,7 +70,7 @@ public abstract class DrmAdapter {
         }
 
         @Override
-        public boolean registerAsset(String localAssetPath, String assetId, String licenseUri, PKRequestParams.Adapter adapter, LocalAssetsManager.AssetRegistrationListener listener, boolean isForceWidevineL3Playback) {
+        public boolean registerAsset(String localAssetPath, String assetId, String licenseUri, PKRequestParams.Adapter adapter, LocalAssetsManager.AssetRegistrationListener listener, boolean forceWidevineL3Playback) {
             if (listener != null) {
                 listener.onRegistered(localAssetPath);
             }
@@ -78,12 +78,12 @@ public abstract class DrmAdapter {
         }
 
         @Override
-        public boolean refreshAsset(String localAssetPath, String assetId, String licenseUri, PKRequestParams.Adapter adapter, LocalAssetsManager.AssetRegistrationListener listener, boolean isForceWidevineL3Playback) {
-            return registerAsset(localAssetPath, assetId, licenseUri, adapter, listener, isForceWidevineL3Playback);
+        public boolean refreshAsset(String localAssetPath, String assetId, String licenseUri, PKRequestParams.Adapter adapter, LocalAssetsManager.AssetRegistrationListener listener, boolean forceWidevineL3Playback) {
+            return registerAsset(localAssetPath, assetId, licenseUri, adapter, listener, forceWidevineL3Playback);
         }
 
         @Override
-        public boolean unregisterAsset(String localAssetPath, String assetId, LocalAssetsManager.AssetRemovalListener listener) {
+        public boolean unregisterAsset(String localAssetPath, String assetId, LocalAssetsManager.AssetRemovalListener listener, boolean forceWidevineL3Playback) {
             if (listener != null) {
                 listener.onRemoved(localAssetPath);
             }

--- a/playkit/src/main/java/com/kaltura/playkit/drm/DrmAdapter.java
+++ b/playkit/src/main/java/com/kaltura/playkit/drm/DrmAdapter.java
@@ -52,9 +52,9 @@ public abstract class DrmAdapter {
         return new NullDrmAdapter();
     }
 
-    public abstract boolean registerAsset(final String localAssetPath, final String assetId, final String licenseUri, PKRequestParams.Adapter adapter, final LocalAssetsManager.AssetRegistrationListener listener) throws IOException;
+    public abstract boolean registerAsset(final String localAssetPath, final String assetId, final String licenseUri, PKRequestParams.Adapter adapter, final LocalAssetsManager.AssetRegistrationListener listener, boolean isForceWidevineL3Playback) throws IOException;
 
-    public abstract boolean refreshAsset(final String localAssetPath, final String assetId, final String licenseUri, PKRequestParams.Adapter adapter, final LocalAssetsManager.AssetRegistrationListener listener);
+    public abstract boolean refreshAsset(final String localAssetPath, final String assetId, final String licenseUri, PKRequestParams.Adapter adapter, final LocalAssetsManager.AssetRegistrationListener listener, boolean isForceWidevineL3Playback);
 
     public abstract boolean unregisterAsset(final String localAssetPath, final String assetId, final LocalAssetsManager.AssetRemovalListener listener);
 
@@ -70,7 +70,7 @@ public abstract class DrmAdapter {
         }
 
         @Override
-        public boolean registerAsset(String localAssetPath, String assetId, String licenseUri, PKRequestParams.Adapter adapter, LocalAssetsManager.AssetRegistrationListener listener) {
+        public boolean registerAsset(String localAssetPath, String assetId, String licenseUri, PKRequestParams.Adapter adapter, LocalAssetsManager.AssetRegistrationListener listener, boolean isForceWidevineL3Playback) {
             if (listener != null) {
                 listener.onRegistered(localAssetPath);
             }
@@ -78,8 +78,8 @@ public abstract class DrmAdapter {
         }
 
         @Override
-        public boolean refreshAsset(String localAssetPath, String assetId, String licenseUri, PKRequestParams.Adapter adapter, LocalAssetsManager.AssetRegistrationListener listener) {
-            return registerAsset(localAssetPath, assetId, licenseUri, adapter, listener);
+        public boolean refreshAsset(String localAssetPath, String assetId, String licenseUri, PKRequestParams.Adapter adapter, LocalAssetsManager.AssetRegistrationListener listener, boolean isForceWidevineL3Playback) {
+            return registerAsset(localAssetPath, assetId, licenseUri, adapter, listener, isForceWidevineL3Playback);
         }
 
         @Override

--- a/playkit/src/main/java/com/kaltura/playkit/drm/WidevineClassicAdapter.java
+++ b/playkit/src/main/java/com/kaltura/playkit/drm/WidevineClassicAdapter.java
@@ -37,7 +37,7 @@ class WidevineClassicAdapter extends DrmAdapter {
     }
 
     @Override
-    public boolean checkAssetStatus(String localAssetPath, String assetId, final LocalAssetsManager.AssetStatusListener listener) {
+    public boolean checkAssetStatus(String localAssetPath, String assetId, final LocalAssetsManager.AssetStatusListener listener, boolean forceWidevineL3Playback) {
         WidevineClassicDrm widevineClassicDrm = new WidevineClassicDrm(context);
         WidevineClassicDrm.RightsInfo info = widevineClassicDrm.getRightsInfo(localAssetPath);
         if (listener != null) {
@@ -47,7 +47,7 @@ class WidevineClassicAdapter extends DrmAdapter {
     }
 
     @Override
-    public boolean registerAsset(final String localAssetPath, String assetId, String licenseUri, PKRequestParams.Adapter adapter, final LocalAssetsManager.AssetRegistrationListener listener, boolean isForceWidevineL3Playback) {
+    public boolean registerAsset(final String localAssetPath, String assetId, String licenseUri, PKRequestParams.Adapter adapter, final LocalAssetsManager.AssetRegistrationListener listener, boolean forceWidevineL3Playback) {
         WidevineClassicDrm widevineClassicDrm = new WidevineClassicDrm(context);
         widevineClassicDrm.setEventListener(new WidevineClassicDrm.EventListener() {
             @Override
@@ -77,12 +77,12 @@ class WidevineClassicAdapter extends DrmAdapter {
     }
 
     @Override
-    public boolean refreshAsset(String localAssetPath, String assetId, String licenseUri, PKRequestParams.Adapter adapter,LocalAssetsManager.AssetRegistrationListener listener, boolean isForceWidevineL3Playback) {
-        return registerAsset(localAssetPath, assetId, licenseUri,  null, listener, isForceWidevineL3Playback);
+    public boolean refreshAsset(String localAssetPath, String assetId, String licenseUri, PKRequestParams.Adapter adapter,LocalAssetsManager.AssetRegistrationListener listener, boolean forceWidevineL3Playback) {
+        return registerAsset(localAssetPath, assetId, licenseUri,  null, listener, forceWidevineL3Playback);
     }
 
     @Override
-    public boolean unregisterAsset(final String localAssetPath, String assetId, final LocalAssetsManager.AssetRemovalListener listener) {
+    public boolean unregisterAsset(final String localAssetPath, String assetId, final LocalAssetsManager.AssetRemovalListener listener, boolean forceWidevineL3Playback) {
         WidevineClassicDrm widevineClassicDrm = new WidevineClassicDrm(context);
         widevineClassicDrm.setEventListener(new WidevineClassicDrm.EventListener() {
             @Override

--- a/playkit/src/main/java/com/kaltura/playkit/drm/WidevineClassicAdapter.java
+++ b/playkit/src/main/java/com/kaltura/playkit/drm/WidevineClassicAdapter.java
@@ -47,7 +47,7 @@ class WidevineClassicAdapter extends DrmAdapter {
     }
 
     @Override
-    public boolean registerAsset(final String localAssetPath, String assetId, String licenseUri, PKRequestParams.Adapter adapter, final LocalAssetsManager.AssetRegistrationListener listener) {
+    public boolean registerAsset(final String localAssetPath, String assetId, String licenseUri, PKRequestParams.Adapter adapter, final LocalAssetsManager.AssetRegistrationListener listener, boolean isForceWidevineL3Playback) {
         WidevineClassicDrm widevineClassicDrm = new WidevineClassicDrm(context);
         widevineClassicDrm.setEventListener(new WidevineClassicDrm.EventListener() {
             @Override
@@ -77,8 +77,8 @@ class WidevineClassicAdapter extends DrmAdapter {
     }
 
     @Override
-    public boolean refreshAsset(String localAssetPath, String assetId, String licenseUri, PKRequestParams.Adapter adapter,LocalAssetsManager.AssetRegistrationListener listener) {
-        return registerAsset(localAssetPath, assetId, licenseUri,  null, listener);
+    public boolean refreshAsset(String localAssetPath, String assetId, String licenseUri, PKRequestParams.Adapter adapter,LocalAssetsManager.AssetRegistrationListener listener, boolean isForceWidevineL3Playback) {
+        return registerAsset(localAssetPath, assetId, licenseUri,  null, listener, isForceWidevineL3Playback);
     }
 
     @Override

--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
@@ -776,8 +776,12 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.EventListener, Met
                 errorMessage = getSourceErrorMessage(error, errorMessage);
                 break;
             case ExoPlaybackException.TYPE_RENDERER:
-                errorType = PKPlayerErrorType.RENDERER_ERROR;
                 errorMessage = getDecoderInitializationErrorMessage(error, errorMessage);
+                if (errorMessage != null && errorMessage.startsWith("DRM_ERROR:")) {
+                    errorType = PKPlayerErrorType.DRM_ERROR;
+                } else {
+                    errorType = PKPlayerErrorType.RENDERER_ERROR;
+                }
                 break;
             case ExoPlaybackException.TYPE_OUT_OF_MEMORY:
                 errorType = PKPlayerErrorType.OUT_OF_MEMORY;
@@ -829,6 +833,7 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.EventListener, Met
         } else if (cause instanceof MediaCodec.CryptoException) {
             MediaCodec.CryptoException mediaCodecCryptoException = (MediaCodec.CryptoException) cause;
             errorMessage = mediaCodecCryptoException.getMessage() != null ? mediaCodecCryptoException.getMessage() : "MediaCodec.CryptoException occurred";
+            errorMessage = "DRM_ERROR:" + errorMessage;
         }
         return errorMessage;
     }

--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
@@ -16,6 +16,7 @@ import android.content.Context;
 import android.net.Uri;
 import android.os.Handler;
 import android.os.Looper;
+import android.text.TextUtils;
 
 import androidx.annotation.NonNull;
 
@@ -336,10 +337,18 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.EventListener, Met
         } else {
             if (sourceConfig.mediaSource instanceof LocalAssetsManager.LocalMediaSource && sourceConfig.mediaSource.hasDrmParams()) {
                 final DrmCallback drmCallback = new DrmCallback(getHttpDataSourceFactory(null), playerSettings.getLicenseRequestAdapter());
-                drmSessionManager = new DeferredDrmSessionManager(mainHandler, drmCallback, drmSessionListener,playerSettings.allowClearLead());
+                drmSessionManager = new DeferredDrmSessionManager(mainHandler, drmCallback, drmSessionListener, playerSettings.allowClearLead());
                 drmSessionManager.setMediaSource(sourceConfig.mediaSource);
             }
             mediaItem = buildInternalExoMediaItem(sourceConfig, externalSubtitleList);
+        }
+
+        if (mediaItem.playbackProperties.drmConfiguration != null &&
+                mediaItem.playbackProperties.drmConfiguration.licenseUri != null &&
+                !TextUtils.isEmpty(mediaItem.playbackProperties.drmConfiguration.licenseUri.toString())) {
+            final DrmCallback drmCallback = new DrmCallback(getHttpDataSourceFactory(null), playerSettings.getLicenseRequestAdapter());
+            drmSessionManager = new DeferredDrmSessionManager(mainHandler, drmCallback, drmSessionListener,playerSettings.allowClearLead());
+            drmSessionManager.setLicenseUrl(mediaItem.playbackProperties.drmConfiguration.licenseUri.toString());
         }
 
         mediaSourceFactory.setDrmSessionManager(sourceConfig.mediaSource.hasDrmParams() ? drmSessionManager : DrmSessionManager.getDummyDrmSessionManager());

--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
@@ -13,6 +13,7 @@
 package com.kaltura.playkit.player;
 
 import android.content.Context;
+import android.media.MediaCodec;
 import android.net.Uri;
 import android.os.Handler;
 import android.os.Looper;
@@ -825,6 +826,9 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.EventListener, Met
             } else {
                 errorMessage = "Unable to instantiate decoder" + decoderInitializationException.codecInfo.name;
             }
+        } else if (cause instanceof MediaCodec.CryptoException) {
+            MediaCodec.CryptoException mediaCodecCryptoException = (MediaCodec.CryptoException) cause;
+            errorMessage = mediaCodecCryptoException.getMessage() != null ? mediaCodecCryptoException.getMessage() : "MediaCodec.CryptoException occurred";
         }
         return errorMessage;
     }

--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
@@ -341,12 +341,13 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.EventListener, Met
             mediaItem = buildInternalExoMediaItem(sourceConfig, externalSubtitleList);
         }
 
+        MediaItem.DrmConfiguration drmConfiguration = mediaItem.playbackProperties.drmConfiguration;
         if (playerSettings.isForceWidevineL3Playback() &&
-                mediaItem.playbackProperties.drmConfiguration != null &&
-                mediaItem.playbackProperties.drmConfiguration.licenseUri != null &&
-                !TextUtils.isEmpty(mediaItem.playbackProperties.drmConfiguration.licenseUri.toString())) {
+                drmConfiguration != null &&
+                drmConfiguration.licenseUri != null &&
+                !TextUtils.isEmpty(drmConfiguration.licenseUri.toString())) {
             drmSessionManager = getDeferredDRMSessionManager();
-            drmSessionManager.setLicenseUrl(mediaItem.playbackProperties.drmConfiguration.licenseUri.toString());
+            drmSessionManager.setLicenseUrl(drmConfiguration.licenseUri.toString());
         }
 
         mediaSourceFactory.setDrmSessionManager(sourceConfig.mediaSource.hasDrmParams() ? drmSessionManager : DrmSessionManager.getDummyDrmSessionManager());

--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
@@ -366,7 +366,8 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.EventListener, Met
         }
 
         MediaItem.DrmConfiguration drmConfiguration = mediaItem.playbackProperties.drmConfiguration;
-        if (playerSettings.isForceWidevineL3Playback() &&
+        if (!(sourceConfig.mediaSource instanceof LocalAssetsManager.LocalMediaSource) &&
+                playerSettings.isForceWidevineL3Playback() &&
                 drmConfiguration != null &&
                 drmConfiguration.licenseUri != null &&
                 !TextUtils.isEmpty(drmConfiguration.licenseUri.toString())) {
@@ -381,8 +382,7 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.EventListener, Met
 
     private DeferredDrmSessionManager getDeferredDRMSessionManager() {
         final DrmCallback drmCallback = new DrmCallback(getHttpDataSourceFactory(null), playerSettings.getLicenseRequestAdapter());
-        drmSessionManager = new DeferredDrmSessionManager(mainHandler, drmCallback, drmSessionListener, playerSettings.allowClearLead(), playerSettings.isForceWidevineL3Playback());
-        return drmSessionManager;
+        return new DeferredDrmSessionManager(mainHandler, drmCallback, drmSessionListener, playerSettings.allowClearLead(), playerSettings.isForceWidevineL3Playback());
     }
 
     private MediaSource buildInternalExoMediaSource(MediaItem mediaItem, PKMediaSourceConfig sourceConfig) {

--- a/playkit/src/main/java/com/kaltura/playkit/player/PlayerSettings.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/PlayerSettings.java
@@ -415,7 +415,7 @@ public class PlayerSettings implements Player.Settings {
     }
 
     @Override
-    public Player.Settings setForceWidevineL3Playback(boolean forceWidevineL3Playback) {
+    public Player.Settings forceWidevineL3Playback(boolean forceWidevineL3Playback) {
         this.forceWidevineL3Playback = forceWidevineL3Playback;
         return this;
     }

--- a/playkit/src/main/java/com/kaltura/playkit/player/PlayerSettings.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/PlayerSettings.java
@@ -53,6 +53,7 @@ public class PlayerSettings implements Player.Settings {
      * Only if IMA plugin is there then only this flag is set to true.
      */
     private boolean forceSinglePlayerEngine = false;
+    private boolean forceWidevineL3Playback = false;
 
     private PKTrackConfig preferredTextTrackConfig;
     private PKTrackConfig preferredAudioTrackConfig;
@@ -195,6 +196,10 @@ public class PlayerSettings implements Player.Settings {
 
     public int getMaxAudioChannelCount() {
         return maxAudioChannelCount;
+    }
+
+    public boolean isForceWidevineL3Playback() {
+        return forceWidevineL3Playback;
     }
 
     @Override
@@ -406,6 +411,12 @@ public class PlayerSettings implements Player.Settings {
     @Override
     public Player.Settings setMaxAudioChannelCount(int maxAudioChannelCount) {
         this.maxAudioChannelCount = maxAudioChannelCount;
+        return this;
+    }
+
+    @Override
+    public Player.Settings setForceWidevineL3Playback(boolean forceWidevineL3Playback) {
+        this.forceWidevineL3Playback = forceWidevineL3Playback;
         return this;
     }
 }


### PR DESCRIPTION
### Description of the Changes

1. If the device codec is known to fail if security level L1 is used then set flag to true, it will force the player to use Widevine L3.
API will work only SDK level 18 or above.

`player.getSettings().forceWidevineL3Playback(true);` // Online Playback
`localAssetsManager.forceWidevineL3Playback(true);` // Offline Playback

2. ErrorCallback changes: Error in case of Output Protection Level (OPL), we are sending as `DRM_ERROR` to the apps with error message `DRM_ERROR:Required output protections are not active`

**NOTE:** For point#1 Application should keep a list of device where they are facing issue for playing the assets on L1 device. Setting this flag to all the device without knowing the side effects is not recommended. It can lead to fatal errors in playback.