### PR TITLE
FEC-11512 Added retry policy for player on MediaSource level

### DIFF
--- a/playkit/src/main/java/com/kaltura/playkit/PKRequestConfig.kt
+++ b/playkit/src/main/java/com/kaltura/playkit/PKRequestConfig.kt
@@ -2,10 +2,13 @@ package com.kaltura.playkit
 
 import androidx.annotation.NonNull
 import com.kaltura.android.exoplayer2.upstream.DefaultHttpDataSource
+import com.kaltura.playkit.player.CustomLoadErrorHandlingPolicy
 
 /**
  * Request Configuration for [com.kaltura.playkit.player.ExoPlayerWrapper.getHttpDataSourceFactory]
  */
 data class PKRequestConfig @JvmOverloads constructor(@NonNull var crossProtocolRedirectEnabled: Boolean = false,
                                                      @NonNull var readTimeoutMs: Int = DefaultHttpDataSource.DEFAULT_READ_TIMEOUT_MILLIS,
-                                                     @NonNull var connectTimeoutMs: Int = DefaultHttpDataSource.DEFAULT_CONNECT_TIMEOUT_MILLIS)
+                                                     @NonNull var connectTimeoutMs: Int = DefaultHttpDataSource.DEFAULT_CONNECT_TIMEOUT_MILLIS,
+                                                     /* Minimum number of times to retry a load in the case of a load error, before propagating the error.*/
+                                                     @NonNull var minLoadableRetryCount: Int = CustomLoadErrorHandlingPolicy.MIN_LOADABLE_RETRY_COUNT)

--- a/playkit/src/main/java/com/kaltura/playkit/PKRequestConfig.kt
+++ b/playkit/src/main/java/com/kaltura/playkit/PKRequestConfig.kt
@@ -10,5 +10,5 @@ import com.kaltura.playkit.player.CustomLoadErrorHandlingPolicy
 data class PKRequestConfig @JvmOverloads constructor(@NonNull var crossProtocolRedirectEnabled: Boolean = false,
                                                      @NonNull var readTimeoutMs: Int = DefaultHttpDataSource.DEFAULT_READ_TIMEOUT_MILLIS,
                                                      @NonNull var connectTimeoutMs: Int = DefaultHttpDataSource.DEFAULT_CONNECT_TIMEOUT_MILLIS,
-                                                     /* Minimum number of times to retry a load in the case of a load error, before propagating the error.*/
-                                                     @NonNull var minRetryCount: Int = CustomLoadErrorHandlingPolicy.MIN_LOADABLE_RETRY_COUNT)
+                                                     /* Maximum number of times to retry a load in the case of a load error, before propagating the error.*/
+                                                     @NonNull var maxRetries: Int = CustomLoadErrorHandlingPolicy.MAX_LOADABLE_RETRY_COUNT)

--- a/playkit/src/main/java/com/kaltura/playkit/PKRequestConfig.kt
+++ b/playkit/src/main/java/com/kaltura/playkit/PKRequestConfig.kt
@@ -11,4 +11,4 @@ data class PKRequestConfig @JvmOverloads constructor(@NonNull var crossProtocolR
                                                      @NonNull var readTimeoutMs: Int = DefaultHttpDataSource.DEFAULT_READ_TIMEOUT_MILLIS,
                                                      @NonNull var connectTimeoutMs: Int = DefaultHttpDataSource.DEFAULT_CONNECT_TIMEOUT_MILLIS,
                                                      /* Maximum number of times to retry a load in the case of a load error, before propagating the error.*/
-                                                     @NonNull var maxRetries: Int = CustomLoadErrorHandlingPolicy.MAX_LOADABLE_RETRY_COUNT)
+                                                     @NonNull var maxRetries: Int = CustomLoadErrorHandlingPolicy.LOADABLE_RETRY_COUNT_UNSET)

