### PR TITLE
FEC-10801 Low Latency Configuration 

### DIFF
--- a/playkit/src/main/java/com/kaltura/playkit/Player.java
+++ b/playkit/src/main/java/com/kaltura/playkit/Player.java
@@ -349,10 +349,10 @@ public interface Player {
         /**
          * Creates a Low Latency Live playback configuration.
          *
-         * @param PKLlLiveConfiguration - Configuration for Low Latency
+         * @param pkLlLiveConfiguration - Configuration for Low Latency
          * @return - Player Settings
          */
-        Settings setLlLiveConfiguration(PKLlLiveConfiguration PKLlLiveConfiguration);
+        Settings setLlLiveConfiguration(PKLlLiveConfiguration pkLlLiveConfiguration);
     }
 
     /**

--- a/playkit/src/main/java/com/kaltura/playkit/Player.java
+++ b/playkit/src/main/java/com/kaltura/playkit/Player.java
@@ -547,6 +547,8 @@ public interface Player {
      */
     void updateSurfaceAspectRatioResizeMode(PKAspectRatioResizeMode resizeMode);
 
+    void updateLlLiveConfiguration(PKLlLiveConfiguration pkLlLiveConfiguration);
+
     /**
      * Add listener by event type as Class object. This generics-based method allows the caller to
      * avoid the otherwise required cast.

--- a/playkit/src/main/java/com/kaltura/playkit/Player.java
+++ b/playkit/src/main/java/com/kaltura/playkit/Player.java
@@ -18,7 +18,7 @@ import androidx.annotation.Nullable;
 import com.kaltura.playkit.player.ABRSettings;
 import com.kaltura.playkit.player.LoadControlBuffers;
 import com.kaltura.playkit.player.PKAspectRatioResizeMode;
-import com.kaltura.playkit.player.PKLlLiveConfiguration;
+import com.kaltura.playkit.player.PKLowLatencyConfig;
 import com.kaltura.playkit.player.PKMaxVideoSize;
 import com.kaltura.playkit.player.PlayerView;
 import com.kaltura.playkit.player.SubtitleStyleSettings;
@@ -349,10 +349,10 @@ public interface Player {
         /**
          * Creates a Low Latency Live playback configuration.
          *
-         * @param pkLlLiveConfiguration - Configuration for Low Latency
+         * @param pkLowLatencyConfig - Configuration for Low Latency
          * @return - Player Settings
          */
-        Settings setLlLiveConfiguration(PKLlLiveConfiguration pkLlLiveConfiguration);
+        Settings setPKLowLatencyConfig(PKLowLatencyConfig pkLowLatencyConfig);
     }
 
     /**
@@ -547,7 +547,10 @@ public interface Player {
      */
     void updateSurfaceAspectRatioResizeMode(PKAspectRatioResizeMode resizeMode);
 
-    void updateLlLiveConfiguration(PKLlLiveConfiguration pkLlLiveConfiguration);
+    /**
+     * Update Low Latency configuration
+     */
+    void updatePKLowLatencyConfig(PKLowLatencyConfig pkLowLatencyConfig);
 
     /**
      * Add listener by event type as Class object. This generics-based method allows the caller to

--- a/playkit/src/main/java/com/kaltura/playkit/Player.java
+++ b/playkit/src/main/java/com/kaltura/playkit/Player.java
@@ -18,6 +18,7 @@ import androidx.annotation.Nullable;
 import com.kaltura.playkit.player.ABRSettings;
 import com.kaltura.playkit.player.LoadControlBuffers;
 import com.kaltura.playkit.player.PKAspectRatioResizeMode;
+import com.kaltura.playkit.player.PKLlLiveConfiguration;
 import com.kaltura.playkit.player.PKMaxVideoSize;
 import com.kaltura.playkit.player.PlayerView;
 import com.kaltura.playkit.player.SubtitleStyleSettings;
@@ -344,6 +345,14 @@ public interface Player {
          * @return - Player Settings
          */
         Settings forceWidevineL3Playback(boolean forceWidevineL3Playback);
