### PR TITLE
FEC-12253 Implementation of accessing SCTE-35 event streams as player event

### DIFF
--- a/playkit/src/main/java/com/kaltura/playkit/PlayerEngineWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/PlayerEngineWrapper.java
@@ -1,4 +1,5 @@
 package com.kaltura.playkit;
+
 import com.kaltura.android.exoplayer2.upstream.cache.Cache;
 import com.kaltura.android.exoplayer2.source.dash.manifest.EventStream;
 import com.kaltura.playkit.player.ABRSettings;

--- a/playkit/src/main/java/com/kaltura/playkit/PlayerEngineWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/PlayerEngineWrapper.java
@@ -1,6 +1,6 @@
 package com.kaltura.playkit;
 
-import com.kaltura.android.exoplayer2.upstream.cache.Cache;
+import com.kaltura.android.exoplayer2.source.dash.manifest.EventStream;
 import com.kaltura.playkit.player.ABRSettings;
 import com.kaltura.playkit.player.BaseTrack;
 import com.kaltura.playkit.player.PKAspectRatioResizeMode;
@@ -186,6 +186,11 @@ public class PlayerEngineWrapper implements PlayerEngine {
     }
 
     @Override
+    public List<EventStream> getEventStreams() {
+        return playerEngine.getEventStreams();
+    }
+
+    @Override
     public boolean isLive() {
         return playerEngine.isLive();
     }
