### PR TITLE
FEC-12011 Remove warning from logcat

### DIFF
--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
@@ -1217,6 +1217,9 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.Listener, Metadata
         log.v("release");
         if (assertPlayerIsNotNull("release()")) {
             savePlayerPosition();
+            if (assertPlayerIsNotNull("release()")) {
+                trackSelectionHelper.clearCurrentTracksOverrides();
+            }
             player.release();
             player = null;
             if (bandwidthMeter != null) {

--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
@@ -1217,9 +1217,6 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.Listener, Metadata
         log.v("release");
         if (assertPlayerIsNotNull("release()")) {
             savePlayerPosition();
-            if (assertPlayerIsNotNull("release()")) {
-                trackSelectionHelper.clearCurrentTracksOverrides();
-            }
             player.release();
             player = null;
             if (bandwidthMeter != null) {

--- a/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
@@ -196,6 +196,7 @@ public class TrackSelectionHelper {
      * @return - true if tracks data created successful, if mappingTrackInfo not ready return false.
      */
     boolean prepareTracks(TracksInfo trackSelections, String externalThumbnailWebVttUrl, CustomDashManifest customDashManifest) {
+        clearCurrentTracksOverrides();
         tracksInfo = trackSelections;
         mappedTrackInfo = selector.getCurrentMappedTrackInfo();
         if (mappedTrackInfo == null) {
@@ -251,7 +252,6 @@ public class TrackSelectionHelper {
     public PKTracks buildTracks(String externalThumbnailWebVttUrl, List<CustomFormat> rawImageTracks) {
 
         clearTracksLists();
-        clearCurrentTracksOverrides();
 
         TrackGroupArray trackGroupArray;
         TrackGroup trackGroup;

--- a/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
@@ -2058,7 +2058,7 @@ public class TrackSelectionHelper {
      * to apply the same for the next media. Which internally may cause the incorrect track/period
      * selection
      */
-    protected void clearCurrentTracksOverrides() {
+    private void clearCurrentTracksOverrides() {
         if (selector != null && trackSelectionOverridesBuilder != null) {
             ImmutableList<TrackSelectionOverrides.TrackSelectionOverride> trackOverridesList = selector.getParameters().trackSelectionOverrides.asList();
             if (trackOverridesList.isEmpty()) {

--- a/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
@@ -251,6 +251,7 @@ public class TrackSelectionHelper {
     public PKTracks buildTracks(String externalThumbnailWebVttUrl, List<CustomFormat> rawImageTracks) {
 
         clearTracksLists();
+        clearCurrentTracksOverrides();
 
         TrackGroupArray trackGroupArray;
         TrackGroup trackGroup;
@@ -1884,12 +1885,10 @@ public class TrackSelectionHelper {
             externalVttThumbnailRangesInfo.clear();
             externalVttThumbnailRangesInfo = null;
         }
-        clearCurrentTracksOverrides();
     }
 
     protected void release() {
         tracksInfoListener.onRelease(lastSelectedTrackIds);
-        clearCurrentTracksOverrides();
         tracksInfoListener = null;
         trackSelectionParameters = null;
         trackSelectionOverridesBuilder = null;
@@ -2059,7 +2058,7 @@ public class TrackSelectionHelper {
      * to apply the same for the next media. Which internally may cause the incorrect track/period
      * selection
      */
-    private void clearCurrentTracksOverrides() {
+    protected void clearCurrentTracksOverrides() {
         if (selector != null && trackSelectionOverridesBuilder != null) {
             ImmutableList<TrackSelectionOverrides.TrackSelectionOverride> trackOverridesList = selector.getParameters().trackSelectionOverrides.asList();
             if (trackOverridesList.isEmpty()) {


### PR DESCRIPTION
* Remove warning from logcat

* Clearing overrides in `buildTracks` and `stop`
  `stop` is required because on change media media is loaded first then `buildTracks` comes. Because of it ExoPlayer uses previous overrides and goes into error. Hence it is important to clear it before hand.

* Moving the call from `buildTracks` to `prepareTracks`