### PR TITLE
FEC-12321 `checkAssetStatus` is not returning correct status for Clear media asset with DRM license

### DIFF
--- a/playkit/src/main/java/com/kaltura/playkit/drm/WidevineModularAdapter.java
+++ b/playkit/src/main/java/com/kaltura/playkit/drm/WidevineModularAdapter.java
@@ -258,6 +258,11 @@ public class WidevineModularAdapter extends DrmAdapter {
             throw new LocalAssetsManager.RegisterException("Unable to parse the widevine data", null);
         }
 
+        //no content protection, so there could not be any status info, so return null.
+        if (!assetParsingStatus.hasContentProtection) {
+            return null;
+        }
+
         byte[] widevineInitData = assetParsingStatus.initData;
         if (widevineInitData == null) {
             throw new NoWidevinePSSHException("No Widevine PSSH in media", null);


### PR DESCRIPTION
- Added the condition to send `isRegistered` `true` for clear content having DRM license.