@@ -204,7 +209,7 @@ public class PlayerEngineWrapper implements PlayerEngine {
     public void setDownloadCache(Cache downloadCache) {
         playerEngine.setDownloadCache(downloadCache);
     }
-    
+
     @Override
     public ThumbnailInfo getThumbnailInfo(long positionMS) {
         return playerEngine.getThumbnailInfo(positionMS);

--- a/playkit/src/main/java/com/kaltura/playkit/PlayerEngineWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/PlayerEngineWrapper.java
@@ -1,5 +1,5 @@
 package com.kaltura.playkit;
-
+import com.kaltura.android.exoplayer2.upstream.cache.Cache;
 import com.kaltura.android.exoplayer2.source.dash.manifest.EventStream;
 import com.kaltura.playkit.player.ABRSettings;
 import com.kaltura.playkit.player.BaseTrack;

--- a/playkit/src/main/java/com/kaltura/playkit/PlayerEvent.java
+++ b/playkit/src/main/java/com/kaltura/playkit/PlayerEvent.java
@@ -42,7 +42,7 @@ public class PlayerEvent implements PKEvent {
     public static final Class<VideoTrackChanged> videoTrackChanged = VideoTrackChanged.class;
     public static final Class<AudioTrackChanged> audioTrackChanged = AudioTrackChanged.class;
     public static final Class<TextTrackChanged> textTrackChanged = TextTrackChanged.class;
-    public static final Class<EventStreamChanged> eventStreamAvailable = EventStreamChanged.class;
+    public static final Class<EventStreamChanged> eventStreamChanged = EventStreamChanged.class;
     public static final Class<ImageTrackChanged> imageTrackChanged = ImageTrackChanged.class;
 
     public static final Class<PlaybackRateChanged> playbackRateChanged = PlaybackRateChanged.class;

--- a/playkit/src/main/java/com/kaltura/playkit/PlayerEvent.java
+++ b/playkit/src/main/java/com/kaltura/playkit/PlayerEvent.java
@@ -14,6 +14,7 @@ package com.kaltura.playkit;
 
 import androidx.annotation.NonNull;
 
+import com.kaltura.android.exoplayer2.source.dash.manifest.EventStream;
 import com.kaltura.playkit.player.AudioTrack;
 import com.kaltura.playkit.player.ImageTrack;
 import com.kaltura.playkit.player.PKAspectRatioResizeMode;
@@ -41,6 +42,7 @@ public class PlayerEvent implements PKEvent {
     public static final Class<VideoTrackChanged> videoTrackChanged = VideoTrackChanged.class;
     public static final Class<AudioTrackChanged> audioTrackChanged = AudioTrackChanged.class;
     public static final Class<TextTrackChanged> textTrackChanged = TextTrackChanged.class;
+    public static final Class<EventStreamAvailable> eventStreamAvailable = EventStreamAvailable.class;
     public static final Class<ImageTrackChanged> imageTrackChanged = ImageTrackChanged.class;
 
     public static final Class<PlaybackRateChanged> playbackRateChanged = PlaybackRateChanged.class;
@@ -212,6 +214,14 @@ public class PlayerEvent implements PKEvent {
         }
     }
 
+    public static class EventStreamAvailable extends PlayerEvent {
+        public final List<EventStream> eventStreamsList;
+        public EventStreamAvailable(List<EventStream> eventStreams) {
+            super(Type.EVENT_STREAMS_AVAILABLE);
+            this.eventStreamsList = eventStreams;
+        }
+    }
+
     public static class ImageTrackChanged extends PlayerEvent {
 
         public final ImageTrack newTrack;
@@ -376,7 +386,8 @@ public class PlayerEvent implements PKEvent {
         OUTPUT_BUFFER_COUNT_UPDATE,
         BYTES_LOADED,           // Bytes were downloaded from the network
         SUBTITLE_STYLE_CHANGED,  // Subtitle style is changed.
-        ASPECT_RATIO_RESIZE_MODE_CHANGED //Send when updating the Surface Vide Aspect Ratio size mode.
+        ASPECT_RATIO_RESIZE_MODE_CHANGED, //Send when updating the Surface Vide Aspect Ratio size mode.
+        EVENT_STREAMS_AVAILABLE //Send event streams received from manifest
     }
 
     @Override

--- a/playkit/src/main/java/com/kaltura/playkit/PlayerEvent.java
+++ b/playkit/src/main/java/com/kaltura/playkit/PlayerEvent.java
@@ -217,7 +217,7 @@ public class PlayerEvent implements PKEvent {
     public static class EventStreamChanged extends PlayerEvent {
         public final List<EventStream> eventStreamList;
         public EventStreamChanged(List<EventStream> eventStreams) {
-            super(Type.EVENT_STREAMS_CHANGED);
+            super(Type.EVENT_STREAM_CHANGED);
             this.eventStreamList = eventStreams;
         }
     }
@@ -387,7 +387,7 @@ public class PlayerEvent implements PKEvent {
         BYTES_LOADED,           // Bytes were downloaded from the network
         SUBTITLE_STYLE_CHANGED,  // Subtitle style is changed.
         ASPECT_RATIO_RESIZE_MODE_CHANGED, //Send when updating the Surface Vide Aspect Ratio size mode.
-        EVENT_STREAMS_CHANGED //Send event streams received from manifest
+        EVENT_STREAM_CHANGED //Send event streams received from manifest
     }
 
     @Override

--- a/playkit/src/main/java/com/kaltura/playkit/PlayerEvent.java
+++ b/playkit/src/main/java/com/kaltura/playkit/PlayerEvent.java
@@ -42,7 +42,7 @@ public class PlayerEvent implements PKEvent {
     public static final Class<VideoTrackChanged> videoTrackChanged = VideoTrackChanged.class;
     public static final Class<AudioTrackChanged> audioTrackChanged = AudioTrackChanged.class;
     public static final Class<TextTrackChanged> textTrackChanged = TextTrackChanged.class;
-    public static final Class<EventStreamAvailable> eventStreamAvailable = EventStreamAvailable.class;
+    public static final Class<EventStreamChanged> eventStreamAvailable = EventStreamChanged.class;
     public static final Class<ImageTrackChanged> imageTrackChanged = ImageTrackChanged.class;
 
     public static final Class<PlaybackRateChanged> playbackRateChanged = PlaybackRateChanged.class;
@@ -214,10 +214,10 @@ public class PlayerEvent implements PKEvent {
         }
     }
 
-    public static class EventStreamAvailable extends PlayerEvent {
+    public static class EventStreamChanged extends PlayerEvent {
         public final List<EventStream> eventStreamsList;
-        public EventStreamAvailable(List<EventStream> eventStreams) {
-            super(Type.EVENT_STREAMS_AVAILABLE);
+        public EventStreamChanged(List<EventStream> eventStreams) {
+            super(Type.EVENT_STREAMS_CHANGED);
             this.eventStreamsList = eventStreams;
         }
     }
@@ -387,7 +387,7 @@ public class PlayerEvent implements PKEvent {
         BYTES_LOADED,           // Bytes were downloaded from the network
         SUBTITLE_STYLE_CHANGED,  // Subtitle style is changed.
         ASPECT_RATIO_RESIZE_MODE_CHANGED, //Send when updating the Surface Vide Aspect Ratio size mode.
-        EVENT_STREAMS_AVAILABLE //Send event streams received from manifest
+        EVENT_STREAMS_CHANGED //Send event streams received from manifest
     }
 
     @Override

--- a/playkit/src/main/java/com/kaltura/playkit/PlayerEvent.java
+++ b/playkit/src/main/java/com/kaltura/playkit/PlayerEvent.java
@@ -215,10 +215,10 @@ public class PlayerEvent implements PKEvent {
     }
 
     public static class EventStreamChanged extends PlayerEvent {
-        public final List<EventStream> eventStreamsList;
+        public final List<EventStream> eventStreamList;
         public EventStreamChanged(List<EventStream> eventStreams) {
             super(Type.EVENT_STREAMS_CHANGED);
-            this.eventStreamsList = eventStreams;
+            this.eventStreamList = eventStreams;
         }
     }
 

--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
@@ -1606,6 +1606,13 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.Listener, Metadata
             public void onImageTrackChanged() {
                 sendEvent(PlayerEvent.Type.IMAGE_TRACK_CHANGED);
             }
+
+            @Override
+            public void onEventStreamsReady(List<EventStream> eventStreamsList) {
+                eventStreams = eventStreamsList;
+                sendDistinctEvent(PlayerEvent.Type.EVENT_STREAMS_AVAILABLE);
+
+            }
         };
     }
 
@@ -1666,6 +1673,11 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.Listener, Metadata
             return trackSelectionHelper.getLastSelectedTrack(renderType);
         }
         return null;
+    }
+
+    @Override
+    public List<EventStream> getEventStreams() {
+        return eventStreams;
     }
 
     @Override

--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
@@ -953,9 +953,9 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.Listener, Metadata
 
             if (player.getCurrentManifest() instanceof DashManifest) {
                 if (((DashManifest) player.getCurrentManifest()).getPeriodCount() > 0) {
-                    List<EventStream> eventStreamsList = ((DashManifest) player.getCurrentManifest()).getPeriod(0).eventStreams;
-                    if (!eventStreamsList.isEmpty()) {
-                        eventStreams = eventStreamsList;
+                    List<EventStream> eventStreamList = ((DashManifest) player.getCurrentManifest()).getPeriod(0).eventStreams;
+                    if (!eventStreamList.isEmpty()) {
+                        eventStreams = eventStreamList;
                         sendDistinctEvent(PlayerEvent.Type.EVENT_STREAMS_CHANGED);
                     }
                 }
@@ -1629,8 +1629,8 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.Listener, Metadata
             }
 
             @Override
-            public void onEventStreamsChanged(List<EventStream> eventStreamsList) {
-                eventStreams = eventStreamsList;
+            public void onEventStreamsChanged(List<EventStream> eventStreamList) {
+                eventStreams = eventStreamList;
                 sendDistinctEvent(PlayerEvent.Type.EVENT_STREAMS_CHANGED);
             }
         };

--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
@@ -956,7 +956,7 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.Listener, Metadata
                     List<EventStream> eventStreamsList = ((DashManifest) player.getCurrentManifest()).getPeriod(0).eventStreams;
                     if (!eventStreamsList.isEmpty()) {
                         eventStreams = eventStreamsList;
-                        sendDistinctEvent(PlayerEvent.Type.EVENT_STREAMS_AVAILABLE);
+                        sendDistinctEvent(PlayerEvent.Type.EVENT_STREAMS_CHANGED);
                     }
                 }
             }
@@ -1629,9 +1629,9 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.Listener, Metadata
             }
 
             @Override
-            public void onEventStreamsReady(List<EventStream> eventStreamsList) {
+            public void onEventStreamsChanged(List<EventStream> eventStreamsList) {
                 eventStreams = eventStreamsList;
-                sendDistinctEvent(PlayerEvent.Type.EVENT_STREAMS_AVAILABLE);
+                sendDistinctEvent(PlayerEvent.Type.EVENT_STREAMS_CHANGED);
             }
         };
     }

