### PR TITLE
FEC-12063 Exposed `allowChunklessPreparation` on `PlayerSettings`

### DIFF
--- a/playkit/src/main/java/com/kaltura/playkit/Player.java
+++ b/playkit/src/main/java/com/kaltura/playkit/Player.java
@@ -218,6 +218,34 @@ public interface Player {
         Settings forceSinglePlayerEngine(boolean forceSinglePlayerEngine);
 
         /**
+         * Default is `true`.
+         * <br>
+         * Player will only use the information in the multivariant playlist to prepare the stream,
+         * which works if the `#EXT-X-STREAM-INF` tags contain the `CODECS` attribute
+         * <br>
+         * You may need to disable this feature if your media segments contain muxed
+         * closed-caption tracks that are not declared in the multivariant playlist with a
+         * `#EXT-X-MEDIA:TYPE=CLOSED-CAPTIONS` tag. Otherwise, these closed-caption tracks
+         * won't be detected and played.
+         * </br/>
+         * <br>
+         * <br>
+         * You can disable chunkless preparation in the
+         * `HlsMediaSource.Factory` as shown in the following snippet.
+         * </br/>
+         * <br>
+         * <br>
+         * Note that this
+         * will increase start up time as ExoPlayer needs to download a media segment to
+         * discover these additional tracks and it is preferable to declare the
+         * closed-caption tracks in the multivariant playlist instead.
+         * </br/>
+         * @param allowChunklessPreparation chunkless preparation is allowed or not
+         * @return - Player Settings
+         */
+        Settings allowChunklessPreparation(boolean allowChunklessPreparation);
+
+        /**
          * Set the flag which handles the video view
          *
          * @param hide video surface visibility

--- a/playkit/src/main/java/com/kaltura/playkit/Player.java
+++ b/playkit/src/main/java/com/kaltura/playkit/Player.java
@@ -221,7 +221,7 @@ public interface Player {
          * Default is `true`.
          * <br>
          * Player will only use the information in the multivariant playlist to prepare the stream,
-         * which works if the `#EXT-X-STREAM-INF` tags contain the `CODECS` attribute
+         * which works if the `#EXT-X-STREAM-INF` tags contain the `CODECS` attribute.
          * <br>
          * You may need to disable this feature if your media segments contain muxed
          * closed-caption tracks that are not declared in the multivariant playlist with a
@@ -230,13 +230,9 @@ public interface Player {
          * </br/>
          * <br>
          * <br>
-         * You can disable chunkless preparation in the
-         * `HlsMediaSource.Factory` as shown in the following snippet.
-         * </br/>
-         * <br>
-         * <br>
+         * You can disable chunkless preparation by setting this flag to `false`.
          * Note that this
-         * will increase start up time as ExoPlayer needs to download a media segment to
+         * will increase start up time as Player needs to download a media segment to
          * discover these additional tracks and it is preferable to declare the
          * closed-caption tracks in the multivariant playlist instead.
          * </br/>

--- a/playkit/src/main/java/com/kaltura/playkit/Player.java
+++ b/playkit/src/main/java/com/kaltura/playkit/Player.java
@@ -218,7 +218,7 @@ public interface Player {
         Settings forceSinglePlayerEngine(boolean forceSinglePlayerEngine);
 
         /**
-         * Default is `true`.
+         * This flag is only for the HLS Streams. Default is `true`.
          * <br>
          * Player will only use the information in the multivariant playlist to prepare the stream,
          * which works if the `#EXT-X-STREAM-INF` tags contain the `CODECS` attribute.

--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
@@ -322,7 +322,7 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.Listener, Metadata
             } else {
                 player.setMediaSources(Collections.singletonList(mediaSource), 0, playerPosition == TIME_UNSET ? 0 : playerPosition);
             }
-
+            
             player.prepare();
 
             changeState(PlayerState.LOADING);
@@ -507,6 +507,7 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.Listener, Metadata
                 mediaSource = new HlsMediaSource.Factory(dataSourceFactory)
                         .setDrmSessionManagerProvider(getDrmSessionManagerProvider(sourceConfig.mediaSource))
                         .setLoadErrorHandlingPolicy(customLoadErrorHandlingPolicy)
+                        .setAllowChunklessPreparation(playerSettings.isAllowChunklessPreparation())
                         .createMediaSource(mediaItem);
                 break;
 

--- a/playkit/src/main/java/com/kaltura/playkit/player/PlayerSettings.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/PlayerSettings.java
@@ -32,12 +32,18 @@ public class PlayerSettings implements Player.Settings {
     private boolean adAutoPlayOnResume = true;
     private boolean vrPlayerEnabled = true;
     private boolean isVideoViewHidden;
-    private VideoCodecSettings preferredVideoCodecSettings = new VideoCodecSettings();
-    private AudioCodecSettings preferredAudioCodecSettings = new AudioCodecSettings();
     private boolean isTunneledAudioPlayback;
     private boolean handleAudioBecomingNoisyEnabled;
-    private PKWakeMode wakeMode = PKWakeMode.NONE;
     private boolean handleAudioFocus;
+
+    //Flag helping to check if client app wants to use a single player instance at a time
+    //Only if IMA plugin is there then only this flag is set to true.
+    private boolean forceSinglePlayerEngine = false;
+    private boolean allowChunklessPreparation = true;
+
+    private PKWakeMode wakeMode = PKWakeMode.NONE;
+    private VideoCodecSettings preferredVideoCodecSettings = new VideoCodecSettings();
+    private AudioCodecSettings preferredAudioCodecSettings = new AudioCodecSettings();
     private PKSubtitlePreference subtitlePreference = PKSubtitlePreference.INTERNAL;
     private Integer maxAudioBitrate;
     private int maxAudioChannelCount = -1;
@@ -50,11 +56,7 @@ public class PlayerSettings implements Player.Settings {
     private VRSettings vrSettings;
     private PKLowLatencyConfig pkLowLatencyConfig;
     private PKRequestConfig pkRequestConfig = new PKRequestConfig();
-    /**
-     * Flag helping to check if client app wants to use a single player instance at a time
-     * Only if IMA plugin is there then only this flag is set to true.
-     */
-    private boolean forceSinglePlayerEngine = false;
+
     private DRMSettings drmSettings = new DRMSettings(PKDrmParams.Scheme.WidevineCENC);
     private PKTrackConfig preferredTextTrackConfig;
     private PKTrackConfig preferredAudioTrackConfig;
@@ -149,6 +151,10 @@ public class PlayerSettings implements Player.Settings {
 
     public boolean isForceSinglePlayerEngine() {
         return forceSinglePlayerEngine;
+    }
+
+    public boolean isAllowChunklessPreparation() {
+        return allowChunklessPreparation;
     }
 
     public VideoCodecSettings getPreferredVideoCodecSettings() {
@@ -323,6 +329,12 @@ public class PlayerSettings implements Player.Settings {
     @Override
     public Player.Settings forceSinglePlayerEngine(boolean forceSinglePlayerEngine) {
         this.forceSinglePlayerEngine = forceSinglePlayerEngine;
+        return this;
+    }
+
+    @Override
+    public Player.Settings allowChunklessPreparation(boolean allowChunklessPreparation) {
+        this.allowChunklessPreparation = allowChunklessPreparation;
         return this;
     }
 


### PR DESCRIPTION
- This flag is for HLS streams.