### PR TITLE
FEC-12094 Support Instream DRM license 

### DIFF
--- a/playkit/src/main/java/com/kaltura/playkit/player/DRMSettings.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/DRMSettings.java
@@ -59,7 +59,7 @@ public class DRMSettings {
      * </br>
      * <br>
      * <br>
-     * Passing `false` for Widevine streams is not applicable.
+     * Passing `true` for Widevine streams is not applicable.
      * </br>
      */
     public DRMSettings setIsForceDefaultLicenseUri(boolean isForceDefaultLicenseUri) {

--- a/playkit/src/main/java/com/kaltura/playkit/player/DRMSettings.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/DRMSettings.java
@@ -47,6 +47,20 @@ public class DRMSettings {
     /**
      * Sets whether to force use the default DRM license server URI even if the media specifies its
      * own DRM license server URI.
+     * <br>
+     * Default is set to `true` for Playready DRM streams otherwise `false` for Widevine DRM streams.
+     * Means in both the cases, DRM license URL should be passed for the playback.
+     * </br>
+     * <br>
+     * <br>
+     * If license URL is not passed for Playready Stream and
+     * manifest has InStream license URL then set it `false`,
+     * by doing this; Player will take the license URL from the manifest.
+     * </br>
+     * <br>
+     * <br>
+     * Passing `false` for Widevine streams is not applicable.
+     * </br>
      */
     public DRMSettings setIsForceDefaultLicenseUri(boolean isForceDefaultLicenseUri) {
         this.isForceDefaultLicenseUri = isForceDefaultLicenseUri;

--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
@@ -672,7 +672,7 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.Listener, Metadata
         String licenseUri = getDrmLicenseUrl(sourceConfig.mediaSource, scheme);
         UUID uuid = (scheme == PKDrmParams.Scheme.WidevineCENC) ? MediaSupport.WIDEVINE_UUID : MediaSupport.PLAYREADY_UUID;
         boolean isForceDefaultLicenseUri = playerSettings.getDRMSettings().getIsForceDefaultLicenseUri();
-        if (licenseUri == null && isForceDefaultLicenseUri) {
+        if (TextUtils.isEmpty(licenseUri) && isForceDefaultLicenseUri) {
             sendUnexpectedError();
             return;
         }
@@ -1355,22 +1355,24 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.Listener, Metadata
      * By default DRM Schema is Widevine and if Schema
      * comes as 'Playready', it means application wants to play
      * a playready media.
-     *
+     * <br>
      * Now if Application is not sending any license then the license
      * should be picked from the manifest. For that Application has to
      * pass
+     * </br>
+     *
      * <br>
      * <br>
      * player.getSettings().setDRMSettings(new DRMSettings(PKDrmParams.Scheme.PlayReadyCENC).setIsForceDefaultLicenseUri(false));
      * </br>
      *
-     * If `setIsForceDefaultLicenseUri` is set to `true`
+     * If `setIsForceDefaultLicenseUri` is set to `true` and license URL is not there
      * then sending fatal error to the App
      */
     private void sendUnexpectedError() {
         log.v("sendUnexpectedError");
         if (eventListener != null) {
-            String errorMessage = "If DRM license is not provided for Stream then use `setIsForceDefaultLicenseUri(false)` in `DRMSettings`. \n" +
+            String errorMessage = "If DRM license is not provided for Playready Stream then use `setIsForceDefaultLicenseUri(false)` in `DRMSettings`. \n" +
                     "It will enable the Player to take InStream DRM license.";
             currentError = new PKError(PKPlayerErrorType.UNEXPECTED, PKError.Severity.Fatal, errorMessage, new IllegalArgumentException(errorMessage));
             eventListener.onEvent(PlayerEvent.Type.ERROR);

--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
@@ -672,10 +672,8 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.Listener, Metadata
         String licenseUri = getDrmLicenseUrl(sourceConfig.mediaSource, scheme);
         UUID uuid = (scheme == PKDrmParams.Scheme.WidevineCENC) ? MediaSupport.WIDEVINE_UUID : MediaSupport.PLAYREADY_UUID;
         boolean isForceDefaultLicenseUri = playerSettings.getDRMSettings().getIsForceDefaultLicenseUri();
-        if (scheme == PKDrmParams.Scheme.PlayReadyCENC &&
-                licenseUri == null &&
-                isForceDefaultLicenseUri) {
-            sendPlayReadyDRMError();
+        if (licenseUri == null && isForceDefaultLicenseUri) {
+            sendUnexpectedError();
             return;
         }
 
@@ -683,7 +681,7 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.Listener, Metadata
                 .Builder(uuid)
                 .setLicenseUri(licenseUri)
                 .setMultiSession(playerSettings.getDRMSettings().getIsMultiSession())
-                .setForceDefaultLicenseUri(licenseUri != null && isForceDefaultLicenseUri /* If DRM license is null then `isForceDefaultLicenseUri` should be false*/);
+                .setForceDefaultLicenseUri(isForceDefaultLicenseUri);
 
         Map<String, String> licenseRequestParamsHeaders = getLicenseRequestParamsHeaders(licenseUri);
         if (licenseRequestParamsHeaders != null) {
@@ -1369,12 +1367,12 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.Listener, Metadata
      * If `setIsForceDefaultLicenseUri` is set to `true`
      * then sending fatal error to the App
      */
-    private void sendPlayReadyDRMError() {
-        log.v("sendPlayReadyDRMError");
+    private void sendUnexpectedError() {
+        log.v("sendUnexpectedError");
         if (eventListener != null) {
-            String errorMessage = "If DRM license is not provided for PlayReady Stream then use `setIsForceDefaultLicenseUri(false)` in `DRMSettings`. \n" +
+            String errorMessage = "If DRM license is not provided for Stream then use `setIsForceDefaultLicenseUri(false)` in `DRMSettings`. \n" +
                     "It will enable the Player to take InStream DRM license.";
-            currentError = new PKError(PKPlayerErrorType.DRM_ERROR, PKError.Severity.Fatal, errorMessage, new IllegalArgumentException(errorMessage));
+            currentError = new PKError(PKPlayerErrorType.UNEXPECTED, PKError.Severity.Fatal, errorMessage, new IllegalArgumentException(errorMessage));
             eventListener.onEvent(PlayerEvent.Type.ERROR);
         }
     }

--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
@@ -20,6 +20,7 @@ import android.text.TextUtils;
 import android.util.Pair;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.google.common.base.Charsets;
 import com.kaltura.android.exoplayer2.C;
@@ -633,7 +634,7 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.Listener, Metadata
             builder.setLiveConfiguration(lowLatencyConfiguration);
         }
 
-        if ((format == PKMediaFormat.dash || format == PKMediaFormat.hls) && sourceConfig.mediaSource.hasDrmParams()) {
+        if ((format == PKMediaFormat.dash || format == PKMediaFormat.hls)) {
             setMediaItemBuilderDRMParams(sourceConfig, builder);
         } else  if (format == PKMediaFormat.udp) {
             builder.setMimeType(null);
@@ -669,29 +670,36 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.Listener, Metadata
         log.d("PKDrmParams.Scheme = " + scheme);
 
         String licenseUri = getDrmLicenseUrl(sourceConfig.mediaSource, scheme);
+        UUID uuid = (scheme == PKDrmParams.Scheme.WidevineCENC) ? MediaSupport.WIDEVINE_UUID : MediaSupport.PLAYREADY_UUID;
 
+        MediaItem.DrmConfiguration.Builder drmConfigurationBuilder = new MediaItem.DrmConfiguration
+                .Builder(uuid)
+                .setLicenseUri(licenseUri)
+                .setMultiSession(playerSettings.getDRMSettings().getIsMultiSession())
+                .setForceDefaultLicenseUri(playerSettings.getDRMSettings().getIsForceDefaultLicenseUri());
+
+        Map<String, String> licenseRequestParamsHeaders = getLicenseRequestParamsHeaders(licenseUri);
+        if (licenseRequestParamsHeaders != null) {
+            drmConfigurationBuilder.setLicenseRequestHeaders(licenseRequestParamsHeaders);
+        }
+
+        builder.setDrmConfiguration(drmConfigurationBuilder.build());
+    }
+
+    @Nullable
+    private Map<String, String> getLicenseRequestParamsHeaders(String licenseUri) {
+        Map<String, String> licenseRequestParamsHeaders = null;
         if (licenseUri != null) {
             PKRequestParams licenseRequestParams = new PKRequestParams(Uri.parse(licenseUri), new HashMap<>());
-
             if (playerSettings.getLicenseRequestAdapter() != null) {
                 licenseRequestParams = playerSettings.getLicenseRequestAdapter().adapt(licenseRequestParams);
             }
-
-            Map<String, String> licenseRequestParamsHeaders = licenseRequestParams.headers;
-            UUID uuid = (scheme == PKDrmParams.Scheme.WidevineCENC) ? MediaSupport.WIDEVINE_UUID : MediaSupport.PLAYREADY_UUID;
-
-            MediaItem.DrmConfiguration drmConfiguration = new MediaItem.DrmConfiguration
-                    .Builder(uuid)
-                    .setLicenseUri(licenseUri)
-                    .setMultiSession(playerSettings.getDRMSettings().getIsMultiSession())
-                    .setForceDefaultLicenseUri(playerSettings.getDRMSettings().getIsForceDefaultLicenseUri())
-                    .setLicenseRequestHeaders(licenseRequestParamsHeaders)
-                    .build();
-
-            builder.setDrmConfiguration(drmConfiguration);
+            licenseRequestParamsHeaders = licenseRequestParams.headers;
         }
+        return licenseRequestParamsHeaders;
     }
 
+    @Nullable
     private String getDrmLicenseUrl(PKMediaSource mediaSource, PKDrmParams.Scheme scheme) {
         String licenseUrl = null;
 

--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
@@ -691,10 +691,16 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.Listener, Metadata
         }
     }
 
+    /**
+     * Get the license request headers from the Adapter
+     *
+     * @param licenseUri license URI for the media
+     * @return return the license request header's map
+     */
     @Nullable
     private Map<String, String> getLicenseRequestParamsHeaders(String licenseUri) {
         Map<String, String> licenseRequestParamsHeaders = null;
-        if (licenseUri != null) {
+        if (!TextUtils.isEmpty(licenseUri)) {
             PKRequestParams licenseRequestParams = new PKRequestParams(Uri.parse(licenseUri), new HashMap<>());
             if (playerSettings.getLicenseRequestAdapter() != null) {
                 licenseRequestParams = playerSettings.getLicenseRequestAdapter().adapt(licenseRequestParams);


### PR DESCRIPTION
### Description of the Changes

Sets whether to force use the default DRM license server URI even if the media specifies its
own DRM license server URI.

Use following with Playready media URL if all license key requests will specify their own URL. 

`        player.getSettings().setDRMSettings(new DRMSettings(PKDrmParams.Scheme.PlayReadyCENC).setIsForceDefaultLicenseUri(false));
`

### CheckLists

- [x] Playready DRM media with `DRMSettings`
- [x] Widevine DRM media with `DRMSettings`
- [x] Clear Dash Media