--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
@@ -943,23 +943,24 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.Listener, Metadata
             }
         }
 
-        if (reason == Player.TIMELINE_CHANGE_REASON_SOURCE_UPDATE && getDuration() != TIME_UNSET) {
-            if (!isLoadedMetaDataFired)  {
-                sendDistinctEvent(PlayerEvent.Type.LOADED_METADATA);
+        if (reason == Player.TIMELINE_CHANGE_REASON_SOURCE_UPDATE) {
+            if (getDuration() != TIME_UNSET) {
+                if (!isLoadedMetaDataFired) {
+                    sendDistinctEvent(PlayerEvent.Type.LOADED_METADATA);
+                }
+                sendDistinctEvent(PlayerEvent.Type.DURATION_CHANGE);
             }
-            sendDistinctEvent(PlayerEvent.Type.DURATION_CHANGE);
-        }
 
-        if(player.getCurrentManifest() instanceof  DashManifest){
-            if(((DashManifest)player.getCurrentManifest()).getPeriodCount() > 0){
-                List<EventStream> eventStreamsList = ((DashManifest) player.getCurrentManifest()).getPeriod(0).eventStreams;
-                if (eventStreamsList.size() > 0) {
-                    eventStreams = eventStreamsList;
-                    sendDistinctEvent(PlayerEvent.Type.EVENT_STREAMS_AVAILABLE);
+            if (player.getCurrentManifest() instanceof DashManifest) {
+                if (((DashManifest) player.getCurrentManifest()).getPeriodCount() > 0) {
+                    List<EventStream> eventStreamsList = ((DashManifest) player.getCurrentManifest()).getPeriod(0).eventStreams;
+                    if (!eventStreamsList.isEmpty()) {
+                        eventStreams = eventStreamsList;
+                        sendDistinctEvent(PlayerEvent.Type.EVENT_STREAMS_AVAILABLE);
+                    }
                 }
             }
         }
-
     }
 
     @Override
@@ -1034,7 +1035,7 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.Listener, Metadata
                         dashManifestString = null;
                     }
                 }
-                shouldGetTracksInfo = !trackSelectionHelper.prepareTracks(tracksInfo, sourceConfig.getExternalVttThumbnailUrl() ,customDashManifest);
+                shouldGetTracksInfo = !trackSelectionHelper.prepareTracks(tracksInfo, sourceConfig.getExternalVttThumbnailUrl(), customDashManifest);
             }
         }
 