--- a/playkit/src/main/java/com/kaltura/playkit/PKRequestConfig.kt
+++ b/playkit/src/main/java/com/kaltura/playkit/PKRequestConfig.kt
@@ -11,4 +11,4 @@ data class PKRequestConfig @JvmOverloads constructor(@NonNull var crossProtocolR
                                                      @NonNull var readTimeoutMs: Int = DefaultHttpDataSource.DEFAULT_READ_TIMEOUT_MILLIS,
                                                      @NonNull var connectTimeoutMs: Int = DefaultHttpDataSource.DEFAULT_CONNECT_TIMEOUT_MILLIS,
                                                      /* Minimum number of times to retry a load in the case of a load error, before propagating the error.*/
-                                                     @NonNull var minLoadableRetryCount: Int = CustomLoadErrorHandlingPolicy.MIN_LOADABLE_RETRY_COUNT)
+                                                     @NonNull var minRetryCount: Int = CustomLoadErrorHandlingPolicy.MIN_LOADABLE_RETRY_COUNT)

--- a/playkit/src/main/java/com/kaltura/playkit/player/CustomLoadErrorHandlingPolicy.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/CustomLoadErrorHandlingPolicy.java
@@ -17,16 +17,16 @@ public class CustomLoadErrorHandlingPolicy extends DefaultLoadErrorHandlingPolic
     private static final PKLog log = PKLog.get("LoadErrorHandlingPolicy");
 
     private CustomLoadErrorHandlingPolicy.OnTextTrackLoadErrorListener textTrackLoadErrorListener;
-    public static final int MIN_LOADABLE_RETRY_COUNT = -1;
+    public static final int MAX_LOADABLE_RETRY_COUNT = -1;
     private static final int DATA_TYPE_MEDIA_PROGRESSIVE_LIVE = 7;
-    private final int minimumLoadableRetryCount;
+    private final int maximumLoadableRetryCount;
 
     public interface OnTextTrackLoadErrorListener {
         void onTextTrackLoadError(PKError currentError);
     }
 
