### PR TITLE
FEC-11187 Protect parsing error on CustomDashManifestParser 

### DIFF
--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
@@ -950,7 +950,7 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.EventListener, Met
             //if the track info new -> map the available tracks. and when ready, notify user about available tracks.
             if (shouldGetTracksInfo) {
                 CustomDashManifest customDashManifest = null;
-                if (dashLastDataSink != null && player.getCurrentManifest() instanceof DashManifest) {
+                if (!TextUtils.isEmpty(dashManifestString) && dashLastDataSink != null && player.getCurrentManifest() instanceof DashManifest) {
                     byte[] bytes = dashLastDataSink.getData();
                     try {
                         customDashManifest = new CustomDashManifestParser().parse(player.getMediaItemAt(0).playbackProperties.uri, dashManifestString);


### PR DESCRIPTION
- Protect parsing error on CustomDashManifestParser due to dashManifestString
- Now, we are not parsing manifest for image tracks if dashManifestString is empty