+
+        /**
+         * Creates a Low Latency Live playback configuration.
+         *
+         * @param PKLlLiveConfiguration - Configuration for Low Latency
+         * @return - Player Settings
+         */
+        Settings setLlLiveConfiguration(PKLlLiveConfiguration PKLlLiveConfiguration);
     }
 
     /**

--- a/playkit/src/main/java/com/kaltura/playkit/PlayerDecoratorBase.java
+++ b/playkit/src/main/java/com/kaltura/playkit/PlayerDecoratorBase.java
@@ -16,6 +16,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.kaltura.playkit.player.PKAspectRatioResizeMode;
+import com.kaltura.playkit.player.PKLlLiveConfiguration;
 import com.kaltura.playkit.player.PlayerView;
 import com.kaltura.playkit.player.SubtitleStyleSettings;
 
@@ -221,6 +222,11 @@ public class PlayerDecoratorBase implements Player {
     @Override
     public void updateSurfaceAspectRatioResizeMode(PKAspectRatioResizeMode resizeMode) {
         player.updateSurfaceAspectRatioResizeMode(resizeMode);
+    }
+
+    @Override
+    public void updateLlLiveConfiguration(PKLlLiveConfiguration pkLlLiveConfiguration) {
+        player.updateLlLiveConfiguration(pkLlLiveConfiguration);
     }
 
     @Override

--- a/playkit/src/main/java/com/kaltura/playkit/PlayerDecoratorBase.java
+++ b/playkit/src/main/java/com/kaltura/playkit/PlayerDecoratorBase.java
@@ -16,7 +16,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.kaltura.playkit.player.PKAspectRatioResizeMode;
-import com.kaltura.playkit.player.PKLlLiveConfiguration;
+import com.kaltura.playkit.player.PKLowLatencyConfig;
 import com.kaltura.playkit.player.PlayerView;
 import com.kaltura.playkit.player.SubtitleStyleSettings;
 
@@ -225,8 +225,8 @@ public class PlayerDecoratorBase implements Player {
     }
 
     @Override
-    public void updateLlLiveConfiguration(PKLlLiveConfiguration pkLlLiveConfiguration) {
-        player.updateLlLiveConfiguration(pkLlLiveConfiguration);
+    public void updatePKLowLatencyConfig(PKLowLatencyConfig pkLowLatencyConfig) {
+        player.updatePKLowLatencyConfig(pkLowLatencyConfig);
     }
 
     @Override

--- a/playkit/src/main/java/com/kaltura/playkit/PlayerEngineWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/PlayerEngineWrapper.java
@@ -2,6 +2,7 @@ package com.kaltura.playkit;
 
 import com.kaltura.playkit.player.BaseTrack;
 import com.kaltura.playkit.player.PKAspectRatioResizeMode;
+import com.kaltura.playkit.player.PKLlLiveConfiguration;
 import com.kaltura.playkit.player.PKMediaSourceConfig;
 import com.kaltura.playkit.player.PKTracks;
 import com.kaltura.playkit.player.PlayerEngine;
@@ -204,6 +205,11 @@ public class PlayerEngineWrapper implements PlayerEngine {
     @Override
     public void updateSurfaceAspectRatioResizeMode(PKAspectRatioResizeMode resizeMode) {
         playerEngine.updateSurfaceAspectRatioResizeMode(resizeMode);
+    }
+
+    @Override
+    public void updateLlLiveConfiguration(PKLlLiveConfiguration pkLlLiveConfiguration) {
+        playerEngine.updateLlLiveConfiguration(pkLlLiveConfiguration);
     }
 
     @Override

--- a/playkit/src/main/java/com/kaltura/playkit/PlayerEngineWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/PlayerEngineWrapper.java
@@ -2,7 +2,7 @@ package com.kaltura.playkit;
 
 import com.kaltura.playkit.player.BaseTrack;
 import com.kaltura.playkit.player.PKAspectRatioResizeMode;
-import com.kaltura.playkit.player.PKLlLiveConfiguration;
+import com.kaltura.playkit.player.PKLowLatencyConfig;
 import com.kaltura.playkit.player.PKMediaSourceConfig;
 import com.kaltura.playkit.player.PKTracks;
 import com.kaltura.playkit.player.PlayerEngine;
@@ -208,8 +208,8 @@ public class PlayerEngineWrapper implements PlayerEngine {
     }
 
     @Override
-    public void updateLlLiveConfiguration(PKLlLiveConfiguration pkLlLiveConfiguration) {
-        playerEngine.updateLlLiveConfiguration(pkLlLiveConfiguration);
+    public void updatePKLowLatencyConfig(PKLowLatencyConfig pkLowLatencyConfig) {
+        playerEngine.updatePKLowLatencyConfig(pkLowLatencyConfig);
     }
 
     @Override

--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
@@ -520,7 +520,7 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.EventListener, Met
                         .setClipEndPositionMs(C.TIME_END_OF_SOURCE);
 
         if (playerSettings.getPKLowLatencyConfig() != null &&
-                (sourceConfig.mediaEntryType == PKMediaEntry.MediaEntryType.Live || sourceConfig.mediaEntryType == PKMediaEntry.MediaEntryType.DvrLive)) {
+                (isLiveMediaWithDvr() || isLiveMediaWithoutDvr())) {
             builder.setLiveTargetOffsetMs(playerSettings.getPKLowLatencyConfig().getTargetOffsetMs())
                     .setLiveMinOffsetMs(playerSettings.getPKLowLatencyConfig().getMinOffsetMs())
                     .setLiveMaxOffsetMs(playerSettings.getPKLowLatencyConfig().getMaxOffsetMs())
@@ -1136,6 +1136,13 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.EventListener, Met
         return false;
     }
 
+    private boolean isLiveMediaWithDvr() {
+        if (sourceConfig != null) {
+            return (PKMediaEntry.MediaEntryType.DvrLive == sourceConfig.mediaEntryType);
+        }
+        return false;
+    }
+
     @Override
     public void destroy() {
         log.v("destroy");
@@ -1583,6 +1590,14 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.EventListener, Met
 
     @Override
     public void updatePKLowLatencyConfig(PKLowLatencyConfig pkLowLatencyConfig) {
+        if (!isLiveMediaWithDvr() && !isLiveMediaWithoutDvr()) {
+            return;
+        }
+        
+        if (pkLowLatencyConfig == null) {
+            pkLowLatencyConfig = PKLowLatencyConfig.UNSET;
+        }
+
         playerSettings.setPKLowLatencyConfig(pkLowLatencyConfig);
         if (player != null && player.getCurrentMediaItem() != null) {
             player.setMediaItem(player.getCurrentMediaItem().buildUpon()

--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
@@ -33,9 +33,7 @@ import com.kaltura.android.exoplayer2.Player;
 import com.kaltura.android.exoplayer2.SimpleExoPlayer;
 import com.kaltura.android.exoplayer2.Timeline;
 import com.kaltura.android.exoplayer2.audio.AudioAttributes;
-import com.kaltura.android.exoplayer2.drm.DefaultDrmSessionManagerProvider;
 import com.kaltura.android.exoplayer2.drm.DrmSessionManager;
-import com.kaltura.android.exoplayer2.drm.DrmSessionManagerProvider;
 import com.kaltura.android.exoplayer2.ext.okhttp.OkHttpDataSource;
 import com.kaltura.android.exoplayer2.mediacodec.MediaCodecRenderer;
 import com.kaltura.android.exoplayer2.mediacodec.MediaCodecUtil;
@@ -511,12 +509,12 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.EventListener, Met
                         .setClipStartPositionMs(0L)
                         .setClipEndPositionMs(C.TIME_END_OF_SOURCE);
 
-        if (playerSettings.getPKLlLiveConfiguration() != null) {
-            builder.setLiveTargetOffsetMs(playerSettings.getPKLlLiveConfiguration().getTargetOffsetMs())
-                    .setLiveMinOffsetMs(playerSettings.getPKLlLiveConfiguration().getMinOffsetMs())
-                    .setLiveMaxOffsetMs(playerSettings.getPKLlLiveConfiguration().getMaxOffsetMs())
-                    .setLiveMinPlaybackSpeed(playerSettings.getPKLlLiveConfiguration().getMinPlaybackSpeed())
-                    .setLiveMaxPlaybackSpeed(playerSettings.getPKLlLiveConfiguration().getMaxPlaybackSpeed());
+        if (playerSettings.getPKLowLatencyConfig() != null) {
+            builder.setLiveTargetOffsetMs(playerSettings.getPKLowLatencyConfig().getTargetOffsetMs())
+                    .setLiveMinOffsetMs(playerSettings.getPKLowLatencyConfig().getMinOffsetMs())
+                    .setLiveMaxOffsetMs(playerSettings.getPKLowLatencyConfig().getMaxOffsetMs())
+                    .setLiveMinPlaybackSpeed(playerSettings.getPKLowLatencyConfig().getMinPlaybackSpeed())
+                    .setLiveMaxPlaybackSpeed(playerSettings.getPKLowLatencyConfig().getMaxPlaybackSpeed());
         }
 
         if (format == PKMediaFormat.dash && sourceConfig.mediaSource.hasDrmParams()) {
@@ -1573,15 +1571,15 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.EventListener, Met
     }
 
     @Override
-    public void updateLlLiveConfiguration(PKLlLiveConfiguration pkLlLiveConfiguration) {
-        playerSettings.setLlLiveConfiguration(pkLlLiveConfiguration);
+    public void updatePKLowLatencyConfig(PKLowLatencyConfig pkLowLatencyConfig) {
+        playerSettings.setPKLowLatencyConfig(pkLowLatencyConfig);
         if (player != null && player.getCurrentMediaItem() != null && player.getCurrentMediaItem().buildUpon() != null) {
             player.setMediaItem(player.getCurrentMediaItem().buildUpon()
-                    .setLiveTargetOffsetMs(pkLlLiveConfiguration.getTargetOffsetMs())
-                    .setLiveMinOffsetMs(pkLlLiveConfiguration.getMinOffsetMs())
-                    .setLiveMaxOffsetMs(pkLlLiveConfiguration.getMaxOffsetMs())
-                    .setLiveMaxPlaybackSpeed(pkLlLiveConfiguration.getMaxPlaybackSpeed())
-                    .setLiveMinPlaybackSpeed(pkLlLiveConfiguration.getMinPlaybackSpeed()).build());
+                    .setLiveTargetOffsetMs(pkLowLatencyConfig.getTargetOffsetMs())
+                    .setLiveMinOffsetMs(pkLowLatencyConfig.getMinOffsetMs())
+                    .setLiveMaxOffsetMs(pkLowLatencyConfig.getMaxOffsetMs())
+                    .setLiveMaxPlaybackSpeed(pkLowLatencyConfig.getMaxPlaybackSpeed())
+                    .setLiveMinPlaybackSpeed(pkLowLatencyConfig.getMinPlaybackSpeed()).build());
         }
     }
 

--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
@@ -33,7 +33,9 @@ import com.kaltura.android.exoplayer2.Player;
 import com.kaltura.android.exoplayer2.SimpleExoPlayer;
 import com.kaltura.android.exoplayer2.Timeline;
 import com.kaltura.android.exoplayer2.audio.AudioAttributes;
+import com.kaltura.android.exoplayer2.drm.DefaultDrmSessionManagerProvider;
 import com.kaltura.android.exoplayer2.drm.DrmSessionManager;
+import com.kaltura.android.exoplayer2.drm.DrmSessionManagerProvider;
 import com.kaltura.android.exoplayer2.ext.okhttp.OkHttpDataSource;
 import com.kaltura.android.exoplayer2.mediacodec.MediaCodecRenderer;
 import com.kaltura.android.exoplayer2.mediacodec.MediaCodecUtil;
@@ -1568,6 +1570,19 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.EventListener, Met
         playerSettings.setSurfaceAspectRatioResizeMode(resizeMode);
         configureAspectRatioResizeMode();
         sendEvent(PlayerEvent.Type.ASPECT_RATIO_RESIZE_MODE_CHANGED);
+    }
+
+    @Override
+    public void updateLlLiveConfiguration(PKLlLiveConfiguration pkLlLiveConfiguration) {
+        playerSettings.setLlLiveConfiguration(pkLlLiveConfiguration);
+        if (player != null && player.getCurrentMediaItem() != null && player.getCurrentMediaItem().buildUpon() != null) {
+            player.setMediaItem(player.getCurrentMediaItem().buildUpon()
+                    .setLiveTargetOffsetMs(pkLlLiveConfiguration.getTargetOffsetMs())
+                    .setLiveMinOffsetMs(pkLlLiveConfiguration.getMinOffsetMs())
+                    .setLiveMaxOffsetMs(pkLlLiveConfiguration.getMaxOffsetMs())
+                    .setLiveMaxPlaybackSpeed(pkLlLiveConfiguration.getMaxPlaybackSpeed())
+                    .setLiveMinPlaybackSpeed(pkLlLiveConfiguration.getMinPlaybackSpeed()).build());
+        }
     }
 
     private void configureAspectRatioResizeMode() {

--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
@@ -519,7 +519,8 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.EventListener, Met
                         .setClipStartPositionMs(0L)
                         .setClipEndPositionMs(C.TIME_END_OF_SOURCE);
 
-        if (playerSettings.getPKLowLatencyConfig() != null) {
+        if (playerSettings.getPKLowLatencyConfig() != null &&
+                (sourceConfig.mediaEntryType == PKMediaEntry.MediaEntryType.Live || sourceConfig.mediaEntryType == PKMediaEntry.MediaEntryType.DvrLive)) {
             builder.setLiveTargetOffsetMs(playerSettings.getPKLowLatencyConfig().getTargetOffsetMs())
                     .setLiveMinOffsetMs(playerSettings.getPKLowLatencyConfig().getMinOffsetMs())
                     .setLiveMaxOffsetMs(playerSettings.getPKLowLatencyConfig().getMaxOffsetMs())
@@ -1583,7 +1584,7 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.EventListener, Met
     @Override
     public void updatePKLowLatencyConfig(PKLowLatencyConfig pkLowLatencyConfig) {
         playerSettings.setPKLowLatencyConfig(pkLowLatencyConfig);
-        if (player != null && player.getCurrentMediaItem() != null && player.getCurrentMediaItem().buildUpon() != null) {
+        if (player != null && player.getCurrentMediaItem() != null) {
             player.setMediaItem(player.getCurrentMediaItem().buildUpon()
                     .setLiveTargetOffsetMs(pkLowLatencyConfig.getTargetOffsetMs())
                     .setLiveMinOffsetMs(pkLowLatencyConfig.getMinOffsetMs())

--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
@@ -509,6 +509,14 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.EventListener, Met
                         .setClipStartPositionMs(0L)
                         .setClipEndPositionMs(C.TIME_END_OF_SOURCE);
 
+        if (playerSettings.getPKLlLiveConfiguration() != null) {
+            builder.setLiveTargetOffsetMs(playerSettings.getPKLlLiveConfiguration().getTargetOffsetMs())
+                    .setLiveMinOffsetMs(playerSettings.getPKLlLiveConfiguration().getMinOffsetMs())
+                    .setLiveMaxOffsetMs(playerSettings.getPKLlLiveConfiguration().getMaxOffsetMs())
+                    .setLiveMinPlaybackSpeed(playerSettings.getPKLlLiveConfiguration().getMinPlaybackSpeed())
+                    .setLiveMaxPlaybackSpeed(playerSettings.getPKLlLiveConfiguration().getMaxPlaybackSpeed());
+        }
+
         if (format == PKMediaFormat.dash && sourceConfig.mediaSource.hasDrmParams()) {
             setMediaItemBuilderDRMParams(sourceConfig, builder);
         } else  if (format == PKMediaFormat.udp) {

--- a/playkit/src/main/java/com/kaltura/playkit/player/PKLlLiveConfiguration.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/PKLlLiveConfiguration.java
@@ -1,0 +1,86 @@
+package com.kaltura.playkit.player;
+
+import com.kaltura.playkit.utils.Consts;
+
+public class PKLlLiveConfiguration {
+
+    private long targetOffsetMs = Consts.TIME_UNSET;
+    private long minOffsetMs = Consts.TIME_UNSET;
+    private long maxOffsetMs = Consts.TIME_UNSET;
+    private float minPlaybackSpeed = Consts.RATE_UNSET;
+    private float maxPlaybackSpeed = Consts.RATE_UNSET;
+
+    long getTargetOffsetMs() {
+        return targetOffsetMs;
+    }
+
+    long getMinOffsetMs() {
+        return minOffsetMs;
+    }
+
+    long getMaxOffsetMs() {
+        return maxOffsetMs;
+    }
+
+    float getMinPlaybackSpeed() {
+        return minPlaybackSpeed;
+    }
+
+    float getMaxPlaybackSpeed() {
+        return maxPlaybackSpeed;
+    }
+
+    /**
+     * Target live offset, in milliseconds, or {@link Consts#TIME_UNSET} to use the
+     * media-defined default.
+     * The player will attempt to get close to this live offset during playback if possible.
+     */
+    public PKLlLiveConfiguration setTargetOffsetMs(long targetOffsetMs) {
+        this.targetOffsetMs = targetOffsetMs;
+        return this;
+    }
+
+    /**
+     * The minimum allowed live offset, in milliseconds, or {@link Consts#TIME_UNSET}
+     * to use the media-defined default.
+     * Even when adjusting the offset to current network conditions,
+     * the player will not attempt to get below this offset during playback.
+     */
+    public PKLlLiveConfiguration setMinOffsetMs(long minOffsetMs) {
+        this.minOffsetMs = minOffsetMs;
+        return this;
+    }
+
+    /**
+     * The maximum allowed live offset, in milliseconds, or {@link Consts#TIME_UNSET}
+     * to use the media-defined default.
+     * Even when adjusting the offset to current network conditions,
+     * the player will not attempt to get above this offset during playback.
+     */
+    public PKLlLiveConfiguration setMaxOffsetMs(long maxOffsetMs) {
+        this.maxOffsetMs = maxOffsetMs;
+        return this;
+    }
+
+    /**
+     * Minimum playback speed, or {@link Consts#RATE_UNSET} to use the
+     * media-defined default.
+     * The minimum playback speed the player can use to fall back
+     * when trying to reach the target live offset.
+     */
+    public PKLlLiveConfiguration setMinPlaybackSpeed(float minPlaybackSpeed) {
+        this.minPlaybackSpeed = minPlaybackSpeed;
+        return this;
+    }
+
+    /**
+     * Maximum playback speed, or {@link Consts#RATE_UNSET} to use the
+     * media-defined default.
+     * The maximum playback speed the player can use to catch up
+     * when trying to reach the target live offset.
+     */
+    public PKLlLiveConfiguration setMaxPlaybackSpeed(float maxPlaybackSpeed) {
+        this.maxPlaybackSpeed = maxPlaybackSpeed;
+        return this;
+    }
+}

