### PR TITLE
FEC-11741 ExoPlayer Upgrade to v2.16.1

### DIFF
--- a/playkit/build.gradle
+++ b/playkit/build.gradle
@@ -41,7 +41,7 @@ tasks.withType(Javadoc) {
 
 dependencies {
 
-    def exoPlayerVersion = '2.15.1'
+    def exoPlayerVersion = '2.16.1'
     api "com.kaltura.playkit:kexoplayer:$exoPlayerVersion"
 
     api 'com.google.code.gson:gson:2.8.6'

--- a/playkit/src/main/java/com/kaltura/android/exoplayer2/dashmanifestparser/CustomAdaptationSet.java
+++ b/playkit/src/main/java/com/kaltura/android/exoplayer2/dashmanifestparser/CustomAdaptationSet.java
@@ -1,5 +1,6 @@
 package com.kaltura.android.exoplayer2.dashmanifestparser;
 
+import com.kaltura.android.exoplayer2.C;
 import com.kaltura.android.exoplayer2.source.dash.manifest.Descriptor;
 import com.kaltura.android.exoplayer2.source.dash.manifest.Representation;
 
@@ -22,11 +23,8 @@ public class CustomAdaptationSet {
      */
     public final int id;
 
-    /**
-     * The type of the adaptation set. One of the {@link com.kaltura.android.exoplayer2.C}
-     * {@code TRACK_TYPE_*} constants.
-     */
-    public final int type;
+    /** The {@link C.TrackType track type} of the adaptation set. */
+    public final @C.TrackType int type;
 
     /**
      * {@link Representation}s in the adaptation set.
@@ -47,8 +45,7 @@ public class CustomAdaptationSet {
     /**
      * @param id A non-negative identifier for the adaptation set that's unique in the scope of its
      *     containing period, or {@link #ID_UNSET} if not specified.
-     * @param type The type of the adaptation set. One of the {@link com.kaltura.android.exoplayer2.C}
-     *     {@code TRACK_TYPE_*} constants.
+     * @param type The {@link C.TrackType track type} of the adaptation set.
      * @param representations {@link Representation}s in the adaptation set.
      * @param accessibilityDescriptors Accessibility descriptors in the adaptation set.
      * @param essentialProperties Essential properties in the adaptation set.
@@ -56,7 +53,7 @@ public class CustomAdaptationSet {
      */
     public CustomAdaptationSet(
             int id,
-            int type,
+            @C.TrackType int type,
             List<CustomRepresentation> representations,
             List<Descriptor> accessibilityDescriptors,
             List<Descriptor> essentialProperties,

--- a/playkit/src/main/java/com/kaltura/android/exoplayer2/dashmanifestparser/CustomDashManifest.java
+++ b/playkit/src/main/java/com/kaltura/android/exoplayer2/dashmanifestparser/CustomDashManifest.java
@@ -8,6 +8,7 @@ import com.kaltura.android.exoplayer2.offline.StreamKey;
 import com.kaltura.android.exoplayer2.source.dash.manifest.ProgramInformation;
 import com.kaltura.android.exoplayer2.source.dash.manifest.ServiceDescriptionElement;
 import com.kaltura.android.exoplayer2.source.dash.manifest.UtcTimingElement;
+import com.kaltura.android.exoplayer2.util.Util;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -159,7 +160,7 @@ public class CustomDashManifest implements FilterableManifest<CustomDashManifest
     }
 
     public final long getPeriodDurationUs(int index) {
-        return C.msToUs(getPeriodDurationMs(index));
+        return Util.msToUs(getPeriodDurationMs(index));
     }
 
     @Override
@@ -215,7 +216,7 @@ public class CustomDashManifest implements FilterableManifest<CustomDashManifest
             List<CustomRepresentation> representations = adaptationSet.representations;
             ArrayList<CustomRepresentation> copyRepresentations = new ArrayList<>();
             do {
-                CustomRepresentation representation = representations.get(key.trackIndex);
+                CustomRepresentation representation = representations.get(key.streamIndex);
                 copyRepresentations.add(representation);
                 key = keys.poll();
             } while (key.periodIndex == periodIndex && key.groupIndex == adaptationSetIndex);

--- a/playkit/src/main/java/com/kaltura/android/exoplayer2/dashmanifestparser/CustomFormat.java
+++ b/playkit/src/main/java/com/kaltura/android/exoplayer2/dashmanifestparser/CustomFormat.java
@@ -1,22 +1,33 @@
 package com.kaltura.android.exoplayer2.dashmanifestparser;
 
+import android.os.Bundle;
 import android.os.Parcel;
 import android.os.Parcelable;
+
+import androidx.annotation.IntDef;
 import androidx.annotation.Nullable;
 
+import com.google.common.base.Joiner;
+import com.kaltura.android.exoplayer2.Bundleable;
 import com.kaltura.android.exoplayer2.C;
+import com.kaltura.android.exoplayer2.Format;
 import com.kaltura.android.exoplayer2.drm.DrmInitData;
-import com.kaltura.android.exoplayer2.drm.ExoMediaCrypto;
-import com.kaltura.android.exoplayer2.drm.UnsupportedMediaCrypto;
 import com.kaltura.android.exoplayer2.metadata.Metadata;
-import com.kaltura.android.exoplayer2.util.Assertions;
+import com.kaltura.android.exoplayer2.util.BundleableUtil;
 import com.kaltura.android.exoplayer2.util.MimeTypes;
 import com.kaltura.android.exoplayer2.util.Util;
 import com.kaltura.android.exoplayer2.video.ColorInfo;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.UUID;
 
 /**
  * Represents a media format.
@@ -94,7 +105,7 @@ import java.util.List;
  *   <li>{@link #accessibilityChannel}
  * </ul>
  */
-public final class CustomFormat implements Parcelable {
+public final class CustomFormat implements Bundleable {
 
     /**
      * Builds {@link CustomFormat} instances.
@@ -110,8 +121,8 @@ public final class CustomFormat implements Parcelable {
         @Nullable private String id;
         @Nullable private String label;
         @Nullable private String language;
-        @C.SelectionFlags private int selectionFlags;
-        @C.RoleFlags private int roleFlags;
+        private @C.SelectionFlags int selectionFlags;
+        private @C.RoleFlags int roleFlags;
         private int averageBitrate;
         private int peakBitrate;
         @Nullable private String codecs;
@@ -154,7 +165,7 @@ public final class CustomFormat implements Parcelable {
 
         // Provided by the source.
 
-        @Nullable private Class<? extends ExoMediaCrypto> exoMediaCryptoType;
+        @C.CryptoType private int cryptoType;
 
         /** Creates a new instance with default values. */
         public Builder() {
@@ -175,6 +186,8 @@ public final class CustomFormat implements Parcelable {
             pcmEncoding = NO_VALUE;
             // Text specific.
             accessibilityChannel = NO_VALUE;
+            // Provided by the source.
+            cryptoType = C.CRYPTO_TYPE_NONE;
         }
 
         /**
@@ -218,7 +231,7 @@ public final class CustomFormat implements Parcelable {
             // Text specific.
             this.accessibilityChannel = format.accessibilityChannel;
             // Provided by the source.
-            this.exoMediaCryptoType = format.exoMediaCryptoType;
+            this.cryptoType = format.cryptoType;
         }
 
         /**
@@ -570,14 +583,13 @@ public final class CustomFormat implements Parcelable {
         // Provided by source.
 
         /**
-         * Sets {@link CustomFormat#exoMediaCryptoType}. The default value is {@code null}.
+         * Sets {@link Format#cryptoType}. The default value is {@link C#CRYPTO_TYPE_NONE}.
          *
-         * @param exoMediaCryptoType The {@link CustomFormat#exoMediaCryptoType}.
+         * @param cryptoType The {@link C.CryptoType}.
          * @return The builder.
          */
-        public Builder setExoMediaCryptoType(
-                @Nullable Class<? extends ExoMediaCrypto> exoMediaCryptoType) {
-            this.exoMediaCryptoType = exoMediaCryptoType;
+        public Builder setCryptoType(@C.CryptoType int cryptoType) {
+            this.cryptoType = cryptoType;
             return this;
         }
 
@@ -597,6 +609,8 @@ public final class CustomFormat implements Parcelable {
      */
     public static final long OFFSET_SAMPLE_RELATIVE = Long.MAX_VALUE;
 
+    private static final CustomFormat DEFAULT = new Builder().build();
+
     /** An identifier for the format, or null if unknown or not applicable. */
     @Nullable public final String id;
     /** The human readable label, or null if unknown or not applicable. */
@@ -604,9 +618,9 @@ public final class CustomFormat implements Parcelable {
     /** The language as an IETF BCP 47 conformant tag, or null if unknown or not applicable. */
     @Nullable public final String language;
     /** Track selection flags. */
-    @C.SelectionFlags public final int selectionFlags;
+    public final @C.SelectionFlags int selectionFlags;
     /** Track role flags. */
-    @C.RoleFlags public final int roleFlags;
+    public final @C.RoleFlags int roleFlags;
     /**
      * The average bitrate in bits per second, or {@link #NO_VALUE} if unknown or not applicable. The
      * way in which this field is populated depends on the type of media to which the format
@@ -749,11 +763,12 @@ public final class CustomFormat implements Parcelable {
     // Provided by source.
 
     /**
-     * The type of {@link ExoMediaCrypto} that will be associated with the content this format
-     * describes, or {@code null} if the content is not encrypted. Cannot be null if {@link
-     * #drmInitData} is non-null.
+     * The type of crypto that must be used to decode samples associated with this format, or {@link
+     * C#CRYPTO_TYPE_NONE} if the content is not encrypted. Cannot be {@link C#CRYPTO_TYPE_NONE} if
+     * {@link #drmInitData} is non-null, but may be {@link C#CRYPTO_TYPE_UNSUPPORTED} to indicate that
+     * the samples are encrypted using an unsupported crypto type.
      */
-    @Nullable public final Class<? extends ExoMediaCrypto> exoMediaCryptoType;
+    @C.CryptoType public final int cryptoType;
 
     // Lazily initialized hashcode.
     private int hashCode;
@@ -1215,61 +1230,12 @@ public final class CustomFormat implements Parcelable {
         // Text specific.
         accessibilityChannel = builder.accessibilityChannel;
         // Provided by source.
-        if (builder.exoMediaCryptoType == null && drmInitData != null) {
-            // Encrypted content must always have a non-null exoMediaCryptoType.
-            exoMediaCryptoType = UnsupportedMediaCrypto.class;
+        if (builder.cryptoType == C.CRYPTO_TYPE_NONE && drmInitData != null) {
+            // Encrypted content cannot use CRYPTO_TYPE_NONE.
+            cryptoType = C.CRYPTO_TYPE_UNSUPPORTED;
         } else {
-            exoMediaCryptoType = builder.exoMediaCryptoType;
+            cryptoType = builder.cryptoType;
         }
-    }
-
-    // Some fields are deprecated but they're still assigned below.
-    @SuppressWarnings({"ResourceType"})
-    /* package */ CustomFormat(Parcel in) {
-        id = in.readString();
-        label = in.readString();
-        language = in.readString();
-        selectionFlags = in.readInt();
-        roleFlags = in.readInt();
-        averageBitrate = in.readInt();
-        peakBitrate = in.readInt();
-        bitrate = peakBitrate != NO_VALUE ? peakBitrate : averageBitrate;
-        codecs = in.readString();
-        metadata = in.readParcelable(Metadata.class.getClassLoader());
-        formatThumbnailInfo = in.readParcelable(FormatThumbnailInfo.class.getClassLoader());
-        // Container specific.
-        containerMimeType = in.readString();
-        // Sample specific.
-        sampleMimeType = in.readString();
-        maxInputSize = in.readInt();
-        int initializationDataSize = in.readInt();
-        initializationData = new ArrayList<>(initializationDataSize);
-        for (int i = 0; i < initializationDataSize; i++) {
-            initializationData.add(Assertions.checkNotNull(in.createByteArray()));
-        }
-        drmInitData = in.readParcelable(DrmInitData.class.getClassLoader());
-        subsampleOffsetUs = in.readLong();
-        // Video specific.
-        width = in.readInt();
-        height = in.readInt();
-        frameRate = in.readFloat();
-        rotationDegrees = in.readInt();
-        pixelWidthHeightRatio = in.readFloat();
-        boolean hasProjectionData = Util.readBoolean(in);
-        projectionData = hasProjectionData ? in.createByteArray() : null;
-        stereoMode = in.readInt();
-        colorInfo = in.readParcelable(ColorInfo.class.getClassLoader());
-        // Audio specific.
-        channelCount = in.readInt();
-        sampleRate = in.readInt();
-        pcmEncoding = in.readInt();
-        encoderDelay = in.readInt();
-        encoderPadding = in.readInt();
-        // Text specific.
-        accessibilityChannel = in.readInt();
-        // Provided by source.
-        // Encrypted content must always have a non-null exoMediaCryptoType.
-        exoMediaCryptoType = drmInitData != null ? UnsupportedMediaCrypto.class : null;
     }
 
     /** Returns a {@link CustomFormat.Builder} initialized with the values of this instance. */
@@ -1308,7 +1274,7 @@ public final class CustomFormat implements Parcelable {
             return this;
         }
 
-        int trackType = MimeTypes.getTrackType(sampleMimeType);
+        @C.TrackType int trackType = MimeTypes.getTrackType(sampleMimeType);
 
         // Use manifest value only.
         @Nullable String id = manifestFormat.id;
@@ -1413,10 +1379,9 @@ public final class CustomFormat implements Parcelable {
         return buildUpon().setWidth(width).setHeight(height).build();
     }
 
-    /** Returns a copy of this format with the specified {@link #exoMediaCryptoType}. */
-    public CustomFormat copyWithExoMediaCryptoType(
-            @Nullable Class<? extends ExoMediaCrypto> exoMediaCryptoType) {
-        return buildUpon().setExoMediaCryptoType(exoMediaCryptoType).build();
+    /** Returns a copy of this format with the specified {@link #cryptoType}. */
+    public CustomFormat copyWithCryptoType(@C.CryptoType int cryptoType) {
+        return buildUpon().setCryptoType(cryptoType).build();
     }
 
     /**
@@ -1497,7 +1462,7 @@ public final class CustomFormat implements Parcelable {
             // Text specific.
             result = 31 * result + accessibilityChannel;
             // Provided by the source.
-            result = 31 * result + (exoMediaCryptoType == null ? 0 : exoMediaCryptoType.hashCode());
+            result = 31 * result + cryptoType;
             hashCode = result;
         }
         return hashCode;
@@ -1532,9 +1497,9 @@ public final class CustomFormat implements Parcelable {
                 && encoderDelay == other.encoderDelay
                 && encoderPadding == other.encoderPadding
                 && accessibilityChannel == other.accessibilityChannel
+                && cryptoType == other.cryptoType
                 && Float.compare(frameRate, other.frameRate) == 0
                 && Float.compare(pixelWidthHeightRatio, other.pixelWidthHeightRatio) == 0
-                && Util.areEqual(exoMediaCryptoType, other.exoMediaCryptoType)
                 && Util.areEqual(id, other.id)
                 && Util.areEqual(label, other.label)
                 && Util.areEqual(codecs, other.codecs)
@@ -1583,6 +1548,26 @@ public final class CustomFormat implements Parcelable {
         if (format.codecs != null) {
             builder.append(", codecs=").append(format.codecs);
         }
+        if (format.drmInitData != null) {
+            Set<String> schemes = new LinkedHashSet<>();
+            for (int i = 0; i < format.drmInitData.schemeDataCount; i++) {
+                UUID schemeUuid = format.drmInitData.get(i).uuid;
+                if (schemeUuid.equals(C.COMMON_PSSH_UUID)) {
+                    schemes.add("cenc");
+                } else if (schemeUuid.equals(C.CLEARKEY_UUID)) {
+                    schemes.add("clearkey");
+                } else if (schemeUuid.equals(C.PLAYREADY_UUID)) {
+                    schemes.add("playready");
+                } else if (schemeUuid.equals(C.WIDEVINE_UUID)) {
+                    schemes.add("widevine");
+                } else if (schemeUuid.equals(C.UUID_NIL)) {
+                    schemes.add("universal");
+                } else {
+                    schemes.add("unknown (" + schemeUuid + ")");
+                }
+            }
+            builder.append(", drm=[").append(Joiner.on(',').join(schemes)).append(']');
+        }
         if (format.width != NO_VALUE && format.height != NO_VALUE) {
             builder.append(", res=").append(format.width).append("x").append(format.height);
         }
@@ -1601,75 +1586,216 @@ public final class CustomFormat implements Parcelable {
         if (format.label != null) {
             builder.append(", label=").append(format.label);
         }
+        if ((format.roleFlags & C.ROLE_FLAG_TRICK_PLAY) != 0) {
+            builder.append(", trick-play-track");
+        }
         return builder.toString();
     }
 
-    // Parcelable implementation.
+    // Bundleable implementation.
+    @Documented
+    @Retention(RetentionPolicy.SOURCE)
+    @IntDef({
+            FIELD_ID,
+            FIELD_LABEL,
+            FIELD_LANGUAGE,
+            FIELD_SELECTION_FLAGS,
+            FIELD_ROLE_FLAGS,
+            FIELD_AVERAGE_BITRATE,
+            FIELD_PEAK_BITRATE,
+            FIELD_CODECS,
+            FIELD_METADATA,
+            FIELD_CONTAINER_MIME_TYPE,
+            FIELD_SAMPLE_MIME_TYPE,
+            FIELD_MAX_INPUT_SIZE,
+            FIELD_INITIALIZATION_DATA,
+            FIELD_DRM_INIT_DATA,
+            FIELD_SUBSAMPLE_OFFSET_US,
+            FIELD_WIDTH,
+            FIELD_HEIGHT,
+            FIELD_FRAME_RATE,
+            FIELD_ROTATION_DEGREES,
+            FIELD_PIXEL_WIDTH_HEIGHT_RATIO,
+            FIELD_PROJECTION_DATA,
+            FIELD_STEREO_MODE,
+            FIELD_COLOR_INFO,
+            FIELD_CHANNEL_COUNT,
+            FIELD_SAMPLE_RATE,
+            FIELD_PCM_ENCODING,
+            FIELD_ENCODER_DELAY,
+            FIELD_ENCODER_PADDING,
+            FIELD_ACCESSIBILITY_CHANNEL,
+            FIELD_CRYPTO_TYPE,
+    })
+    private @interface FieldNumber {}
+
+    private static final int FIELD_ID = 0;
+    private static final int FIELD_LABEL = 1;
+    private static final int FIELD_LANGUAGE = 2;
+    private static final int FIELD_SELECTION_FLAGS = 3;
+    private static final int FIELD_ROLE_FLAGS = 4;
+    private static final int FIELD_AVERAGE_BITRATE = 5;
+    private static final int FIELD_PEAK_BITRATE = 6;
+    private static final int FIELD_CODECS = 7;
+    private static final int FIELD_METADATA = 8;
+    private static final int FIELD_CONTAINER_MIME_TYPE = 9;
+    private static final int FIELD_SAMPLE_MIME_TYPE = 10;
+    private static final int FIELD_MAX_INPUT_SIZE = 11;
+    private static final int FIELD_INITIALIZATION_DATA = 12;
+    private static final int FIELD_DRM_INIT_DATA = 13;
+    private static final int FIELD_SUBSAMPLE_OFFSET_US = 14;
+    private static final int FIELD_WIDTH = 15;
+    private static final int FIELD_HEIGHT = 16;
+    private static final int FIELD_FRAME_RATE = 17;
+    private static final int FIELD_ROTATION_DEGREES = 18;
+    private static final int FIELD_PIXEL_WIDTH_HEIGHT_RATIO = 19;
+    private static final int FIELD_PROJECTION_DATA = 20;
+    private static final int FIELD_STEREO_MODE = 21;
+    private static final int FIELD_COLOR_INFO = 22;
+    private static final int FIELD_CHANNEL_COUNT = 23;
+    private static final int FIELD_SAMPLE_RATE = 24;
+    private static final int FIELD_PCM_ENCODING = 25;
+    private static final int FIELD_ENCODER_DELAY = 26;
+    private static final int FIELD_ENCODER_PADDING = 27;
+    private static final int FIELD_ACCESSIBILITY_CHANNEL = 28;
+    private static final int FIELD_CRYPTO_TYPE = 29;
 
     @Override
-    public int describeContents() {
-        return 0;
-    }
-
-    @Override
-    public void writeToParcel(Parcel dest, int flags) {
-        dest.writeString(id);
-        dest.writeString(label);
-        dest.writeString(language);
-        dest.writeInt(selectionFlags);
-        dest.writeInt(roleFlags);
-        dest.writeInt(averageBitrate);
-        dest.writeInt(peakBitrate);
-        dest.writeString(codecs);
-        dest.writeParcelable(metadata, 0);
-        dest.writeParcelable(formatThumbnailInfo, 0);
+    public Bundle toBundle() {
+        Bundle bundle = new Bundle();
+        bundle.putString(keyForField(FIELD_ID), id);
+        bundle.putString(keyForField(FIELD_LABEL), label);
+        bundle.putString(keyForField(FIELD_LANGUAGE), language);
+        bundle.putInt(keyForField(FIELD_SELECTION_FLAGS), selectionFlags);
+        bundle.putInt(keyForField(FIELD_ROLE_FLAGS), roleFlags);
+        bundle.putInt(keyForField(FIELD_AVERAGE_BITRATE), averageBitrate);
+        bundle.putInt(keyForField(FIELD_PEAK_BITRATE), peakBitrate);
+        bundle.putString(keyForField(FIELD_CODECS), codecs);
+        // Metadata is currently not Bundleable because Metadata.Entry is an Interface,
+        // which would be difficult to unbundle in a backward compatible way.
+        // The entries are additionally of limited usefulness to remote processes.
+        bundle.putParcelable(keyForField(FIELD_METADATA), metadata);
         // Container specific.
-        dest.writeString(containerMimeType);
+        bundle.putString(keyForField(FIELD_CONTAINER_MIME_TYPE), containerMimeType);
         // Sample specific.
-        dest.writeString(sampleMimeType);
-        dest.writeInt(maxInputSize);
-        int initializationDataSize = initializationData.size();
-        dest.writeInt(initializationDataSize);
-        for (int i = 0; i < initializationDataSize; i++) {
-            dest.writeByteArray(initializationData.get(i));
+        bundle.putString(keyForField(FIELD_SAMPLE_MIME_TYPE), sampleMimeType);
+        bundle.putInt(keyForField(FIELD_MAX_INPUT_SIZE), maxInputSize);
+        for (int i = 0; i < initializationData.size(); i++) {
+            bundle.putByteArray(keyForInitializationData(i), initializationData.get(i));
         }
-        dest.writeParcelable(drmInitData, 0);
-        dest.writeLong(subsampleOffsetUs);
+        // DrmInitData doesn't need to be Bundleable as it's only used in the playing process to
+        // initialize the decoder.
+        bundle.putParcelable(keyForField(FIELD_DRM_INIT_DATA), drmInitData);
+        bundle.putLong(keyForField(FIELD_SUBSAMPLE_OFFSET_US), subsampleOffsetUs);
         // Video specific.
-        dest.writeInt(width);
-        dest.writeInt(height);
-        dest.writeFloat(frameRate);
-        dest.writeInt(rotationDegrees);
-        dest.writeFloat(pixelWidthHeightRatio);
-        Util.writeBoolean(dest, projectionData != null);
-        if (projectionData != null) {
-            dest.writeByteArray(projectionData);
-        }
-        dest.writeInt(stereoMode);
-        dest.writeParcelable(colorInfo, flags);
+        bundle.putInt(keyForField(FIELD_WIDTH), width);
+        bundle.putInt(keyForField(FIELD_HEIGHT), height);
+        bundle.putFloat(keyForField(FIELD_FRAME_RATE), frameRate);
+        bundle.putInt(keyForField(FIELD_ROTATION_DEGREES), rotationDegrees);
+        bundle.putFloat(keyForField(FIELD_PIXEL_WIDTH_HEIGHT_RATIO), pixelWidthHeightRatio);
+        bundle.putByteArray(keyForField(FIELD_PROJECTION_DATA), projectionData);
+        bundle.putInt(keyForField(FIELD_STEREO_MODE), stereoMode);
+        bundle.putBundle(keyForField(FIELD_COLOR_INFO), BundleableUtil.toNullableBundle(colorInfo));
         // Audio specific.
-        dest.writeInt(channelCount);
-        dest.writeInt(sampleRate);
-        dest.writeInt(pcmEncoding);
-        dest.writeInt(encoderDelay);
-        dest.writeInt(encoderPadding);
+        bundle.putInt(keyForField(FIELD_CHANNEL_COUNT), channelCount);
+        bundle.putInt(keyForField(FIELD_SAMPLE_RATE), sampleRate);
+        bundle.putInt(keyForField(FIELD_PCM_ENCODING), pcmEncoding);
+        bundle.putInt(keyForField(FIELD_ENCODER_DELAY), encoderDelay);
+        bundle.putInt(keyForField(FIELD_ENCODER_PADDING), encoderPadding);
         // Text specific.
-        dest.writeInt(accessibilityChannel);
+        bundle.putInt(keyForField(FIELD_ACCESSIBILITY_CHANNEL), accessibilityChannel);
+        // Source specific.
+        bundle.putInt(keyForField(FIELD_CRYPTO_TYPE), cryptoType);
+        return bundle;
     }
 
-    public static final Creator<CustomFormat> CREATOR = new Creator<CustomFormat>() {
+    /** Object that can restore {@code Format} from a {@link Bundle}. */
+    public static final Creator<CustomFormat> CREATOR = CustomFormat::fromBundle;
 
-        @Override
-        public CustomFormat createFromParcel(Parcel in) {
-            return new CustomFormat(in);
+    private static CustomFormat fromBundle(Bundle bundle) {
+        Builder builder = new Builder();
+        BundleableUtil.ensureClassLoader(bundle);
+        builder
+                .setId(defaultIfNull(bundle.getString(keyForField(FIELD_ID)), DEFAULT.id))
+                .setLabel(defaultIfNull(bundle.getString(keyForField(FIELD_LABEL)), DEFAULT.label))
+                .setLanguage(defaultIfNull(bundle.getString(keyForField(FIELD_LANGUAGE)), DEFAULT.language))
+                .setSelectionFlags(
+                        bundle.getInt(keyForField(FIELD_SELECTION_FLAGS), DEFAULT.selectionFlags))
+                .setRoleFlags(bundle.getInt(keyForField(FIELD_ROLE_FLAGS), DEFAULT.roleFlags))
+                .setAverageBitrate(
+                        bundle.getInt(keyForField(FIELD_AVERAGE_BITRATE), DEFAULT.averageBitrate))
+                .setPeakBitrate(bundle.getInt(keyForField(FIELD_PEAK_BITRATE), DEFAULT.peakBitrate))
+                .setCodecs(defaultIfNull(bundle.getString(keyForField(FIELD_CODECS)), DEFAULT.codecs))
+                .setMetadata(
+                        defaultIfNull(bundle.getParcelable(keyForField(FIELD_METADATA)), DEFAULT.metadata))
+                // Container specific.
+                .setContainerMimeType(
+                        defaultIfNull(
+                                bundle.getString(keyForField(FIELD_CONTAINER_MIME_TYPE)),
+                                DEFAULT.containerMimeType))
+                // Sample specific.
+                .setSampleMimeType(
+                        defaultIfNull(
+                                bundle.getString(keyForField(FIELD_SAMPLE_MIME_TYPE)), DEFAULT.sampleMimeType))
+                .setMaxInputSize(bundle.getInt(keyForField(FIELD_MAX_INPUT_SIZE), DEFAULT.maxInputSize));
+
+        List<byte[]> initializationData = new ArrayList<>();
+        for (int i = 0; ; i++) {
+            @Nullable byte[] data = bundle.getByteArray(keyForInitializationData(i));
+            if (data == null) {
+                break;
+            }
+            initializationData.add(data);
         }
+        builder
+                .setInitializationData(initializationData)
+                .setDrmInitData(bundle.getParcelable(keyForField(FIELD_DRM_INIT_DATA)))
+                .setSubsampleOffsetUs(
+                        bundle.getLong(keyForField(FIELD_SUBSAMPLE_OFFSET_US), DEFAULT.subsampleOffsetUs))
+                // Video specific.
+                .setWidth(bundle.getInt(keyForField(FIELD_WIDTH), DEFAULT.width))
+                .setHeight(bundle.getInt(keyForField(FIELD_HEIGHT), DEFAULT.height))
+                .setFrameRate(bundle.getFloat(keyForField(FIELD_FRAME_RATE), DEFAULT.frameRate))
+                .setRotationDegrees(
+                        bundle.getInt(keyForField(FIELD_ROTATION_DEGREES), DEFAULT.rotationDegrees))
+                .setPixelWidthHeightRatio(
+                        bundle.getFloat(
+                                keyForField(FIELD_PIXEL_WIDTH_HEIGHT_RATIO), DEFAULT.pixelWidthHeightRatio))
+                .setProjectionData(bundle.getByteArray(keyForField(FIELD_PROJECTION_DATA)))
+                .setStereoMode(bundle.getInt(keyForField(FIELD_STEREO_MODE), DEFAULT.stereoMode))
+                .setColorInfo(
+                        BundleableUtil.fromNullableBundle(
+                                ColorInfo.CREATOR, bundle.getBundle(keyForField(FIELD_COLOR_INFO))))
+                // Audio specific.
+                .setChannelCount(bundle.getInt(keyForField(FIELD_CHANNEL_COUNT), DEFAULT.channelCount))
+                .setSampleRate(bundle.getInt(keyForField(FIELD_SAMPLE_RATE), DEFAULT.sampleRate))
+                .setPcmEncoding(bundle.getInt(keyForField(FIELD_PCM_ENCODING), DEFAULT.pcmEncoding))
+                .setEncoderDelay(bundle.getInt(keyForField(FIELD_ENCODER_DELAY), DEFAULT.encoderDelay))
+                .setEncoderPadding(
+                        bundle.getInt(keyForField(FIELD_ENCODER_PADDING), DEFAULT.encoderPadding))
+                // Text specific.
+                .setAccessibilityChannel(
+                        bundle.getInt(keyForField(FIELD_ACCESSIBILITY_CHANNEL), DEFAULT.accessibilityChannel))
+                // Source specific.
+                .setCryptoType(bundle.getInt(keyForField(FIELD_CRYPTO_TYPE), DEFAULT.cryptoType));
 
-        @Override
-        public CustomFormat[] newArray(int size) {
-            return new CustomFormat[size];
-        }
+        return builder.build();
+    }
 
-    };
+    private static String keyForField(@FieldNumber int field) {
+        return Integer.toString(field, Character.MAX_RADIX);
+    }
+
+    private static String keyForInitializationData(int initialisationDataIndex) {
+        return keyForField(FIELD_INITIALIZATION_DATA)
+                + "_"
+                + Integer.toString(initialisationDataIndex, Character.MAX_RADIX);
+    }
+
+    @Nullable
+    private static <T> T defaultIfNull(@Nullable T value, @Nullable T defaultValue) {
+        return value != null ? value : defaultValue;
+    }
 
     public static class FormatThumbnailInfo implements Parcelable {
         public String structure;

--- a/playkit/src/main/java/com/kaltura/android/exoplayer2/dashmanifestparser/CustomPeriod.java
+++ b/playkit/src/main/java/com/kaltura/android/exoplayer2/dashmanifestparser/CustomPeriod.java
@@ -45,6 +45,12 @@ public class CustomPeriod {
         this(id, startMs, adaptationSets, Collections.emptyList(), /* assetIdentifier= */ null);
     }
 
+    /**
+     * @param id The period identifier. May be null.
+     * @param startMs The start time of the period in milliseconds.
+     * @param adaptationSets The adaptation sets belonging to the period.
+     * @param eventStreams The {@link EventStream}s belonging to the period.
+     */
     public CustomPeriod(
             @Nullable String id,
             long startMs,

--- a/playkit/src/main/java/com/kaltura/android/exoplayer2/dashmanifestparser/CustomPeriod.java
+++ b/playkit/src/main/java/com/kaltura/android/exoplayer2/dashmanifestparser/CustomPeriod.java
@@ -45,14 +45,11 @@ public class CustomPeriod {
         this(id, startMs, adaptationSets, Collections.emptyList(), /* assetIdentifier= */ null);
     }
 
-    /**
-     * @param id The period identifier. May be null.
-     * @param startMs The start time of the period in milliseconds.
-     * @param adaptationSets The adaptation sets belonging to the period.
-     * @param eventStreams The {@link EventStream}s belonging to the period.
-     */
-    public CustomPeriod(@Nullable String id, long startMs, List<CustomAdaptationSet> adaptationSets,
-                  List<EventStream> eventStreams) {
+    public CustomPeriod(
+            @Nullable String id,
+            long startMs,
+            List<CustomAdaptationSet> adaptationSets,
+            List<EventStream> eventStreams) {
         this(id, startMs, adaptationSets, eventStreams, /* assetIdentifier= */ null);
     }
 

--- a/playkit/src/main/java/com/kaltura/android/exoplayer2/dashmanifestparser/CustomSegmentBase.java
+++ b/playkit/src/main/java/com/kaltura/android/exoplayer2/dashmanifestparser/CustomSegmentBase.java
@@ -486,8 +486,9 @@ public abstract class CustomSegmentBase {
         @Nullable
         public RangedUri getInitialization(CustomRepresentation representation) {
             if (initializationTemplate != null) {
-                String urlString = initializationTemplate.buildUri(representation.format.id, 0,
-                        representation.format.bitrate, 0);
+                String urlString =
+                        initializationTemplate.buildUri(
+                                representation.format.id, 0, representation.format.bitrate, 0);
                 return new RangedUri(urlString, 0, C.LENGTH_UNSET);
             } else {
                 return super.getInitialization(representation);
@@ -502,8 +503,9 @@ public abstract class CustomSegmentBase {
             } else {
                 time = (sequenceNumber - startNumber) * duration;
             }
-            String uriString = mediaTemplate.buildUri(representation.format.id, sequenceNumber,
-                    representation.format.bitrate, time);
+            String uriString =
+                    mediaTemplate.buildUri(
+                            representation.format.id, sequenceNumber, representation.format.bitrate, time);
             return new RangedUri(uriString, 0, C.LENGTH_UNSET);
         }
 

--- a/playkit/src/main/java/com/kaltura/android/exoplayer2/source/dash/manifest/DashManifestParserForThumbnail.java
+++ b/playkit/src/main/java/com/kaltura/android/exoplayer2/source/dash/manifest/DashManifestParserForThumbnail.java
@@ -742,6 +742,8 @@ public class DashManifestParserForThumbnail extends DefaultHandler
                 drmSchemeType,
                 drmSchemeDatas,
                 inbandEventStreams,
+                essentialProperties,
+                supplementalProperties,
                 Representation.REVISION_ID_DEFAULT);
     }
 
@@ -764,7 +766,7 @@ public class DashManifestParserForThumbnail extends DefaultHandler
         if (MimeTypes.AUDIO_E_AC3.equals(sampleMimeType)) {
             sampleMimeType = parseEac3SupplementalProperties(supplementalProperties);
             if (MimeTypes.AUDIO_E_AC3_JOC.equals(sampleMimeType)) {
-                codecs = Ac3Util.E_AC3_JOC_CODEC_STRING;
+                codecs = MimeTypes.CODEC_E_AC3_JOC;
             }
         }
         @C.SelectionFlags int selectionFlags = parseSelectionFlagsFromRoleDescriptors(roleDescriptors);
@@ -828,7 +830,10 @@ public class DashManifestParserForThumbnail extends DefaultHandler
                 formatBuilder.build(),
                 representationInfo.baseUrls,
                 representationInfo.segmentBase,
-                inbandEventStreams);
+                inbandEventStreams,
+                representationInfo.essentialProperties,
+                representationInfo.supplementalProperties,
+                /* cacheKey= */ null);
     }
 
     // SegmentBase, SegmentList and SegmentTemplate parsing.
@@ -1902,6 +1907,8 @@ public class DashManifestParserForThumbnail extends DefaultHandler
         public final ArrayList<SchemeData> drmSchemeDatas;
         public final ArrayList<Descriptor> inbandEventStreams;
         public final long revisionId;
+        public final List<Descriptor> essentialProperties;
+        public final List<Descriptor> supplementalProperties;
 
         public RepresentationInfo(
                 Format format,
@@ -1910,6 +1917,8 @@ public class DashManifestParserForThumbnail extends DefaultHandler
                 @Nullable String drmSchemeType,
                 ArrayList<SchemeData> drmSchemeDatas,
                 ArrayList<Descriptor> inbandEventStreams,
+                List<Descriptor> essentialProperties,
+                List<Descriptor> supplementalProperties,
                 long revisionId) {
             this.format = format;
             this.baseUrls = ImmutableList.copyOf(baseUrls);
@@ -1917,6 +1926,8 @@ public class DashManifestParserForThumbnail extends DefaultHandler
             this.drmSchemeType = drmSchemeType;
             this.drmSchemeDatas = drmSchemeDatas;
             this.inbandEventStreams = inbandEventStreams;
+            this.essentialProperties = essentialProperties;
+            this.supplementalProperties = supplementalProperties;
             this.revisionId = revisionId;
         }
     }

--- a/playkit/src/main/java/com/kaltura/android/exoplayer2/source/dash/manifest/DashManifestParserForThumbnail.java
+++ b/playkit/src/main/java/com/kaltura/android/exoplayer2/source/dash/manifest/DashManifestParserForThumbnail.java
@@ -5,14 +5,16 @@ import android.text.TextUtils;
 import android.util.Base64;
 import android.util.Pair;
 import android.util.Xml;
+
 import androidx.annotation.Nullable;
 
 import com.google.common.base.Ascii;
+import com.google.common.base.Charsets;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.kaltura.android.exoplayer2.C;
 import com.kaltura.android.exoplayer2.Format;
 import com.kaltura.android.exoplayer2.ParserException;
-import com.kaltura.android.exoplayer2.audio.Ac3Util;
 import com.kaltura.android.exoplayer2.drm.DrmInitData;
 import com.kaltura.android.exoplayer2.drm.DrmInitData.SchemeData;
 import com.kaltura.android.exoplayer2.extractor.mp4.PsshAtomUtil;
@@ -28,8 +30,14 @@ import com.kaltura.android.exoplayer2.util.MimeTypes;
 import com.kaltura.android.exoplayer2.util.UriUtil;
 import com.kaltura.android.exoplayer2.util.Util;
 import com.kaltura.android.exoplayer2.util.XmlPullParserUtil;
-import com.google.common.base.Charsets;
-import com.google.common.collect.ImmutableList;
+
+import org.checkerframework.checker.nullness.compatqual.NullableType;
+import org.xml.sax.helpers.DefaultHandler;
+import org.xmlpull.v1.XmlPullParser;
+import org.xmlpull.v1.XmlPullParserException;
+import org.xmlpull.v1.XmlPullParserFactory;
+import org.xmlpull.v1.XmlSerializer;
+
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -38,12 +46,6 @@ import java.util.List;
 import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import org.checkerframework.checker.nullness.compatqual.NullableType;
-import org.xml.sax.helpers.DefaultHandler;
-import org.xmlpull.v1.XmlPullParser;
-import org.xmlpull.v1.XmlPullParserException;
-import org.xmlpull.v1.XmlPullParserFactory;
-import org.xmlpull.v1.XmlSerializer;
 
 /**
  * A parser of media presentation description files.
@@ -959,8 +961,8 @@ public class DashManifestParserForThumbnail extends DefaultHandler
                 timeline,
                 availabilityTimeOffsetUs,
                 segments,
-                C.msToUs(timeShiftBufferDepthMs),
-                C.msToUs(periodStartUnixTimeMs));
+                Util.msToUs(timeShiftBufferDepthMs),
+                Util.msToUs(periodStartUnixTimeMs));
     }
 
     protected SegmentTemplate parseSegmentTemplate(
@@ -1049,8 +1051,8 @@ public class DashManifestParserForThumbnail extends DefaultHandler
                 availabilityTimeOffsetUs,
                 initializationTemplate,
                 mediaTemplate,
-                C.msToUs(timeShiftBufferDepthMs),
-                C.msToUs(periodStartUnixTimeMs));
+                Util.msToUs(timeShiftBufferDepthMs),
+                Util.msToUs(periodStartUnixTimeMs));
     }
 
     /**

--- a/playkit/src/main/java/com/kaltura/playkit/Player.java
+++ b/playkit/src/main/java/com/kaltura/playkit/Player.java
@@ -515,9 +515,9 @@ public interface Player {
 
     /**
      * Change the volume of the current audio track.
-     * Accept values between 0 and 1. Where 0 is mute and 1 is maximum volume.
-     * If the volume parameter is higher then 1, it will be converted to 1.
-     * If the volume parameter is lower then 0, it be converted to 0.
+     * Accept values between 0.0 and 1.0. Where 0.0 is mute and 1.0 is maximum volume.
+     * If the volume parameter is higher then 1.0, it will be converted to 1.0.
+     * If the volume parameter is lower then 0.0, it be converted to 0.0.
      *
      * @param volume - volume to set.
      */

--- a/playkit/src/main/java/com/kaltura/playkit/drm/DeferredDrmSessionManager.java
+++ b/playkit/src/main/java/com/kaltura/playkit/drm/DeferredDrmSessionManager.java
@@ -20,6 +20,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 
+import com.kaltura.android.exoplayer2.C;
 import com.kaltura.android.exoplayer2.Format;
 import com.kaltura.android.exoplayer2.drm.DefaultDrmSessionManager;
 import com.kaltura.android.exoplayer2.drm.DrmInitData;
@@ -173,7 +174,7 @@ public class DeferredDrmSessionManager implements DrmSessionManager, DrmSessionE
         if (drmSessionManager != null) {
             return drmSessionManager.getCryptoType(format);
         }
-        return 0;
+        return C.CRYPTO_TYPE_NONE;
     }
 
     @Override

--- a/playkit/src/main/java/com/kaltura/playkit/drm/DeferredDrmSessionManager.java
+++ b/playkit/src/main/java/com/kaltura/playkit/drm/DeferredDrmSessionManager.java
@@ -16,6 +16,7 @@ import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 
@@ -168,7 +169,7 @@ public class DeferredDrmSessionManager implements DrmSessionManager, DrmSessionE
     }
 
     @Override
-    public int getCryptoType(Format format) {
+    public int getCryptoType(@NonNull Format format) {
         if (drmSessionManager != null) {
             return drmSessionManager.getCryptoType(format);
         }

--- a/playkit/src/main/java/com/kaltura/playkit/drm/DeferredDrmSessionManager.java
+++ b/playkit/src/main/java/com/kaltura/playkit/drm/DeferredDrmSessionManager.java
@@ -25,7 +25,6 @@ import com.kaltura.android.exoplayer2.drm.DrmInitData;
 import com.kaltura.android.exoplayer2.drm.DrmSession;
 import com.kaltura.android.exoplayer2.drm.DrmSessionEventListener;
 import com.kaltura.android.exoplayer2.drm.DrmSessionManager;
-import com.kaltura.android.exoplayer2.drm.ExoMediaCrypto;
 import com.kaltura.android.exoplayer2.drm.FrameworkMediaDrm;
 import com.kaltura.android.exoplayer2.drm.UnsupportedDrmException;
 import com.kaltura.android.exoplayer2.extractor.mp4.PsshAtomUtil;
@@ -168,13 +167,12 @@ public class DeferredDrmSessionManager implements DrmSessionManager, DrmSessionE
         return drmSessionManager;
     }
 
-    @Nullable
     @Override
-    public Class<? extends ExoMediaCrypto> getExoMediaCryptoType(Format format) {
+    public int getCryptoType(Format format) {
         if (drmSessionManager != null) {
-            return drmSessionManager.getExoMediaCryptoType(format);
+            return drmSessionManager.getCryptoType(format);
         }
-        return null;
+        return 0;
     }
 
     @Override

--- a/playkit/src/main/java/com/kaltura/playkit/player/BaseExoplayerView.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/BaseExoplayerView.java
@@ -3,7 +3,7 @@ package com.kaltura.playkit.player;
 import android.content.Context;
 import android.util.AttributeSet;
 
-import com.kaltura.android.exoplayer2.SimpleExoPlayer;
+import com.kaltura.android.exoplayer2.ExoPlayer;
 import com.kaltura.android.exoplayer2.ui.SubtitleView;
 
 public abstract class BaseExoplayerView extends PlayerView {
@@ -20,7 +20,7 @@ public abstract class BaseExoplayerView extends PlayerView {
         super(context, attrs);
     }
 
-    public abstract void setPlayer(SimpleExoPlayer player, boolean useTextureView, boolean isSurfaceSecured, boolean hideVideoViews);
+    public abstract void setPlayer(ExoPlayer player, boolean useTextureView, boolean isSurfaceSecured, boolean hideVideoViews);
 
     public abstract void setVideoSurfaceProperties(boolean useTextureView, boolean isSurfaceSecured, boolean hideVideoViews);
 

--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerView.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerView.java
@@ -197,7 +197,9 @@ class ExoPlayerView extends BaseExoplayerView {
         }
 
         //Clear listeners.
-        player.removeListener(componentListener);
+        if (componentListener != null) {
+            player.removeListener(componentListener);
+        }
 
         lastReportedCues = null;
         contentFrame.removeView(videoSurface);

--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerView.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerView.java
@@ -29,7 +29,6 @@ import androidx.annotation.NonNull;
 
 import com.kaltura.android.exoplayer2.ExoPlayer;
 import com.kaltura.android.exoplayer2.Player;
-import com.kaltura.android.exoplayer2.SimpleExoPlayer;
 import com.kaltura.android.exoplayer2.text.Cue;
 import com.kaltura.android.exoplayer2.text.TextOutput;
 import com.kaltura.android.exoplayer2.ui.AspectRatioFrameLayout;
@@ -54,7 +53,7 @@ class ExoPlayerView extends BaseExoplayerView {
     private SubtitleView subtitleView;
     private AspectRatioFrameLayout contentFrame;
 
-    private SimpleExoPlayer player;
+    private ExoPlayer player;
     private ComponentListener componentListener;
     private Player.Listener playerEventListener;
     private int textureViewRotation;
@@ -115,14 +114,14 @@ class ExoPlayerView extends BaseExoplayerView {
     }
 
     /**
-     * Set the {@link SimpleExoPlayer} to use. If ExoplayerView instance already has
+     * Set the {@link ExoPlayer} to use. If ExoplayerView instance already has
      * player attached to it, it will remove and clear videoSurface first.
      *
-     * @param player           - The {@link SimpleExoPlayer} to use.
+     * @param player           - The {@link ExoPlayer} to use.
      * @param isSurfaceSecured - should allow secure rendering of the surface
      */
     @Override
-    public void setPlayer(SimpleExoPlayer player, boolean useTextureView, boolean isSurfaceSecured, boolean hideVideoViews) {
+    public void setPlayer(ExoPlayer player, boolean useTextureView, boolean isSurfaceSecured, boolean hideVideoViews) {
         if (this.player == player) {
             return;
         }
@@ -158,22 +157,19 @@ class ExoPlayerView extends BaseExoplayerView {
         resetViews();
         createVideoSurface(useTextureView);
 
-        ExoPlayer.VideoComponent newVideoComponent = player.getVideoComponent();
         player.addListener(playerEventListener);
 
         //Decide which type of videoSurface should be set.
-        if (newVideoComponent != null) {
-            if (videoSurface instanceof TextureView) {
-                newVideoComponent.setVideoTextureView((TextureView) videoSurface);
-            } else {
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
-                    ((SurfaceView) videoSurface).setSecure(isSurfaceSecured);
-                }
-                newVideoComponent.setVideoSurfaceView((SurfaceView) videoSurface);
+        if (videoSurface instanceof TextureView) {
+            player.setVideoTextureView((TextureView) videoSurface);
+        } else {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+                ((SurfaceView) videoSurface).setSecure(isSurfaceSecured);
             }
-            //Set listeners
-            player.addListener(componentListener);
+            player.setVideoSurfaceView((SurfaceView) videoSurface);
         }
+        //Set listeners
+        player.addListener(componentListener);
 
         contentFrame.addView(videoSurface, 0);
 
@@ -189,27 +185,20 @@ class ExoPlayerView extends BaseExoplayerView {
      * Clear all the listeners and detach Surface from view hierarchy.
      */
     private void removeVideoSurface() {
-        ExoPlayer.VideoComponent oldVideoComponent = player.getVideoComponent();
-        ExoPlayer.TextComponent oldTextComponent = player.getTextComponent();
+
         if (playerEventListener != null) {
             player.removeListener(playerEventListener);
         }
         //Remove existed videoSurface from player.
-        if (oldVideoComponent != null) {
-
-            if (videoSurface instanceof SurfaceView) {
-                oldVideoComponent.clearVideoSurfaceView((SurfaceView) videoSurface);
-            } else if (videoSurface instanceof TextureView) {
-                oldVideoComponent.clearVideoTextureView((TextureView) videoSurface);
-            }
-
-            //Clear listeners.
-            player.removeListener(componentListener);
+        if (videoSurface instanceof SurfaceView) {
+            player.clearVideoSurfaceView((SurfaceView) videoSurface);
+        } else if (videoSurface instanceof TextureView) {
+            player.clearVideoTextureView((TextureView) videoSurface);
         }
 
-        if (oldTextComponent != null) {
-            player.removeListener(componentListener);
-        }
+        //Clear listeners.
+        player.removeListener(componentListener);
+
         lastReportedCues = null;
         contentFrame.removeView(videoSurface);
     }

--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
@@ -1018,7 +1018,7 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.Listener, Metadata
 
     @Override
     public void onAudioInputFormatChanged(@NonNull Format format) {
-        if (assertTrackSelectionIsNotNull("onVideoInputFormatChanged")) {
+        if (assertTrackSelectionIsNotNull("onAudioInputFormatChanged")) {
             trackSelectionHelper.setCurrentAudioFormat(format);
         }
     }

--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
@@ -928,7 +928,7 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.Listener, Metadata
     }
 
     @Override
-    public void onTimelineChanged(Timeline timeline, int reason) {
+    public void onTimelineChanged(@NonNull Timeline timeline, int reason) {
         log.d("onTimelineChanged reason = " + reason + " duration = " + getDuration());
         if (reason == Player.TIMELINE_CHANGE_REASON_PLAYLIST_CHANGED) {
             isLoadedMetaDataFired = false;

--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
@@ -980,7 +980,7 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.Listener, Metadata
 
     @Override
     public void onTracksInfoChanged(@NonNull TracksInfo tracksInfo) {
-        log.d("onTracksInfoChanged ");
+        log.d("onTracksInfoChanged");
 
         //if onTracksChanged happened when application went background, do not update the tracks.
         if (assertTrackSelectionIsNotNull("onTracksChanged()")) {

--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
@@ -58,7 +58,6 @@ import com.kaltura.android.exoplayer2.source.dash.manifest.DashManifest;
 import com.kaltura.android.exoplayer2.source.dash.manifest.DashManifestParserForThumbnail;
 import com.kaltura.android.exoplayer2.source.hls.HlsMediaSource;
 import com.kaltura.android.exoplayer2.trackselection.DefaultTrackSelector;
-import com.kaltura.android.exoplayer2.trackselection.TrackSelectionParameters;
 import com.kaltura.android.exoplayer2.ui.SubtitleView;
 import com.kaltura.android.exoplayer2.upstream.BandwidthMeter;
 import com.kaltura.android.exoplayer2.upstream.ByteArrayDataSink;

--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
@@ -76,22 +76,7 @@ import com.kaltura.android.exoplayer2.upstream.cache.Cache;
 import com.kaltura.android.exoplayer2.upstream.cache.CacheDataSource;
 import com.kaltura.android.exoplayer2.util.TimestampAdjuster;
 import com.kaltura.android.exoplayer2.video.CustomLoadControl;
-import com.kaltura.playkit.LocalAssetsManager;
-import com.kaltura.playkit.LocalAssetsManagerExo;
-import com.kaltura.playkit.PKAbrFilter;
-import com.kaltura.playkit.PKDrmParams;
-import com.kaltura.playkit.PKError;
-import com.kaltura.playkit.PKLog;
-import com.kaltura.playkit.PKMediaEntry;
-import com.kaltura.playkit.PKMediaFormat;
-import com.kaltura.playkit.PKMediaSource;
-import com.kaltura.playkit.PKPlaybackException;
-import com.kaltura.playkit.PKRequestConfig;
-import com.kaltura.playkit.PKRequestParams;
-import com.kaltura.playkit.PlaybackInfo;
-import com.kaltura.playkit.PlayerEvent;
-import com.kaltura.playkit.PlayerState;
-import com.kaltura.playkit.Utils;
+import com.kaltura.playkit.*;
 import com.kaltura.playkit.drm.DeferredDrmSessionManager;
 import com.kaltura.playkit.drm.DrmCallback;
 import com.kaltura.playkit.player.metadata.MetadataConverter;
@@ -1036,14 +1021,6 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.Listener, Metadata
     public void onAudioInputFormatChanged(@NonNull Format format) {
         if (assertTrackSelectionIsNotNull("onVideoInputFormatChanged")) {
             trackSelectionHelper.setCurrentAudioFormat(format);
-        }
-    }
-
-    @Override
-    public void onTrackSelectionParametersChanged(@NonNull TrackSelectionParameters parameters) {
-        log.d("onTrackSelectionParametersChanged");
-        if (assertTrackSelectionIsNotNull("onTrackSelectionParametersChanged")) {
-            trackSelectionHelper.setTrackSelectionParameters(parameters);
         }
     }
 

--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
@@ -730,7 +730,11 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.Listener, Metadata
 
                 MediaItem.SubtitleConfiguration.Builder builder = new MediaItem.SubtitleConfiguration.Builder(Uri.parse(pkExternalSubtitle.getUrl()));
                 builder.setMimeType(subtitleMimeType);
+
+                // "-" is important to be added between lang and mimetype
+                // This is how we understand that this is external subtitle in TrackSelectionHelper
                 builder.setLanguage(pkExternalSubtitle.getLanguage() + "-" + subtitleMimeType);
+
                 builder.setSelectionFlags(pkExternalSubtitle.getSelectionFlags());
                 builder.setRoleFlags(pkExternalSubtitle.getRoleFlag());
                 builder.setLabel(pkExternalSubtitle.getLabel());

--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
@@ -52,14 +52,13 @@ import com.kaltura.android.exoplayer2.source.MediaSourceFactory;
 import com.kaltura.android.exoplayer2.source.MergingMediaSource;
 import com.kaltura.android.exoplayer2.source.ProgressiveMediaSource;
 import com.kaltura.android.exoplayer2.source.SingleSampleMediaSource;
-import com.kaltura.android.exoplayer2.source.TrackGroupArray;
 import com.kaltura.android.exoplayer2.source.dash.DashMediaSource;
 import com.kaltura.android.exoplayer2.source.dash.DefaultDashChunkSource;
 import com.kaltura.android.exoplayer2.source.dash.manifest.DashManifest;
 import com.kaltura.android.exoplayer2.source.dash.manifest.DashManifestParserForThumbnail;
 import com.kaltura.android.exoplayer2.source.hls.HlsMediaSource;
 import com.kaltura.android.exoplayer2.trackselection.DefaultTrackSelector;
-import com.kaltura.android.exoplayer2.trackselection.TrackSelectionArray;
+import com.kaltura.android.exoplayer2.trackselection.TrackSelectionParameters;
 import com.kaltura.android.exoplayer2.ui.SubtitleView;
 import com.kaltura.android.exoplayer2.upstream.BandwidthMeter;
 import com.kaltura.android.exoplayer2.upstream.ByteArrayDataSink;
@@ -1039,7 +1038,15 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.Listener, Metadata
             trackSelectionHelper.setCurrentAudioFormat(format);
         }
     }
-    
+
+    @Override
+    public void onTrackSelectionParametersChanged(@NonNull TrackSelectionParameters parameters) {
+        log.d("onTrackSelectionParametersChanged");
+        if (assertTrackSelectionIsNotNull("onTrackSelectionParametersChanged")) {
+            trackSelectionHelper.setTrackSelectionParameters(parameters);
+        }
+    }
+
     @Override
     public void onMetadata(Metadata metadata) {
         this.metadataList = MetadataConverter.convert(metadata);

--- a/playkit/src/main/java/com/kaltura/playkit/player/PKExternalSubtitle.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/PKExternalSubtitle.java
@@ -7,14 +7,13 @@ import androidx.annotation.NonNull;
 import com.kaltura.android.exoplayer2.C;
 import com.kaltura.android.exoplayer2.Format;
 import com.kaltura.playkit.PKSubtitleFormat;
-import com.kaltura.playkit.utils.Consts;
 
 public class PKExternalSubtitle implements Parcelable {
 
     private String url;
     private String id;
     private String mimeType;
-    private int selectionFlags = Consts.TRACK_UNSELECTED_FLAG;
+    private @C.SelectionFlags int selectionFlags = C.SELECTION_FLAG_AUTOSELECT;
     /**
      * Indicates the track contains subtitles. This flag may be set on video tracks to indicate the
      * presence of burned in subtitles.
@@ -49,7 +48,7 @@ public class PKExternalSubtitle implements Parcelable {
         return url;
     }
 
-    public int getSelectionFlags() {
+    public @C.SelectionFlags int getSelectionFlags() {
         return selectionFlags;
     }
 
@@ -93,11 +92,11 @@ public class PKExternalSubtitle implements Parcelable {
 
     public PKExternalSubtitle setDefault() {
         this.isDefault = true;
-        setSelectionFlags(Consts.DEFAULT_TRACK_SELECTION_FLAG_HLS);
+        setSelectionFlags(C.SELECTION_FLAG_DEFAULT | C.SELECTION_FLAG_AUTOSELECT);
         return this;
     }
 
-    private void setSelectionFlags(int selectionFlags) {
+    private void setSelectionFlags(@C.SelectionFlags int selectionFlags) {
         this.selectionFlags = selectionFlags;
     }
 

--- a/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
@@ -328,15 +328,23 @@ public class TrackSelectionHelper {
                                 }
                                 break;
                             case TRACK_TYPE_TEXT:
-                                if (format.language != null && hasExternalSubtitles && discardTextTrackOnPreference(format)) {
+                                if (format.language != null && hasExternalSubtitles) {
                                     int selectionFlag = format.selectionFlags;
                                     if (selector != null && (selectionFlag == Consts.DEFAULT_TRACK_SELECTION_FLAG_HLS || selectionFlag == Consts.DEFAULT_TRACK_SELECTION_FLAG_DASH)) {
                                         DefaultTrackSelector.ParametersBuilder parametersBuilder = selector.getParameters().buildUpon();
-                                        trackSelectionOverridesBuilder.clearOverridesOfType(C.TRACK_TYPE_TEXT);
-                                        parametersBuilder.setRendererDisabled(TRACK_TYPE_TEXT, true);
+
+                                        if (discardTextTrackOnPreference(format)) {
+                                            trackSelectionOverridesBuilder.clearOverride(trackGroup);
+                                            parametersBuilder.setRendererDisabled(TRACK_TYPE_TEXT, true);
+                                            continue;
+                                        } else {
+                                            TrackSelectionOverrides.TrackSelectionOverride trackSelectionOverride = new TrackSelectionOverrides.TrackSelectionOverride(trackGroup, Collections.singletonList(trackIndex));
+                                            TrackSelectionOverrides trackSelectionOverrides = trackSelectionOverridesBuilder.setOverrideForType(trackSelectionOverride).build();
+                                            parametersBuilder.setTrackSelectionOverrides(trackSelectionOverrides);
+                                        }
+
                                         selector.setParameters(parametersBuilder);
                                     }
-                                    continue;
                                 }
 
                                 if (CEA_608.equals(format.sampleMimeType)) {

--- a/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
@@ -106,7 +106,7 @@ public class TrackSelectionHelper {
 
     private final Context context;
     private final DefaultTrackSelector selector;
-    private TracksInfo trackSelectionArray;
+    private TracksInfo tracksInfo;
     private MappingTrackSelector.MappedTrackInfo mappedTrackInfo;
     private TrackSelectionParameters trackSelectionParameters;
     private TrackSelectionOverrides.Builder trackSelectionOverridesBuilder;
@@ -196,7 +196,7 @@ public class TrackSelectionHelper {
      * @return - true if tracks data created successful, if mappingTrackInfo not ready return false.
      */
     boolean prepareTracks(TracksInfo trackSelections, String externalThumbnailWebVttUrl, CustomDashManifest customDashManifest) {
-        trackSelectionArray = trackSelections;
+        tracksInfo = trackSelections;
         mappedTrackInfo = selector.getCurrentMappedTrackInfo();
         if (mappedTrackInfo == null) {
             log.w("Trying to get current MappedTrackInfo returns null");
@@ -1040,7 +1040,7 @@ public class TrackSelectionHelper {
                 trackType = TRACK_TYPE_TEXT;
             }
 
-            if (trackType == TRACK_TYPE_AUDIO && currentAudioFormat != null && trackSelectionArray != null) {
+            if (trackType == TRACK_TYPE_AUDIO && currentAudioFormat != null && tracksInfo != null) {
                 defaultTrackIndex = findDefaultTrackIndex(currentAudioFormat.language, trackList, defaultTrackIndex);
             }
         }
@@ -1894,9 +1894,9 @@ public class TrackSelectionHelper {
     }
 
     protected boolean isAudioOnlyStream() {
-        if (trackSelectionArray != null && !trackSelectionArray.getTrackGroupInfos().isEmpty()) {
+        if (tracksInfo != null && !tracksInfo.getTrackGroupInfos().isEmpty()) {
             boolean isVideoFormatAvailable = false;
-            for (TracksInfo.TrackGroupInfo trackGroupInfo: trackSelectionArray.getTrackGroupInfos()) {
+            for (TracksInfo.TrackGroupInfo trackGroupInfo: tracksInfo.getTrackGroupInfos()) {
                 if (trackGroupInfo.getTrackType() == C.TRACK_TYPE_VIDEO) {
                     isVideoFormatAvailable = true;
                     break;
@@ -1945,8 +1945,8 @@ public class TrackSelectionHelper {
 
     @Nullable
     private Format getSelectedTextTrackFormat() {
-        if (trackSelectionArray != null && !trackSelectionArray.getTrackGroupInfos().isEmpty()) {
-            for (TracksInfo.TrackGroupInfo trackGroupInfo : trackSelectionArray.getTrackGroupInfos()) {
+        if (tracksInfo != null && !tracksInfo.getTrackGroupInfos().isEmpty()) {
+            for (TracksInfo.TrackGroupInfo trackGroupInfo : tracksInfo.getTrackGroupInfos()) {
                 if (trackGroupInfo.getTrackType() == C.TRACK_TYPE_TEXT &&
                         trackGroupInfo.isSelected() &&
                         trackGroupInfo.getTrackGroup().length > 0) {
@@ -1960,7 +1960,7 @@ public class TrackSelectionHelper {
 
     protected void notifyAboutTrackChange(TracksInfo trackSelections) {
 
-        this.trackSelectionArray = trackSelections;
+        this.tracksInfo = trackSelections;
         if (tracksInfoListener == null) {
             return;
         }
@@ -2029,7 +2029,7 @@ public class TrackSelectionHelper {
     protected void stop() {
         lastSelectedTrackIds = new String[]{NONE, NONE, NONE, NONE};
         requestedChangeTrackIds = new String[]{NONE, NONE, NONE, NONE};
-        trackSelectionArray = null;
+        tracksInfo = null;
         mappedTrackInfo = null;
         videoTracks.clear();
         audioTracks.clear();

--- a/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
@@ -1946,6 +1946,7 @@ public class TrackSelectionHelper {
     @Nullable
     private Format getSelectedTextTrackFormat() {
         if (tracksInfo != null && !tracksInfo.getTrackGroupInfos().isEmpty()) {
+
             for (TracksInfo.TrackGroupInfo trackGroupInfo : tracksInfo.getTrackGroupInfos()) {
                 if (trackGroupInfo.getTrackType() == C.TRACK_TYPE_TEXT &&
                         trackGroupInfo.isSelected() &&

--- a/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
@@ -1635,7 +1635,7 @@ public class TrackSelectionHelper {
 
     private boolean isFormatSupported(int rendererCount, int groupIndex, int trackIndex) {
         return mappedTrackInfo.getTrackSupport(rendererCount, groupIndex, trackIndex)
-                == Consts.FORMAT_HANDLED;
+                == C.FORMAT_HANDLED;
     }
 
     private boolean isAdaptive(int rendererIndex, int groupIndex) {

--- a/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
@@ -1368,7 +1368,6 @@ public class TrackSelectionHelper {
         // Only for video tracks : RENDERER_INDEX is always 0 means video
         List<Integer> selectedIndices = new ArrayList<>();
 
-        SelectionOverride override;
         int rendererIndex = uniqueIds[0][RENDERER_INDEX];
         int groupIndex = uniqueIds[0][GROUP_INDEX];
         int trackIndex = uniqueIds[0][TRACK_INDEX];
@@ -1870,6 +1869,8 @@ public class TrackSelectionHelper {
         audioTracks.clear();
         textTracks.clear();
         imageTracks.clear();
+        currentVideoFormat = null;
+        currentAudioFormat = null;
         for (Map.Entry<PKVideoCodec,List<VideoTrack>> videoTrackEntry : videoTracksCodecsMap.entrySet()) {
             videoTrackEntry.getValue().clear();
         }
@@ -1883,10 +1884,12 @@ public class TrackSelectionHelper {
             externalVttThumbnailRangesInfo.clear();
             externalVttThumbnailRangesInfo = null;
         }
+        clearCurrentTracksOverrides();
     }
 
     protected void release() {
         tracksInfoListener.onRelease(lastSelectedTrackIds);
+        clearCurrentTracksOverrides();
         tracksInfoListener = null;
         trackSelectionParameters = null;
         trackSelectionOverridesBuilder = null;
@@ -2057,7 +2060,7 @@ public class TrackSelectionHelper {
      * selection
      */
     private void clearCurrentTracksOverrides() {
-        if (trackSelectionParameters != null) {
+        if (selector != null && trackSelectionOverridesBuilder != null) {
             ImmutableList<TrackSelectionOverrides.TrackSelectionOverride> trackOverridesList = selector.getParameters().trackSelectionOverrides.asList();
             if (trackOverridesList.isEmpty()) {
                 log.d("There are no TrackSelection overrides, hence returning.");

--- a/playkit/src/main/java/com/kaltura/playkit/plugins/ads/AdEvent.java
+++ b/playkit/src/main/java/com/kaltura/playkit/plugins/ads/AdEvent.java
@@ -17,7 +17,6 @@ import androidx.annotation.Nullable;
 import com.kaltura.playkit.PKError;
 import com.kaltura.playkit.PKEvent;
 import com.kaltura.playkit.ads.AdBreakConfig;
-import com.kaltura.playkit.ads.PKAdvertisingAdInfo;
 
 @SuppressWarnings("unused")
 public class AdEvent implements PKEvent {

--- a/playkit/src/main/java/com/kaltura/playkit/utils/Consts.java
+++ b/playkit/src/main/java/com/kaltura/playkit/utils/Consts.java
@@ -12,6 +12,8 @@
 
 package com.kaltura.playkit.utils;
 
+import com.kaltura.android.exoplayer2.C;
+
 /**
  * Created by anton.afanasiev on 04/12/2016.
  */
@@ -84,8 +86,8 @@ public class Consts {
      * Flag that indicates, that this specified track will be
      * selected by the player as default track.
      */
-    public static final int DEFAULT_TRACK_SELECTION_FLAG_HLS = 5;
-    public static final int DEFAULT_TRACK_SELECTION_FLAG_DASH = 1;
+    public static final int DEFAULT_TRACK_SELECTION_FLAG_HLS = C.SELECTION_FLAG_DEFAULT | C.SELECTION_FLAG_AUTOSELECT;
+    public static final int DEFAULT_TRACK_SELECTION_FLAG_DASH = C.SELECTION_FLAG_DEFAULT;
 
     /**
      * Flag that indicates, that this specified track will not


### PR DESCRIPTION
Fixes FEC-11741 , FEC-11980

#### Tests' checklist

- [x] In-stream Dash Image thumbnails (Kaltura-Player)
- [x] Offline Player (Kaltura-Player)
- [x] Low latency live streams
- [x] External Subtitles
- [x] Change Media with ABR extensively (Using Charles to know the correct track selection).
- [x] Test with AVC, HEVC different codecs with different supported and unsupported devices
- [x] Check Audio only content
- [x] Check ABR Settings
- [x] Check BG/FG(Background/Forground) in app lifecycle
- [x] Check Video ABR with different Text track Selection and go to BG/FG. It should retain the selected tracks after coming to foreground. Need to check with Charles that the correct tracks are playing.
- [ ] Test the app by throttling the network to 3G/4G/Wifi speed and see the performance.
- [x] VR Medias with/without subtitles
- [x] DRM content Playback

#### Document Changes
- [x] Change the Java doc here https://github.com/kaltura/playkit-android/blob/208dacbcb40b1611f6fd35ceda68391d08b985d3/playkit/src/main/java/com/kaltura/playkit/Player.java#L520 to be precise with 0.0 and 1.0