-    public CustomLoadErrorHandlingPolicy(int minimumLoadableRetryCount) {
-        this.minimumLoadableRetryCount = minimumLoadableRetryCount;
+    public CustomLoadErrorHandlingPolicy(int maximumLoadableRetryCount) {
+        this.maximumLoadableRetryCount = maximumLoadableRetryCount;
     }
 
     public void setOnTextTrackErrorListener(CustomLoadErrorHandlingPolicy.OnTextTrackLoadErrorListener onTextTrackErrorListener) {
@@ -56,8 +56,8 @@ public class CustomLoadErrorHandlingPolicy extends DefaultLoadErrorHandlingPolic
 
     @Override
     public int getMinimumLoadableRetryCount(int dataType) {
-        if (minimumLoadableRetryCount > MIN_LOADABLE_RETRY_COUNT && dataType != DATA_TYPE_MEDIA_PROGRESSIVE_LIVE) {
-            return minimumLoadableRetryCount;
+        if (maximumLoadableRetryCount > 0 && dataType != DATA_TYPE_MEDIA_PROGRESSIVE_LIVE) {
+            return maximumLoadableRetryCount;
         }
         return super.getMinimumLoadableRetryCount(dataType);
     }

--- a/playkit/src/main/java/com/kaltura/playkit/player/CustomLoadErrorHandlingPolicy.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/CustomLoadErrorHandlingPolicy.java
@@ -18,7 +18,7 @@ public class CustomLoadErrorHandlingPolicy extends DefaultLoadErrorHandlingPolic
 
     private CustomLoadErrorHandlingPolicy.OnTextTrackLoadErrorListener textTrackLoadErrorListener;
     public static final int MAX_LOADABLE_RETRY_COUNT = -1;
-    private static final int DATA_TYPE_MEDIA_PROGRESSIVE_LIVE = 7;
+    private static final int DATA_TYPE_MEDIA_PROGRESSIVE_LIVE = 7; // For progressive live medias, we are keeping the retry count 6(default in ExoPlayer).
     private final int maximumLoadableRetryCount;
 
     public interface OnTextTrackLoadErrorListener {
@@ -26,7 +26,7 @@ public class CustomLoadErrorHandlingPolicy extends DefaultLoadErrorHandlingPolic
     }
 
     public CustomLoadErrorHandlingPolicy(int maximumLoadableRetryCount) {
-        this.maximumLoadableRetryCount = maximumLoadableRetryCount;
+        this.maximumLoadableRetryCount = setMaximumLoadableRetryCount(maximumLoadableRetryCount);
     }
 
     public void setOnTextTrackErrorListener(CustomLoadErrorHandlingPolicy.OnTextTrackLoadErrorListener onTextTrackErrorListener) {
@@ -56,10 +56,17 @@ public class CustomLoadErrorHandlingPolicy extends DefaultLoadErrorHandlingPolic
 
     @Override
     public int getMinimumLoadableRetryCount(int dataType) {
-        if (maximumLoadableRetryCount > 0 && dataType != DATA_TYPE_MEDIA_PROGRESSIVE_LIVE) {
+        if (maximumLoadableRetryCount != MAX_LOADABLE_RETRY_COUNT && dataType != DATA_TYPE_MEDIA_PROGRESSIVE_LIVE) {
             return maximumLoadableRetryCount;
         }
         return super.getMinimumLoadableRetryCount(dataType);
+    }
+
+    private int setMaximumLoadableRetryCount(int retryCount) {
+        if (retryCount > MAX_LOADABLE_RETRY_COUNT && retryCount <=1) {
+            return retryCount; // In case of count 0 or 1, retry is still 2 times from ExoPlayer
+        }
+        return retryCount > 0 ? retryCount - 1 : MAX_LOADABLE_RETRY_COUNT;
     }
 
     private Uri getPathSegmentUri(IOException ioException) {

--- a/playkit/src/main/java/com/kaltura/playkit/player/CustomLoadErrorHandlingPolicy.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/CustomLoadErrorHandlingPolicy.java
@@ -14,7 +14,7 @@ import java.io.IOException;
 
 public class CustomLoadErrorHandlingPolicy extends DefaultLoadErrorHandlingPolicy {
 
-    private static final PKLog log = PKLog.get("ExternalTextTrackLoadError");
+    private static final PKLog log = PKLog.get("LoadErrorHandlingPolicy");
 
     private CustomLoadErrorHandlingPolicy.OnTextTrackLoadErrorListener textTrackLoadErrorListener;
     public static final int MIN_LOADABLE_RETRY_COUNT = -1;
@@ -32,10 +32,6 @@ public class CustomLoadErrorHandlingPolicy extends DefaultLoadErrorHandlingPolic
     public void setOnTextTrackErrorListener(CustomLoadErrorHandlingPolicy.OnTextTrackLoadErrorListener onTextTrackErrorListener) {
         this.textTrackLoadErrorListener = onTextTrackErrorListener;
     }
-
-    //public void onTextTrackLoadError(PKError currentError) {
-    //    textTrackLoadErrorListener.onTextTrackLoadError(currentError);
-    //} TODO // need to test with vtt errored file
 
     @Override
     public long getRetryDelayMsFor(LoadErrorInfo loadErrorInfo) {
@@ -60,7 +56,7 @@ public class CustomLoadErrorHandlingPolicy extends DefaultLoadErrorHandlingPolic
 
     @Override
     public int getMinimumLoadableRetryCount(int dataType) {
-        if (minimumLoadableRetryCount != MIN_LOADABLE_RETRY_COUNT && dataType != DATA_TYPE_MEDIA_PROGRESSIVE_LIVE) {
+        if (minimumLoadableRetryCount > MIN_LOADABLE_RETRY_COUNT && dataType != DATA_TYPE_MEDIA_PROGRESSIVE_LIVE) {
             return minimumLoadableRetryCount;
         }
         return super.getMinimumLoadableRetryCount(dataType);

--- a/playkit/src/main/java/com/kaltura/playkit/player/CustomLoadErrorHandlingPolicy.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/CustomLoadErrorHandlingPolicy.java
@@ -53,6 +53,13 @@ public class CustomLoadErrorHandlingPolicy extends DefaultLoadErrorHandlingPolic
         }
     }
 
+    /**
+     * Delay in the each retry request
+     * Max delay is 5ms (Formula: min((loadErrorInfo.errorCount - 1) * 1000, 5000))
+     *
+     * @param loadErrorInfo Object containing the data about error
+     * @return delay
+     */
     private long getRetryDelay(LoadErrorInfo loadErrorInfo) {
         if (maximumLoadableRetryCount > LOADABLE_RETRY_COUNT_UNSET && loadErrorInfo.errorCount >= maximumLoadableRetryCount) {
             return Consts.TIME_UNSET;
@@ -60,6 +67,13 @@ public class CustomLoadErrorHandlingPolicy extends DefaultLoadErrorHandlingPolic
         return super.getRetryDelayMsFor(loadErrorInfo);
     }
 
+    /**
+     * Override the retry count on ExoPlayer.
+     * This retry count is valid for all types of Player requests (Manifest/DRM/Chunk)
+     *
+     * @param dataType Type of request
+     * @return No of retries
+     */
     @Override
     public int getMinimumLoadableRetryCount(int dataType) {
         if (maximumLoadableRetryCount > LOADABLE_RETRY_COUNT_UNSET) {

--- a/playkit/src/main/java/com/kaltura/playkit/player/CustomLoadErrorHandlingPolicy.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/CustomLoadErrorHandlingPolicy.java
@@ -12,17 +12,24 @@ import com.kaltura.playkit.utils.Consts;
 
 import java.io.IOException;
 
-public class ExternalTextTrackLoadErrorPolicy extends DefaultLoadErrorHandlingPolicy {
+public class CustomLoadErrorHandlingPolicy extends DefaultLoadErrorHandlingPolicy {
 
     private static final PKLog log = PKLog.get("ExternalTextTrackLoadError");
 
-    private ExternalTextTrackLoadErrorPolicy.OnTextTrackLoadErrorListener textTrackLoadErrorListener;
+    private CustomLoadErrorHandlingPolicy.OnTextTrackLoadErrorListener textTrackLoadErrorListener;
+    public static final int MIN_LOADABLE_RETRY_COUNT = -1;
+    private static final int DATA_TYPE_MEDIA_PROGRESSIVE_LIVE = 7;
+    private final int minimumLoadableRetryCount;
 
     public interface OnTextTrackLoadErrorListener {
         void onTextTrackLoadError(PKError currentError);
     }
 
-    public void setOnTextTrackErrorListener(ExternalTextTrackLoadErrorPolicy.OnTextTrackLoadErrorListener onTextTrackErrorListener) {
+    public CustomLoadErrorHandlingPolicy(int minimumLoadableRetryCount) {
+        this.minimumLoadableRetryCount = minimumLoadableRetryCount;
+    }
+
+    public void setOnTextTrackErrorListener(CustomLoadErrorHandlingPolicy.OnTextTrackLoadErrorListener onTextTrackErrorListener) {
         this.textTrackLoadErrorListener = onTextTrackErrorListener;
     }
 
@@ -49,6 +56,14 @@ public class ExternalTextTrackLoadErrorPolicy extends DefaultLoadErrorHandlingPo
         } else {
             return super.getRetryDelayMsFor(loadErrorInfo);
         }
+    }
+
+    @Override
+    public int getMinimumLoadableRetryCount(int dataType) {
+        if (minimumLoadableRetryCount != MIN_LOADABLE_RETRY_COUNT && dataType != DATA_TYPE_MEDIA_PROGRESSIVE_LIVE) {
+            return minimumLoadableRetryCount;
+        }
+        return super.getMinimumLoadableRetryCount(dataType);
     }
 
     private Uri getPathSegmentUri(IOException ioException) {

--- a/playkit/src/main/java/com/kaltura/playkit/player/CustomLoadErrorHandlingPolicy.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/CustomLoadErrorHandlingPolicy.java
@@ -63,7 +63,7 @@ public class CustomLoadErrorHandlingPolicy extends DefaultLoadErrorHandlingPolic
     }
 
     private int setMaximumLoadableRetryCount(int retryCount) {
-        if (retryCount > MAX_LOADABLE_RETRY_COUNT && retryCount <=1) {
+        if (retryCount > MAX_LOADABLE_RETRY_COUNT && retryCount <= 1) {
             return retryCount; // In case of count 0 or 1, retry is still 2 times from ExoPlayer
         }
         return retryCount > 0 ? retryCount - 1 : MAX_LOADABLE_RETRY_COUNT;

--- a/playkit/src/main/java/com/kaltura/playkit/player/CustomLoadErrorHandlingPolicy.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/CustomLoadErrorHandlingPolicy.java
@@ -18,7 +18,6 @@ public class CustomLoadErrorHandlingPolicy extends DefaultLoadErrorHandlingPolic
 
     private CustomLoadErrorHandlingPolicy.OnTextTrackLoadErrorListener textTrackLoadErrorListener;
     public static final int LOADABLE_RETRY_COUNT_UNSET = 0;
-    private static final int DATA_TYPE_MEDIA_PROGRESSIVE_LIVE = 7; // For progressive live medias, we are keeping the retry count 6(default in ExoPlayer).
     private final int maximumLoadableRetryCount;
 
     public interface OnTextTrackLoadErrorListener {
@@ -57,9 +56,16 @@ public class CustomLoadErrorHandlingPolicy extends DefaultLoadErrorHandlingPolic
     private long getRetryDelay(LoadErrorInfo loadErrorInfo) {
         if (maximumLoadableRetryCount > LOADABLE_RETRY_COUNT_UNSET && loadErrorInfo.errorCount >= maximumLoadableRetryCount) {
             return Consts.TIME_UNSET;
-        } else {
-            return super.getRetryDelayMsFor(loadErrorInfo);
         }
+        return super.getRetryDelayMsFor(loadErrorInfo);
+    }
+
+    @Override
+    public int getMinimumLoadableRetryCount(int dataType) {
+        if (maximumLoadableRetryCount > LOADABLE_RETRY_COUNT_UNSET) {
+            return maximumLoadableRetryCount;
+        }
+        return super.getMinimumLoadableRetryCount(dataType);
     }
 
     private Uri getPathSegmentUri(IOException ioException) {

--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoAnalyticsAggregator.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoAnalyticsAggregator.java
@@ -86,6 +86,7 @@ class ExoAnalyticsAggregator extends EventListener implements AnalyticsListener 
 
     @Override
     public void onLoadError(@NonNull EventTime eventTime, @NonNull LoadEventInfo loadEventInfo, @NonNull MediaLoadData mediaLoadData, @NonNull IOException error, boolean wasCanceled) {
+        log.v("onLoadError Uri = " + loadEventInfo.uri.toString());
         onLoadCompleted(eventTime, loadEventInfo, mediaLoadData);   // in case there are bytes loaded
         if (listener != null) {
             listener.onLoadError(error, wasCanceled);

--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
@@ -589,7 +589,7 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.Listener, Metadata
 
     private void addCustomLoadErrorPolicy() {
         if (customLoadErrorHandlingPolicy == null) {
-            customLoadErrorHandlingPolicy = new CustomLoadErrorHandlingPolicy(playerSettings.getPKRequestConfig().getMinLoadableRetryCount());
+            customLoadErrorHandlingPolicy = new CustomLoadErrorHandlingPolicy(playerSettings.getPKRequestConfig().getMinRetryCount());
         }
     }
 

--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
@@ -589,7 +589,7 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.Listener, Metadata
 
     private void addCustomLoadErrorPolicy() {
         if (customLoadErrorHandlingPolicy == null) {
-            customLoadErrorHandlingPolicy = new CustomLoadErrorHandlingPolicy(playerSettings.getPKRequestConfig().getMinRetryCount());
+            customLoadErrorHandlingPolicy = new CustomLoadErrorHandlingPolicy(playerSettings.getPKRequestConfig().getMaxRetries());
         }
     }
 


### PR DESCRIPTION
Application can pass the max retry for Player requests (Manifest, DRM, Segment/Chunk). It is a single value applicable for all the Player requests.

`player.getSettings().setPKRequestConfig(new PKRequestConfig(crossProtocolRedirectEnabled, readTimeoutMs, connectTimeoutMs, maxRetries));`

`maxRetries`: Maximum number of times to retry a load in the case of a load error, before propagating the error.

To unset the no of retries, use `CustomLoadErrorHandlingPolicy.LOADABLE_RETRY_COUNT_UNSET`. 

For change media, update the `playerSettings` object (with updated maxRetry if required) before player prepare. 
You can not update the retry value during media playback.

**NOTE:** _As mentioned that this retry is applicable for all player request. So in case, if player is trying to load multiple chunks (video/audio) then for each chunk retry count will be applicable. (If player is retrying with 1 audio and 1 video chunk and if count is 5 then for video chunk 5 times and for audio chunk it will be 5 times)_