--- a/playkit/src/main/java/com/kaltura/playkit/player/PKLowLatencyConfig.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/PKLowLatencyConfig.java
@@ -14,6 +14,17 @@ public class PKLowLatencyConfig {
         this.targetOffsetMs = targetOffsetMs;
     }
 
+    /**
+     * Reset the Low Latency Configuration
+     * Now Player will use the media-defined default values.
+     */
+    public final static PKLowLatencyConfig UNSET =
+            new PKLowLatencyConfig(Consts.TIME_UNSET)
+                    .setMaxOffsetMs(Consts.TIME_UNSET)
+                    .setMinOffsetMs(Consts.TIME_UNSET)
+                    .setMinPlaybackSpeed(Consts.DEFAULT_FALLBACK_MIN_PLAYBACK_SPEED)
+                    .setMaxPlaybackSpeed(Consts.DEFAULT_FALLBACK_MAX_PLAYBACK_SPEED);
+
     public long getTargetOffsetMs() {
         return targetOffsetMs;
     }
@@ -73,7 +84,7 @@ public class PKLowLatencyConfig {
      * when trying to reach the target live offset.
      */
     public PKLowLatencyConfig setMinPlaybackSpeed(float minPlaybackSpeed) {
-        this.minPlaybackSpeed = 
+        this.minPlaybackSpeed =
                 minPlaybackSpeed != Consts.RATE_UNSET ? minPlaybackSpeed : Consts.DEFAULT_FALLBACK_MIN_PLAYBACK_SPEED;
         return this;
     }

--- a/playkit/src/main/java/com/kaltura/playkit/player/PKLowLatencyConfig.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/PKLowLatencyConfig.java
@@ -14,6 +14,7 @@ public class PKLowLatencyConfig {
         this.targetOffsetMs = targetOffsetMs;
     }
 
+    
     /**
      * Reset the Low Latency Configuration
      * Now Player will use the media-defined default values.

--- a/playkit/src/main/java/com/kaltura/playkit/player/PKLowLatencyConfig.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/PKLowLatencyConfig.java
@@ -14,7 +14,6 @@ public class PKLowLatencyConfig {
         this.targetOffsetMs = targetOffsetMs;
     }
 
-    
     /**
      * Reset the Low Latency Configuration
      * Now Player will use the media-defined default values.

--- a/playkit/src/main/java/com/kaltura/playkit/player/PKLowLatencyConfig.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/PKLowLatencyConfig.java
@@ -2,7 +2,7 @@ package com.kaltura.playkit.player;
 
 import com.kaltura.playkit.utils.Consts;
 
-public class PKLlLiveConfiguration {
+public class PKLowLatencyConfig {
 
     private long targetOffsetMs = Consts.TIME_UNSET;
     private long minOffsetMs = Consts.TIME_UNSET;
@@ -10,23 +10,23 @@ public class PKLlLiveConfiguration {
     private float minPlaybackSpeed = Consts.RATE_UNSET;
     private float maxPlaybackSpeed = Consts.RATE_UNSET;
 
-    long getTargetOffsetMs() {
+    public long getTargetOffsetMs() {
         return targetOffsetMs;
     }
 
-    long getMinOffsetMs() {
+    public long getMinOffsetMs() {
         return minOffsetMs;
     }
 
-    long getMaxOffsetMs() {
+    public long getMaxOffsetMs() {
         return maxOffsetMs;
     }
 
-    float getMinPlaybackSpeed() {
+    public float getMinPlaybackSpeed() {
         return minPlaybackSpeed;
     }
 
-    float getMaxPlaybackSpeed() {
+    public float getMaxPlaybackSpeed() {
         return maxPlaybackSpeed;
     }
 
@@ -35,7 +35,7 @@ public class PKLlLiveConfiguration {
      * media-defined default.
      * The player will attempt to get close to this live offset during playback if possible.
      */
-    public PKLlLiveConfiguration setTargetOffsetMs(long targetOffsetMs) {
+    public PKLowLatencyConfig setTargetOffsetMs(long targetOffsetMs) {
         this.targetOffsetMs = targetOffsetMs;
         return this;
     }
@@ -46,7 +46,7 @@ public class PKLlLiveConfiguration {
      * Even when adjusting the offset to current network conditions,
      * the player will not attempt to get below this offset during playback.
      */
-    public PKLlLiveConfiguration setMinOffsetMs(long minOffsetMs) {
+    public PKLowLatencyConfig setMinOffsetMs(long minOffsetMs) {
         this.minOffsetMs = minOffsetMs;
         return this;
     }
@@ -57,7 +57,7 @@ public class PKLlLiveConfiguration {
      * Even when adjusting the offset to current network conditions,
      * the player will not attempt to get above this offset during playback.
      */
-    public PKLlLiveConfiguration setMaxOffsetMs(long maxOffsetMs) {
+    public PKLowLatencyConfig setMaxOffsetMs(long maxOffsetMs) {
         this.maxOffsetMs = maxOffsetMs;
         return this;
     }
@@ -68,7 +68,7 @@ public class PKLlLiveConfiguration {
      * The minimum playback speed the player can use to fall back
      * when trying to reach the target live offset.
      */
-    public PKLlLiveConfiguration setMinPlaybackSpeed(float minPlaybackSpeed) {
+    public PKLowLatencyConfig setMinPlaybackSpeed(float minPlaybackSpeed) {
         this.minPlaybackSpeed = minPlaybackSpeed;
         return this;
     }
@@ -79,7 +79,7 @@ public class PKLlLiveConfiguration {
      * The maximum playback speed the player can use to catch up
      * when trying to reach the target live offset.
      */
-    public PKLlLiveConfiguration setMaxPlaybackSpeed(float maxPlaybackSpeed) {
+    public PKLowLatencyConfig setMaxPlaybackSpeed(float maxPlaybackSpeed) {
         this.maxPlaybackSpeed = maxPlaybackSpeed;
         return this;
     }

--- a/playkit/src/main/java/com/kaltura/playkit/player/PKLowLatencyConfig.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/PKLowLatencyConfig.java
@@ -4,11 +4,15 @@ import com.kaltura.playkit.utils.Consts;
 
 public class PKLowLatencyConfig {
 
-    private long targetOffsetMs = Consts.TIME_UNSET;
+    private long targetOffsetMs;
     private long minOffsetMs = Consts.TIME_UNSET;
     private long maxOffsetMs = Consts.TIME_UNSET;
     private float minPlaybackSpeed = Consts.DEFAULT_FALLBACK_MIN_PLAYBACK_SPEED;
     private float maxPlaybackSpeed = Consts.DEFAULT_FALLBACK_MAX_PLAYBACK_SPEED;
+
+    public PKLowLatencyConfig(long targetOffsetMs) {
+        this.targetOffsetMs = targetOffsetMs;
+    }
 
     public long getTargetOffsetMs() {
         return targetOffsetMs;

--- a/playkit/src/main/java/com/kaltura/playkit/player/PKLowLatencyConfig.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/PKLowLatencyConfig.java
@@ -7,8 +7,8 @@ public class PKLowLatencyConfig {
     private long targetOffsetMs = Consts.TIME_UNSET;
     private long minOffsetMs = Consts.TIME_UNSET;
     private long maxOffsetMs = Consts.TIME_UNSET;
-    private float minPlaybackSpeed = Consts.RATE_UNSET;
-    private float maxPlaybackSpeed = Consts.RATE_UNSET;
+    private float minPlaybackSpeed = Consts.DEFAULT_FALLBACK_MIN_PLAYBACK_SPEED;
+    private float maxPlaybackSpeed = Consts.DEFAULT_FALLBACK_MAX_PLAYBACK_SPEED;
 
     public long getTargetOffsetMs() {
         return targetOffsetMs;
@@ -69,7 +69,8 @@ public class PKLowLatencyConfig {
      * when trying to reach the target live offset.
      */
     public PKLowLatencyConfig setMinPlaybackSpeed(float minPlaybackSpeed) {
-        this.minPlaybackSpeed = minPlaybackSpeed;
+        this.minPlaybackSpeed = 
+                minPlaybackSpeed != Consts.RATE_UNSET ? minPlaybackSpeed : Consts.DEFAULT_FALLBACK_MIN_PLAYBACK_SPEED;
         return this;
     }
 
@@ -80,7 +81,8 @@ public class PKLowLatencyConfig {
      * when trying to reach the target live offset.
      */
     public PKLowLatencyConfig setMaxPlaybackSpeed(float maxPlaybackSpeed) {
-        this.maxPlaybackSpeed = maxPlaybackSpeed;
+        this.maxPlaybackSpeed =
+                maxPlaybackSpeed != Consts.RATE_UNSET ? maxPlaybackSpeed : Consts.DEFAULT_FALLBACK_MAX_PLAYBACK_SPEED;
         return this;
     }
 }

--- a/playkit/src/main/java/com/kaltura/playkit/player/PlayerController.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/PlayerController.java
@@ -679,6 +679,14 @@ public class PlayerController implements Player {
     }
 
     @Override
+    public void updateLlLiveConfiguration(PKLlLiveConfiguration pkLlLiveConfiguration) {
+        log.v("updateLlLiveConfiguration");
+        if (assertPlayerIsNotNull("updateLlLiveConfiguration")) {
+            player.updateLlLiveConfiguration(pkLlLiveConfiguration);
+        }
+    }
+
+    @Override
     public <E extends PKEvent> void addListener(Object groupId, Class<E> type, PKEvent.Listener<E> listener) {
         Assert.shouldNeverHappen();
     }

--- a/playkit/src/main/java/com/kaltura/playkit/player/PlayerController.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/PlayerController.java
@@ -679,10 +679,10 @@ public class PlayerController implements Player {
     }
 
     @Override
-    public void updateLlLiveConfiguration(PKLlLiveConfiguration pkLlLiveConfiguration) {
-        log.v("updateLlLiveConfiguration");
-        if (assertPlayerIsNotNull("updateLlLiveConfiguration")) {
-            player.updateLlLiveConfiguration(pkLlLiveConfiguration);
+    public void updatePKLowLatencyConfig(PKLowLatencyConfig pkLowLatencyConfig) {
+        log.v("updatePKLowLatencyConfig");
+        if (assertPlayerIsNotNull("updatePKLowLatencyConfig")) {
+            player.updatePKLowLatencyConfig(pkLowLatencyConfig);
         }
     }
 

--- a/playkit/src/main/java/com/kaltura/playkit/player/PlayerEngine.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/PlayerEngine.java
@@ -271,6 +271,8 @@ public interface PlayerEngine {
       *  @param resizeMode
       */
     default void updateSurfaceAspectRatioResizeMode(PKAspectRatioResizeMode resizeMode) {}
+    
+    default void updateLlLiveConfiguration(PKLlLiveConfiguration pkLlLiveConfiguration) {}
 
     /**
      * Generic getters for playkit controllers.

--- a/playkit/src/main/java/com/kaltura/playkit/player/PlayerEngine.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/PlayerEngine.java
@@ -272,7 +272,7 @@ public interface PlayerEngine {
       */
     default void updateSurfaceAspectRatioResizeMode(PKAspectRatioResizeMode resizeMode) {}
     
-    default void updateLlLiveConfiguration(PKLlLiveConfiguration pkLlLiveConfiguration) {}
+    default void updatePKLowLatencyConfig(PKLowLatencyConfig pkLowLatencyConfig) {}
 
     /**
      * Generic getters for playkit controllers.

--- a/playkit/src/main/java/com/kaltura/playkit/player/PlayerSettings.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/PlayerSettings.java
@@ -48,6 +48,7 @@ public class PlayerSettings implements Player.Settings {
     private PKAspectRatioResizeMode resizeMode = PKAspectRatioResizeMode.fit;
     private ABRSettings abrSettings = new ABRSettings();
     private VRSettings vrSettings;
+    private PKLlLiveConfiguration PKLlLiveConfiguration;
     /**
      * Flag helping to check if client app wants to use a single player instance at a time
      * Only if IMA plugin is there then only this flag is set to true.
@@ -202,6 +203,10 @@ public class PlayerSettings implements Player.Settings {
         return forceWidevineL3Playback;
     }
 
+    public PKLlLiveConfiguration getPKLlLiveConfiguration() {
+        return PKLlLiveConfiguration;
+    }
+
     @Override
     public Player.Settings setVRPlayerEnabled(boolean vrPlayerEnabled) {
         this.vrPlayerEnabled = vrPlayerEnabled;
@@ -267,7 +272,6 @@ public class PlayerSettings implements Player.Settings {
         this.preferredMediaFormat = preferredMediaFormat;
         return this;
     }
-
 
     @Override
     public Player.Settings setAllowCrossProtocolRedirect(boolean crossProtocolRedirectEnabled) {
@@ -417,6 +421,12 @@ public class PlayerSettings implements Player.Settings {
     @Override
     public Player.Settings forceWidevineL3Playback(boolean forceWidevineL3Playback) {
         this.forceWidevineL3Playback = forceWidevineL3Playback;
+        return this;
+    }
+
+    @Override
+    public Player.Settings setLlLiveConfiguration(PKLlLiveConfiguration PKLlLiveConfiguration) {
+        this.PKLlLiveConfiguration = PKLlLiveConfiguration;
         return this;
     }
 }

--- a/playkit/src/main/java/com/kaltura/playkit/player/PlayerSettings.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/PlayerSettings.java
@@ -426,7 +426,9 @@ public class PlayerSettings implements Player.Settings {
 
     @Override
     public Player.Settings setPKLowLatencyConfig(PKLowLatencyConfig pkLowLatencyConfig) {
-        this.pkLowLatencyConfig = pkLowLatencyConfig;
+        if (pkLowLatencyConfig != null) {
+            this.pkLowLatencyConfig = pkLowLatencyConfig;
+        }
         return this;
     }
 }

--- a/playkit/src/main/java/com/kaltura/playkit/player/PlayerSettings.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/PlayerSettings.java
@@ -48,7 +48,7 @@ public class PlayerSettings implements Player.Settings {
     private PKAspectRatioResizeMode resizeMode = PKAspectRatioResizeMode.fit;
     private ABRSettings abrSettings = new ABRSettings();
     private VRSettings vrSettings;
-    private PKLlLiveConfiguration PKLlLiveConfiguration;
+    private PKLlLiveConfiguration pKLlLiveConfiguration;
     /**
      * Flag helping to check if client app wants to use a single player instance at a time
      * Only if IMA plugin is there then only this flag is set to true.
@@ -204,7 +204,7 @@ public class PlayerSettings implements Player.Settings {
     }
 
     public PKLlLiveConfiguration getPKLlLiveConfiguration() {
-        return PKLlLiveConfiguration;
+        return pKLlLiveConfiguration;
     }
 
     @Override
@@ -425,8 +425,8 @@ public class PlayerSettings implements Player.Settings {
     }
 
     @Override
-    public Player.Settings setLlLiveConfiguration(PKLlLiveConfiguration PKLlLiveConfiguration) {
-        this.PKLlLiveConfiguration = PKLlLiveConfiguration;
+    public Player.Settings setLlLiveConfiguration(PKLlLiveConfiguration pKLlLiveConfiguration) {
+        this.pKLlLiveConfiguration = pKLlLiveConfiguration;
         return this;
     }
 }

--- a/playkit/src/main/java/com/kaltura/playkit/player/PlayerSettings.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/PlayerSettings.java
@@ -48,7 +48,7 @@ public class PlayerSettings implements Player.Settings {
     private PKAspectRatioResizeMode resizeMode = PKAspectRatioResizeMode.fit;
     private ABRSettings abrSettings = new ABRSettings();
     private VRSettings vrSettings;
-    private PKLlLiveConfiguration pKLlLiveConfiguration;
+    private PKLowLatencyConfig pkLowLatencyConfig;
     /**
      * Flag helping to check if client app wants to use a single player instance at a time
      * Only if IMA plugin is there then only this flag is set to true.
@@ -203,8 +203,8 @@ public class PlayerSettings implements Player.Settings {
         return forceWidevineL3Playback;
     }
 
-    public PKLlLiveConfiguration getPKLlLiveConfiguration() {
-        return pKLlLiveConfiguration;
+    public PKLowLatencyConfig getPKLowLatencyConfig() {
+        return pkLowLatencyConfig;
     }
 
     @Override
@@ -425,8 +425,8 @@ public class PlayerSettings implements Player.Settings {
     }
 
     @Override
-    public Player.Settings setLlLiveConfiguration(PKLlLiveConfiguration pKLlLiveConfiguration) {
-        this.pKLlLiveConfiguration = pKLlLiveConfiguration;
+    public Player.Settings setPKLowLatencyConfig(PKLowLatencyConfig pkLowLatencyConfig) {
+        this.pkLowLatencyConfig = pkLowLatencyConfig;
         return this;
     }
 }

--- a/playkit/src/main/java/com/kaltura/playkit/utils/Consts.java
+++ b/playkit/src/main/java/com/kaltura/playkit/utils/Consts.java
@@ -32,6 +32,11 @@ public class Consts {
     public static final int POSITION_UNSET = -1;
 
     /**
+     * Represents an unset or unknown rate.
+     */
+    public static final float RATE_UNSET = -Float.MAX_VALUE;
+
+    /**
      * Represents an unset or unknown volume.
      */
     public static final float VOLUME_UNKNOWN = -1;

--- a/playkit/src/main/java/com/kaltura/playkit/utils/Consts.java
+++ b/playkit/src/main/java/com/kaltura/playkit/utils/Consts.java
@@ -37,6 +37,18 @@ public class Consts {
     public static final float RATE_UNSET = -Float.MAX_VALUE;
 
     /**
+     * The default minimum factor by which playback can be sped up that should be used if no minimum
+     * playback speed is defined by the media.
+     */
+    public static final float DEFAULT_FALLBACK_MIN_PLAYBACK_SPEED = 0.97f;
+
+    /**
+     * The default maximum factor by which playback can be sped up that should be used if no maximum
+     * playback speed is defined by the media.
+     */
+    public static final float DEFAULT_FALLBACK_MAX_PLAYBACK_SPEED = 1.03f;
+
+    /**
      * Represents an unset or unknown volume.
      */
     public static final float VOLUME_UNKNOWN = -1;


### PR DESCRIPTION
### Description of the Changes

- This API is dedicated only for Live and DVRLive Medias.

To set the Low Latency,
```java
player.getSettings().setPKLowLatencyConfig(pkLowLatencyConfig
                    .setTargetOffsetMs(15000L).setMaxOffsetMs(12000L).setMaxPlaybackSpeed(4.0f));
```

To update the Low Latency,
```java
player.updatePKLowLatencyConfig(pkLowLatencyConfig
                        .setTargetOffsetMs(10000L).setMaxOffsetMs(7000L).setMaxPlaybackSpeed(1.5f));
```

**CAUTION:** If you want to use this API with Live -> VOD (While changing the media) content using the same player instance then you need to destroy the player before configuring the VOD media.