@@ -1631,7 +1632,6 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.Listener, Metadata
             public void onEventStreamsReady(List<EventStream> eventStreamsList) {
                 eventStreams = eventStreamsList;
                 sendDistinctEvent(PlayerEvent.Type.EVENT_STREAMS_AVAILABLE);
-
             }
         };
     }

--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
@@ -956,7 +956,7 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.Listener, Metadata
                     List<EventStream> eventStreamList = ((DashManifest) player.getCurrentManifest()).getPeriod(0).eventStreams;
                     if (!eventStreamList.isEmpty()) {
                         eventStreams = eventStreamList;
-                        sendDistinctEvent(PlayerEvent.Type.EVENT_STREAMS_CHANGED);
+                        sendDistinctEvent(PlayerEvent.Type.EVENT_STREAM_CHANGED);
                     }
                 }
             }
@@ -1631,7 +1631,7 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.Listener, Metadata
             @Override
             public void onEventStreamsChanged(List<EventStream> eventStreamList) {
                 eventStreams = eventStreamList;
-                sendDistinctEvent(PlayerEvent.Type.EVENT_STREAMS_CHANGED);
+                sendDistinctEvent(PlayerEvent.Type.EVENT_STREAM_CHANGED);
             }
         };
     }

--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
@@ -74,6 +74,7 @@ import com.kaltura.android.exoplayer2.upstream.cache.Cache;
 import com.kaltura.android.exoplayer2.upstream.cache.CacheDataSource;
 import com.kaltura.android.exoplayer2.util.TimestampAdjuster;
 import com.kaltura.android.exoplayer2.video.CustomLoadControl;
