### PR TITLE
FEC-11954 Fixed `setDefault` API for `PKExternalSubtitle` 

### DIFF
--- a/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
@@ -611,7 +611,6 @@ public class TrackSelectionHelper {
      * @return String language
      */
     private String getLanguageFromFormat(Format format) {
-
         String language = format.language;
         if (TextUtils.isEmpty(format.language)) {
             return LANGUAGE_UNKNOWN;
@@ -634,8 +633,8 @@ public class TrackSelectionHelper {
                     }
                 }
                 return iso3Language;
-            } catch (MissingResourceException exception) {
-                log.e("No language code found" + exception.getMessage());
+            } catch (MissingResourceException | NullPointerException ex) {
+                log.e(ex.getMessage());
             }
         }
 


### PR DESCRIPTION
- When subtitle language length was > 2 then it was converting to ISO3 code
which eventually was breaking the logic for external subtitles

- If external subtitle then parse it if language length > 2 then get ISO3 code and append 
mimeType with '-'