### PR TITLE
FEC-10996 Added requestConfiguration for DefaultHttpDataSource and OkHttpClient

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,15 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
+    ext.kotlin_version = '1.4.21'
     repositories {
         google()
         jcenter()
         maven { url "https://maven.google.com" }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.2'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath 'com.android.tools.build:gradle:4.1.3'
         classpath 'com.novoda:bintray-release:0.9.1'
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.4.21'
+    ext.kotlin_version = '1.3.61'
     repositories {
         google()
         jcenter()
@@ -9,7 +9,7 @@ buildscript {
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath 'com.android.tools.build:gradle:3.4.2'
         classpath 'com.novoda:bintray-release:0.9.1'
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip

--- a/playkit/build.gradle
+++ b/playkit/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
 apply from: 'version.gradle'
 
 android {
@@ -27,6 +28,10 @@ android {
     lintOptions {
         lintConfig file("lint.xml")
     }
+
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
 }
 
 tasks.withType(Javadoc) {
@@ -43,6 +48,10 @@ dependencies {
 
     // Ok is (optionally) used by ExoPlayer now
     api 'com.squareup.okhttp3:okhttp:3.12.11'
+
+    // Kotlin Config
+    implementation 'androidx.core:core-ktx:1.3.2'
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
     def checkerframeworkVersion = '3.3.0'
     def checkerframeworkCompatVersion = '2.5.0'

--- a/playkit/gradle-mvn-push.gradle
+++ b/playkit/gradle-mvn-push.gradle
@@ -84,7 +84,8 @@ afterEvaluate { project ->
     task androidJavadocs(type: Javadoc) {
         source = android.sourceSets.main.java.srcDirs
         classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
-        exclude ['**/PlayKitManager.java', '**/*.kt']
+        exclude '**/PlayKitManager.java'
+        exclude '**/*.kt'
     }
 
     afterEvaluate {

--- a/playkit/gradle-mvn-push.gradle
+++ b/playkit/gradle-mvn-push.gradle
@@ -84,7 +84,7 @@ afterEvaluate { project ->
     task androidJavadocs(type: Javadoc) {
         source = android.sourceSets.main.java.srcDirs
         classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
-        exclude '**/PlayKitManager.java'
+        exclude ['**/PlayKitManager.java', '**/*.kt']
     }
 
     afterEvaluate {

--- a/playkit/src/main/java/com/kaltura/playkit/PKRequestConfiguration.kt
+++ b/playkit/src/main/java/com/kaltura/playkit/PKRequestConfiguration.kt
@@ -3,9 +3,6 @@ package com.kaltura.playkit
 import androidx.annotation.NonNull
 import com.kaltura.android.exoplayer2.upstream.DefaultHttpDataSource
 
-/**
- * Request Configuration for [com.kaltura.playkit.player.ExoPlayerWrapper.getHttpDataSourceFactory]
- */
 data class PKRequestConfiguration @JvmOverloads constructor(@NonNull var crossProtocolRedirectEnabled: Boolean = false,
                                                             @NonNull var readTimeoutMs: Int = DefaultHttpDataSource.DEFAULT_READ_TIMEOUT_MILLIS,
                                                             @NonNull var connectTimeoutMs: Int = DefaultHttpDataSource.DEFAULT_CONNECT_TIMEOUT_MILLIS)

--- a/playkit/src/main/java/com/kaltura/playkit/PKRequestConfiguration.kt
+++ b/playkit/src/main/java/com/kaltura/playkit/PKRequestConfiguration.kt
@@ -1,0 +1,11 @@
+package com.kaltura.playkit
+
+import androidx.annotation.NonNull
+import com.kaltura.android.exoplayer2.upstream.DefaultHttpDataSource
+
+/**
+ * Request Configuration for [com.kaltura.playkit.player.ExoPlayerWrapper.getHttpDataSourceFactory]
+ */
+data class PKRequestConfiguration @JvmOverloads constructor(@NonNull var crossProtocolRedirectEnabled: Boolean = false,
+                                                            @NonNull var readTimeoutMs: Int = DefaultHttpDataSource.DEFAULT_READ_TIMEOUT_MILLIS,
+                                                            @NonNull var connectTimeoutMs: Int = DefaultHttpDataSource.DEFAULT_CONNECT_TIMEOUT_MILLIS)

--- a/playkit/src/main/java/com/kaltura/playkit/PKRequestConfiguration.kt
+++ b/playkit/src/main/java/com/kaltura/playkit/PKRequestConfiguration.kt
@@ -3,6 +3,9 @@ package com.kaltura.playkit
 import androidx.annotation.NonNull
 import com.kaltura.android.exoplayer2.upstream.DefaultHttpDataSource
 
+/**
+ * Request Configuration for [com.kaltura.playkit.player.ExoPlayerWrapper.getHttpDataSourceFactory]
+ */
 data class PKRequestConfiguration @JvmOverloads constructor(@NonNull var crossProtocolRedirectEnabled: Boolean = false,
                                                             @NonNull var readTimeoutMs: Int = DefaultHttpDataSource.DEFAULT_READ_TIMEOUT_MILLIS,
                                                             @NonNull var connectTimeoutMs: Int = DefaultHttpDataSource.DEFAULT_CONNECT_TIMEOUT_MILLIS)

--- a/playkit/src/main/java/com/kaltura/playkit/Player.java
+++ b/playkit/src/main/java/com/kaltura/playkit/Player.java
@@ -91,12 +91,16 @@ public interface Player {
         Settings useTextureView(boolean useTextureView);
 
         /**
+         * This method is deprecated.
+         * Please use {@link com.kaltura.playkit.PKRequestConfiguration} to set crossProtocolRedirect
+         *
          * Decide if player should do cross protocol redirect or not. By default it will be always set
          * to false.
          *
          * @param crossProtocolRedirectEnabled - true if should do cross protocol redirect.
          * @return - Player Settings.
          */
+        @Deprecated
         Settings setAllowCrossProtocolRedirect(boolean crossProtocolRedirectEnabled);
 
         /**
@@ -354,6 +358,14 @@ public interface Player {
          * @return - Player Settings
          */
         Settings setPKLowLatencyConfig(PKLowLatencyConfig pkLowLatencyConfig);
+
+        /**
+         * Creates a request configuration for HttpDataSourceFactory {@link com.kaltura.playkit.player.ExoPlayerWrapper}.
+         *
+         * @param pkRequestConfiguration - Configuration for PKRequestConfiguration
+         * @return - Player Settings
+         */
+        Settings setPKRequestConfig(PKRequestConfiguration pkRequestConfiguration);
     }
 
     /**

--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
@@ -648,7 +648,11 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.EventListener, Met
     private HttpDataSource.Factory getHttpDataSourceFactory(Map<String, String> headers) {
         HttpDataSource.Factory httpDataSourceFactory;
         final String userAgent = getUserAgent(context);
-        final boolean crossProtocolRedirectEnabled = playerSettings.crossProtocolRedirectEnabled();
+
+        final PKRequestConfiguration pkRequestConfiguration = playerSettings.getPkRequestConfiguration();
+        final int connectTimeout = pkRequestConfiguration.getConnectTimeoutMs();
+        final int readTimeout = pkRequestConfiguration.getReadTimeoutMs();
+        final boolean crossProtocolRedirectEnabled = pkRequestConfiguration.getCrossProtocolRedirectEnabled();
 
         if (CookieHandler.getDefault() == null) {
             CookieHandler.setDefault(new CookieManager(null, CookiePolicy.ACCEPT_ORIGINAL_SERVER));
@@ -660,8 +664,8 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.EventListener, Met
                     .cookieJar(NativeCookieJarBridge.sharedCookieJar)
                     .followRedirects(true)
                     .followSslRedirects(crossProtocolRedirectEnabled)
-                    .connectTimeout(DefaultHttpDataSource.DEFAULT_CONNECT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)
-                    .readTimeout(DefaultHttpDataSource.DEFAULT_READ_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+                    .connectTimeout(connectTimeout, TimeUnit.MILLISECONDS)
+                    .readTimeout(readTimeout, TimeUnit.MILLISECONDS);
             builder.eventListener(analyticsAggregator);
             if (profiler != Profiler.NOOP) {
                 final okhttp3.EventListener.Factory okListenerFactory = profiler.getOkListenerFactory();
@@ -673,8 +677,8 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.EventListener, Met
         } else {
 
             httpDataSourceFactory = new DefaultHttpDataSource.Factory().setUserAgent(userAgent)
-                    .setConnectTimeoutMs(DefaultHttpDataSource.DEFAULT_CONNECT_TIMEOUT_MILLIS)
-                    .setReadTimeoutMs(DefaultHttpDataSource.DEFAULT_READ_TIMEOUT_MILLIS)
+                    .setConnectTimeoutMs(connectTimeout)
+                    .setReadTimeoutMs(readTimeout)
                     .setAllowCrossProtocolRedirects(crossProtocolRedirectEnabled);
         }
 

--- a/playkit/src/main/java/com/kaltura/playkit/player/PlayerSettings.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/PlayerSettings.java
@@ -13,6 +13,7 @@
 package com.kaltura.playkit.player;
 
 import com.kaltura.playkit.PKMediaFormat;
+import com.kaltura.playkit.PKRequestConfiguration;
 import com.kaltura.playkit.PKRequestParams;
 import com.kaltura.playkit.PKSubtitlePreference;
 import com.kaltura.playkit.PKTrackConfig;
@@ -49,6 +50,7 @@ public class PlayerSettings implements Player.Settings {
     private ABRSettings abrSettings = new ABRSettings();
     private VRSettings vrSettings;
     private PKLowLatencyConfig pkLowLatencyConfig;
+    private PKRequestConfiguration pkRequestConfiguration;
     /**
      * Flag helping to check if client app wants to use a single player instance at a time
      * Only if IMA plugin is there then only this flag is set to true.
@@ -207,6 +209,10 @@ public class PlayerSettings implements Player.Settings {
         return pkLowLatencyConfig;
     }
 
+    public PKRequestConfiguration getPkRequestConfiguration() {
+        return pkRequestConfiguration;
+    }
+
     @Override
     public Player.Settings setVRPlayerEnabled(boolean vrPlayerEnabled) {
         this.vrPlayerEnabled = vrPlayerEnabled;
@@ -272,7 +278,7 @@ public class PlayerSettings implements Player.Settings {
         this.preferredMediaFormat = preferredMediaFormat;
         return this;
     }
-
+    
     @Override
     public Player.Settings setAllowCrossProtocolRedirect(boolean crossProtocolRedirectEnabled) {
         this.crossProtocolRedirectEnabled = crossProtocolRedirectEnabled;
@@ -428,6 +434,18 @@ public class PlayerSettings implements Player.Settings {
     public Player.Settings setPKLowLatencyConfig(PKLowLatencyConfig pkLowLatencyConfig) {
         if (pkLowLatencyConfig != null) {
             this.pkLowLatencyConfig = pkLowLatencyConfig;
+        }
+        return this;
+    }
+
+    @Override
+    public Player.Settings setPKRequestConfig(PKRequestConfiguration pkRequestConfiguration) {
+        if (pkRequestConfiguration != null) {
+            this.pkRequestConfiguration = pkRequestConfiguration;
+        } else {
+            PKRequestConfiguration requestConfiguration = new PKRequestConfiguration();
+            requestConfiguration.setCrossProtocolRedirectEnabled(crossProtocolRedirectEnabled());
+            this.pkRequestConfiguration = requestConfiguration;
         }
         return this;
     }

--- a/playkit/src/main/java/com/kaltura/playkit/player/PlayerSettings.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/PlayerSettings.java
@@ -210,6 +210,11 @@ public class PlayerSettings implements Player.Settings {
     }
 
     public PKRequestConfiguration getPkRequestConfiguration() {
+        if (pkRequestConfiguration == null) {
+            PKRequestConfiguration requestConfiguration = new PKRequestConfiguration();
+            requestConfiguration.setCrossProtocolRedirectEnabled(crossProtocolRedirectEnabled());
+            pkRequestConfiguration = requestConfiguration;
+        }
         return pkRequestConfiguration;
     }
 
@@ -442,10 +447,6 @@ public class PlayerSettings implements Player.Settings {
     public Player.Settings setPKRequestConfig(PKRequestConfiguration pkRequestConfiguration) {
         if (pkRequestConfiguration != null) {
             this.pkRequestConfiguration = pkRequestConfiguration;
-        } else {
-            PKRequestConfiguration requestConfiguration = new PKRequestConfiguration();
-            requestConfiguration.setCrossProtocolRedirectEnabled(crossProtocolRedirectEnabled());
-            this.pkRequestConfiguration = requestConfiguration;
         }
         return this;
     }


### PR DESCRIPTION
- Configured Kotlin
- Updated Gradle version to v4.1.3
- Marked `setAllowCrossProtocolEnabled` deprecated

Example:
`player.getSettings().setPKRequestConfig(new PKRequestConfiguration(...));`

Deprecated Player Setting:
`player.getSettings().setAllowCrossProtocolRedirect();`