+import com.kaltura.android.exoplayer2.source.dash.manifest.EventStream;
 import com.kaltura.playkit.*;
 import com.kaltura.playkit.drm.DeferredDrmSessionManager;
 import com.kaltura.playkit.drm.DrmCallback;
@@ -128,6 +129,7 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.Listener, Metadata
     private boolean rootViewUpdated;
 
     private PKTracks tracks;
+    private List<EventStream> eventStreams;
     private Timeline.Window window;
     private TrackSelectionHelper trackSelectionHelper;
     private DeferredDrmSessionManager drmSessionManager;
@@ -927,6 +929,17 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.Listener, Metadata
             }
             sendDistinctEvent(PlayerEvent.Type.DURATION_CHANGE);
         }
+
+        if(player.getCurrentManifest() instanceof  DashManifest){
+            if(((DashManifest)player.getCurrentManifest()).getPeriodCount() > 0){
+                List<EventStream> eventStreamsList = ((DashManifest) player.getCurrentManifest()).getPeriod(0).eventStreams;
+                if (eventStreamsList.size() > 0) {
+                    eventStreams = eventStreamsList;
+                    sendDistinctEvent(PlayerEvent.Type.EVENT_STREAMS_AVAILABLE);
+                }
+            }
+        }
+
     }
 
     @Override

--- a/playkit/src/main/java/com/kaltura/playkit/player/MediaPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/MediaPlayerWrapper.java
@@ -184,8 +184,6 @@ class MediaPlayerWrapper implements PlayerEngine, SurfaceHolder.Callback, MediaP
         sendDistinctEvent(PlayerEvent.Type.TRACKS_AVAILABLE);
         sendDistinctEvent(PlayerEvent.Type.PLAYBACK_INFO_UPDATED);
         sendDistinctEvent(PlayerEvent.Type.CAN_PLAY);
-        sendDistinctEvent(PlayerEvent.Type.EVENT_STREAMS_AVAILABLE);
-
     }
 
     private void handleContentCompleted() {

--- a/playkit/src/main/java/com/kaltura/playkit/player/MediaPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/MediaPlayerWrapper.java
@@ -184,6 +184,7 @@ class MediaPlayerWrapper implements PlayerEngine, SurfaceHolder.Callback, MediaP
         sendDistinctEvent(PlayerEvent.Type.TRACKS_AVAILABLE);
         sendDistinctEvent(PlayerEvent.Type.PLAYBACK_INFO_UPDATED);
         sendDistinctEvent(PlayerEvent.Type.CAN_PLAY);
+        sendDistinctEvent(PlayerEvent.Type.EVENT_STREAMS_AVAILABLE);
 
     }
 

--- a/playkit/src/main/java/com/kaltura/playkit/player/MediaPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/MediaPlayerWrapper.java
@@ -27,6 +27,7 @@ import android.view.SurfaceHolder;
 import androidx.annotation.NonNull;
 
 import com.kaltura.playkit.PKAbrFilter;
+import com.kaltura.android.exoplayer2.source.dash.manifest.EventStream;
 import com.kaltura.playkit.PKDrmParams;
 import com.kaltura.playkit.PKError;
 import com.kaltura.playkit.PKLog;
@@ -604,6 +605,11 @@ class MediaPlayerWrapper implements PlayerEngine, SurfaceHolder.Callback, MediaP
 
     @Override
     public BaseTrack getLastSelectedTrack(int renderType) {
+        return null;
+    }
+
+    @Override
+    public List<EventStream> getEventStreams() {
         return null;
     }
 

