### PR TITLE
FEC-11539 - add builder class for PKRequestConfig instead of creating using constructor

### DIFF
--- a/playkit/src/main/java/com/kaltura/playkit/PKRequestConfig.kt
+++ b/playkit/src/main/java/com/kaltura/playkit/PKRequestConfig.kt
@@ -11,4 +11,36 @@ data class PKRequestConfig @JvmOverloads constructor(@NonNull var crossProtocolR
                                                      @NonNull var readTimeoutMs: Int = DefaultHttpDataSource.DEFAULT_READ_TIMEOUT_MILLIS,
                                                      @NonNull var connectTimeoutMs: Int = DefaultHttpDataSource.DEFAULT_CONNECT_TIMEOUT_MILLIS,
                                                      /* Maximum number of times to retry a load in the case of a load error, before propagating the error.*/
-                                                     @NonNull var maxRetries: Int = CustomLoadErrorHandlingPolicy.LOADABLE_RETRY_COUNT_UNSET)
+                                                     @NonNull var maxRetries: Int = CustomLoadErrorHandlingPolicy.LOADABLE_RETRY_COUNT_UNSET) {
+    class Builder() {
+
+        private var crossProtocolRedirectEnabled: Boolean = false
+        private var readTimeoutMs: Int = DefaultHttpDataSource.DEFAULT_READ_TIMEOUT_MILLIS
+        private var connectTimeoutMs: Int = DefaultHttpDataSource.DEFAULT_CONNECT_TIMEOUT_MILLIS
+        private var maxRetries = CustomLoadErrorHandlingPolicy.LOADABLE_RETRY_COUNT_UNSET
+
+        fun setCrossProtocolRedirectEnabled(crossProtocolRedirectEnabled: Boolean): Builder {
+            this.crossProtocolRedirectEnabled = crossProtocolRedirectEnabled
+            return this
+        }
+
+        fun setReadTimeoutMs(readTimeoutMs: Int): Builder {
+            this.readTimeoutMs = readTimeoutMs
+            return this
+        }
+
+        fun setConnectTimeoutMs(connectTimeoutMs: Int): Builder {
+            this.connectTimeoutMs = connectTimeoutMs
+            return this
+        }
+
+        fun setMaxRetries(maxRetries: Int): Builder {
+            this.maxRetries = maxRetries
+            return this
+        }
+
+        fun build(): PKRequestConfig {
+            return PKRequestConfig(crossProtocolRedirectEnabled, readTimeoutMs, connectTimeoutMs, maxRetries)
+        }
+    }
+}


### PR DESCRIPTION
for playkit 

```
player.getSettings().setPKRequestConfig(new PKRequestConfig.Builder().setConnectTimeoutMs(10000).setMaxRetries(5).setCrossProtocolRedirectEnabled(true).build());

```

for KalturaPlayer

```
in initOptions:
.setPKRequestConfig(PKRequestConfig.Builder().setCrossProtocolRedirectEnabled(true).setMaxRetries(5).build())

```