--- a/playkit/src/main/java/com/kaltura/playkit/player/PlayerController.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/PlayerController.java
@@ -971,11 +971,11 @@ public class PlayerController implements Player {
                         event = new PlayerEvent.TextTrackChanged(textTrack);
                         break;
                     case EVENT_STREAMS_CHANGED:
-                        List<EventStream> eventStreams = player.getEventStreams();
-                        if (eventStreams == null || eventStreams.isEmpty()) {
+                        List<EventStream> eventStreamList = player.getEventStreams();
+                        if (eventStreamList == null || eventStreamList.isEmpty()) {
                             return;
                         }
-                        event = new PlayerEvent.EventStreamChanged(eventStreams);
+                        event = new PlayerEvent.EventStreamChanged(eventStreamList);
                         break;
                     case IMAGE_TRACK_CHANGED:
                         ImageTrack imageTrack = (ImageTrack) player.getLastSelectedTrack(Consts.TRACK_TYPE_IMAGE);

--- a/playkit/src/main/java/com/kaltura/playkit/player/PlayerController.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/PlayerController.java
@@ -969,7 +969,7 @@ public class PlayerController implements Player {
 
                     case EVENT_STREAMS_AVAILABLE:
                         List<EventStream> streams =  player.getEventStreams();
-                        if (streams == null || streams.size() == 0) {
+                        if (streams == null || streams.isEmpty()) {
                             return;
                         }
                         event = new PlayerEvent.EventStreamAvailable(streams);

--- a/playkit/src/main/java/com/kaltura/playkit/player/PlayerController.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/PlayerController.java
@@ -970,12 +970,12 @@ public class PlayerController implements Player {
                         }
                         event = new PlayerEvent.TextTrackChanged(textTrack);
                         break;
-                    case EVENT_STREAMS_AVAILABLE:
+                    case EVENT_STREAMS_CHANGED:
                         List<EventStream> eventStreams = player.getEventStreams();
                         if (eventStreams == null || eventStreams.isEmpty()) {
                             return;
                         }
-                        event = new PlayerEvent.EventStreamAvailable(eventStreams);
+                        event = new PlayerEvent.EventStreamChanged(eventStreams);
                         break;
                     case IMAGE_TRACK_CHANGED:
                         ImageTrack imageTrack = (ImageTrack) player.getLastSelectedTrack(Consts.TRACK_TYPE_IMAGE);

--- a/playkit/src/main/java/com/kaltura/playkit/player/PlayerController.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/PlayerController.java
@@ -970,7 +970,7 @@ public class PlayerController implements Player {
                         }
                         event = new PlayerEvent.TextTrackChanged(textTrack);
                         break;
-                    case EVENT_STREAMS_CHANGED:
+                    case EVENT_STREAM_CHANGED:
                         List<EventStream> eventStreamList = player.getEventStreams();
                         if (eventStreamList == null || eventStreamList.isEmpty()) {
                             return;

--- a/playkit/src/main/java/com/kaltura/playkit/player/PlayerController.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/PlayerController.java
@@ -22,6 +22,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.kaltura.android.exoplayer2.upstream.cache.Cache;
+import com.kaltura.android.exoplayer2.source.dash.manifest.EventStream;
 import com.kaltura.playkit.Assert;
 import com.kaltura.playkit.PKController;
 import com.kaltura.playkit.PKDeviceCapabilities;
@@ -964,6 +965,14 @@ public class PlayerController implements Player {
                             return;
                         }
                         event = new PlayerEvent.TextTrackChanged(textTrack);
+                        break;
+
+                    case EVENT_STREAMS_AVAILABLE:
+                        List<EventStream> streams =  player.getEventStreams();
+                        if (streams == null || streams.size() == 0) {
+                            return;
+                        }
+                        event = new PlayerEvent.EventStreamAvailable(streams);
                         break;
                     case IMAGE_TRACK_CHANGED:
                         ImageTrack imageTrack = (ImageTrack) player.getLastSelectedTrack(Consts.TRACK_TYPE_IMAGE);

--- a/playkit/src/main/java/com/kaltura/playkit/player/PlayerController.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/PlayerController.java
@@ -970,13 +970,12 @@ public class PlayerController implements Player {
                         }
                         event = new PlayerEvent.TextTrackChanged(textTrack);
                         break;
-
                     case EVENT_STREAMS_AVAILABLE:
-                        List<EventStream> streams =  player.getEventStreams();
-                        if (streams == null || streams.isEmpty()) {
+                        List<EventStream> eventStreams = player.getEventStreams();
+                        if (eventStreams == null || eventStreams.isEmpty()) {
                             return;
                         }
-                        event = new PlayerEvent.EventStreamAvailable(streams);
+                        event = new PlayerEvent.EventStreamAvailable(eventStreams);
                         break;
                     case IMAGE_TRACK_CHANGED:
                         ImageTrack imageTrack = (ImageTrack) player.getLastSelectedTrack(Consts.TRACK_TYPE_IMAGE);

--- a/playkit/src/main/java/com/kaltura/playkit/player/PlayerEngine.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/PlayerEngine.java
@@ -14,6 +14,7 @@ package com.kaltura.playkit.player;
 
 import com.kaltura.android.exoplayer2.upstream.cache.Cache;
 import com.kaltura.playkit.PKAbrFilter;
+import com.kaltura.android.exoplayer2.source.dash.manifest.EventStream;
 import com.kaltura.playkit.PKController;
 import com.kaltura.playkit.PKError;
 import com.kaltura.playkit.PlaybackInfo;
@@ -262,6 +263,8 @@ public interface PlayerEngine {
     List<PKMetadata> getMetadata();
 
     BaseTrack getLastSelectedTrack(int renderType);
+
+    List<EventStream> getEventStreams();
 
     boolean isLive();
 

--- a/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
@@ -216,6 +216,7 @@ public class TrackSelectionHelper {
 
         List<CustomFormat> rawImageTracks = new ArrayList<>();
         List<EventStream> eventStreamsList = new ArrayList<>();
+
         if (customDashManifest != null) {
             for (int periodIndex = 0; periodIndex < customDashManifest.getPeriodCount(); periodIndex++) {
                 eventStreamsList.addAll(customDashManifest.getPeriod(periodIndex).eventStreams);
@@ -244,7 +245,7 @@ public class TrackSelectionHelper {
                 tracksInfoListener.onImageTrackChanged();
             }
 
-            if(!eventStreamsList.isEmpty()){
+            if (!eventStreamsList.isEmpty()) {
                 tracksInfoListener.onEventStreamsReady(eventStreamsList);
             }
         }

--- a/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
@@ -153,7 +153,7 @@ public class TrackSelectionHelper {
 
         void onImageTrackChanged();
 
-        void onEventStreamsReady(List<EventStream> eventStreamsList);
+        void onEventStreamsChanged(List<EventStream> eventStreamsList);
     }
 
     interface TracksErrorListener {
@@ -246,7 +246,7 @@ public class TrackSelectionHelper {
             }
 
             if (!eventStreamsList.isEmpty()) {
-                tracksInfoListener.onEventStreamsReady(eventStreamsList);
+                tracksInfoListener.onEventStreamsChanged(eventStreamsList);
             }
         }
 

--- a/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
@@ -153,7 +153,7 @@ public class TrackSelectionHelper {
 
         void onImageTrackChanged();
 
-        void onEventStreamsChanged(List<EventStream> eventStreamsList);
+        void onEventStreamsChanged(List<EventStream> eventStreamList);
     }
 
     interface TracksErrorListener {
@@ -215,11 +215,11 @@ public class TrackSelectionHelper {
         warnAboutUnsupportedRendererTypes();
 
         List<CustomFormat> rawImageTracks = new ArrayList<>();
-        List<EventStream> eventStreamsList = new ArrayList<>();
+        List<EventStream> eventStreamList = new ArrayList<>();
 
         if (customDashManifest != null && customDashManifest.getPeriodCount() > 0) {
             for (int periodIndex = 0; periodIndex < customDashManifest.getPeriodCount(); periodIndex++) {
-                eventStreamsList.addAll(customDashManifest.getPeriod(periodIndex).eventStreams);
+                eventStreamList.addAll(customDashManifest.getPeriod(periodIndex).eventStreams);
                 List<CustomAdaptationSet> adaptationSets = customDashManifest.getPeriod(periodIndex).adaptationSets;
 
                 for (int adaptationSetIndex = 0 ; adaptationSetIndex < adaptationSets.size() ; adaptationSetIndex++) {
@@ -245,8 +245,8 @@ public class TrackSelectionHelper {
                 tracksInfoListener.onImageTrackChanged();
             }
 
-            if (!eventStreamsList.isEmpty()) {
-                tracksInfoListener.onEventStreamsChanged(eventStreamsList);
+            if (!eventStreamList.isEmpty()) {
+                tracksInfoListener.onEventStreamsChanged(eventStreamList);
             }
         }
 

--- a/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
@@ -217,7 +217,7 @@ public class TrackSelectionHelper {
         List<CustomFormat> rawImageTracks = new ArrayList<>();
         List<EventStream> eventStreamsList = new ArrayList<>();
 
-        if (customDashManifest != null) {
+        if (customDashManifest != null && customDashManifest.getPeriodCount() > 0) {
             for (int periodIndex = 0; periodIndex < customDashManifest.getPeriodCount(); periodIndex++) {
                 eventStreamsList.addAll(customDashManifest.getPeriod(periodIndex).eventStreams);
                 List<CustomAdaptationSet> adaptationSets = customDashManifest.getPeriod(periodIndex).adaptationSets;

--- a/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
@@ -30,6 +30,7 @@ import com.kaltura.android.exoplayer2.dashmanifestparser.CustomFormat;
 import com.kaltura.android.exoplayer2.dashmanifestparser.CustomRepresentation;
 import com.kaltura.android.exoplayer2.source.TrackGroup;
 import com.kaltura.android.exoplayer2.source.TrackGroupArray;
+import com.kaltura.android.exoplayer2.source.dash.manifest.EventStream;
 import com.kaltura.android.exoplayer2.text.Subtitle;
 import com.kaltura.android.exoplayer2.text.webvtt.WebvttCueInfo;
 import com.kaltura.android.exoplayer2.trackselection.DefaultTrackSelector;
@@ -151,6 +152,8 @@ public class TrackSelectionHelper {
         void onTextTrackChanged();
 
         void onImageTrackChanged();
+
+        void onEventStreamsReady(List<EventStream> eventStreamsList);
     }
 
     interface TracksErrorListener {
@@ -212,8 +215,10 @@ public class TrackSelectionHelper {
         warnAboutUnsupportedRendererTypes();
 
         List<CustomFormat> rawImageTracks = new ArrayList<>();
+        List<EventStream> eventStreamsList = new ArrayList<>();
         if (customDashManifest != null) {
             for (int periodIndex = 0; periodIndex < customDashManifest.getPeriodCount(); periodIndex++) {
+                eventStreamsList.addAll(customDashManifest.getPeriod(periodIndex).eventStreams);
                 List<CustomAdaptationSet> adaptationSets = customDashManifest.getPeriod(periodIndex).adaptationSets;
 
                 for (int adaptationSetIndex = 0 ; adaptationSetIndex < adaptationSets.size() ; adaptationSetIndex++) {
@@ -237,6 +242,10 @@ public class TrackSelectionHelper {
             tracksInfoListener.onTracksInfoReady(tracksInfo);
             if (!tracksInfo.getImageTracks().isEmpty()) {
                 tracksInfoListener.onImageTrackChanged();
+            }
+
+            if(!eventStreamsList.isEmpty()){
+                tracksInfoListener.onEventStreamsReady(eventStreamsList);
             }
         }
 

--- a/playkit/version.gradle
+++ b/playkit/version.gradle
@@ -1,5 +1,5 @@
 // PlayKit Library Version
-ext.playkitVersion = 'dev'
+ext.playkitVersion = '4.22.0'
 
 // Append short commit hash to dev builds, i.e. "dev.a1b2c3d"
 if (playkitVersion == 'dev') {

--- a/playkit/version.gradle
+++ b/playkit/version.gradle
@@ -1,5 +1,5 @@
 // PlayKit Library Version
-ext.playkitVersion = '4.22.0'
+ext.playkitVersion = 'dev'
 
 // Append short commit hash to dev builds, i.e. "dev.a1b2c3d"
 if (playkitVersion == 'dev') {


### PR DESCRIPTION
### Description of the Changes

Fixes: https://kaltura.atlassian.net/browse/FEC-12253 
Exposing `PlayerEvent.eventStreamAvailable` event to get the SCTE markers present on the `</EventStream>` in `</Period>` tag.
Other metadata is getting exposed in `PlayerEvent.metadataAvailable` event.

