### PR TITLE
FEC-12367 Fixed Subtitle Position's alignment issue

### DIFF
--- a/playkit/src/main/java/com/kaltura/playkit/PKSubtitleFormat.java
+++ b/playkit/src/main/java/com/kaltura/playkit/PKSubtitleFormat.java
@@ -21,7 +21,8 @@ import java.util.Map;
 
 public enum PKSubtitleFormat {
     vtt(MimeTypes.TEXT_VTT, "vtt"),
-    srt(MimeTypes.APPLICATION_SUBRIP, "srt");
+    srt(MimeTypes.APPLICATION_SUBRIP, "srt"),
+    ttml(MimeTypes.APPLICATION_TTML, "ttml");
 
     public final String mimeType;
     public final String pathExt;

--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerView.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerView.java
@@ -469,8 +469,7 @@ class ExoPlayerView extends BaseExoplayerView {
         if (subtitleViewPosition != null && cueList != null && !cueList.isEmpty()) {
             List<Cue> newCueList = new ArrayList<>();
             for (Cue cue : cueList) {
-                if ((cue.line !=  Cue.DIMEN_UNSET || cue.position != Cue.DIMEN_UNSET)
-                        && !subtitleViewPosition.isOverrideInlineCueConfig()) {
+                if (!subtitleViewPosition.isOverrideInlineCueConfig()) {
                     newCueList.add(cue);
                     continue;
                 }

--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerView.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerView.java
@@ -458,7 +458,7 @@ class ExoPlayerView extends BaseExoplayerView {
     }
 
     /**
-     * Creates new cue configuration if `isIgnoreCueSettings` is set to true by application
+     * Creates new cue configuration if `isOverrideInlineCueConfig` is set to true by application
      * Checks if the application wants to ignore the in-stream CueSettings otherwise goes with existing Cue configuration
      *
      * @param cueList cue list coming in stream
@@ -474,16 +474,16 @@ class ExoPlayerView extends BaseExoplayerView {
                     newCueList.add(cue);
                     continue;
                 }
+
                 CharSequence text = cue.text;
                 if (text != null) {
-                    Cue newCue = new Cue.Builder().
-                            setText(text).
-                            setTextAlignment(subtitleViewPosition.getSubtitleHorizontalPosition()).
-                            setLine(subtitleViewPosition.getVerticalPositionPercentage(), subtitleViewPosition.getLineType()).
-                            setLineAnchor(cue.lineAnchor).
-                            setPosition(cue.position).
-                            setPositionAnchor(cue.positionAnchor).
-                            setSize(subtitleViewPosition.getHorizontalPositionPercentage()).build();
+                    Cue newCue = new Cue.Builder()
+                            .setText(text)
+                            .setTextAlignment(subtitleViewPosition.getSubtitleHorizontalPosition())
+                            .setLine(subtitleViewPosition.getVerticalPositionPercentage(), subtitleViewPosition.getLineType())
+                            .setSize(subtitleViewPosition.getHorizontalPositionPercentage())
+                            .build();
+
                     newCueList.add(newCue);
                 }
             }

--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
@@ -1808,6 +1808,8 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.Listener, Metadata
         }
 
         if (exoPlayerSubtitleView != null) {
+            exoPlayerSubtitleView.setApplyEmbeddedFontSizes(subtitleStyleSettings.isUseEmbeddedFontSizes());
+            exoPlayerSubtitleView.setApplyEmbeddedStyles(subtitleStyleSettings.isUseEmbeddedStyles());
             exoPlayerSubtitleView.setStyle(subtitleStyleSettings.toCaptionStyle());
             exoPlayerSubtitleView.setFractionalTextSize(SubtitleView.DEFAULT_TEXT_SIZE_FRACTION * subtitleStyleSettings.getTextSizeFraction());
         } else {

--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
@@ -1808,7 +1808,8 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.Listener, Metadata
         }
 
         if (exoPlayerSubtitleView != null ) {
-            // Setting `false` will tell ExoPlayer to remove the styling of the cue.
+            // Setting `false` will tell ExoPlayer to remove the styling 
+            // and the font size of the cue.
             // In our API, for FE apps, default is `true` means override the styling
             // Hence reverting the value coming in `subtitleStyleSettings.isOverrideCueStyling()`
             exoPlayerSubtitleView.setApplyEmbeddedStyles(!subtitleStyleSettings.isOverrideCueStyling());

--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
@@ -1807,9 +1807,11 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.Listener, Metadata
             return;
         }
 
-        if (exoPlayerSubtitleView != null) {
-            exoPlayerSubtitleView.setApplyEmbeddedFontSizes(subtitleStyleSettings.isUseEmbeddedFontSizes());
-            exoPlayerSubtitleView.setApplyEmbeddedStyles(subtitleStyleSettings.isUseEmbeddedStyles());
+        if (exoPlayerSubtitleView != null ) {
+            // We are overriding the styling & font sizes given in the TTML or VTT/SRT file
+            exoPlayerSubtitleView.setApplyEmbeddedStyles(false);
+            exoPlayerSubtitleView.setApplyEmbeddedFontSizes(false);
+
             exoPlayerSubtitleView.setStyle(subtitleStyleSettings.toCaptionStyle());
             exoPlayerSubtitleView.setFractionalTextSize(SubtitleView.DEFAULT_TEXT_SIZE_FRACTION * subtitleStyleSettings.getTextSizeFraction());
         } else {

--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
@@ -1808,7 +1808,7 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.Listener, Metadata
         }
 
         if (exoPlayerSubtitleView != null ) {
-            // We are overriding the styling & font sizes given in the TTML or VTT/SRT file
+            // We are overriding the styling & font sizes given in the TTML or VTT file
             exoPlayerSubtitleView.setApplyEmbeddedStyles(false);
             exoPlayerSubtitleView.setApplyEmbeddedFontSizes(false);
 

--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
@@ -1810,6 +1810,7 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.Listener, Metadata
         if (exoPlayerSubtitleView != null ) {
             // Setting `false` will tell ExoPlayer to remove the styling 
             // and the font size of the cue.
+            // Separate ExoPlayer API to remove font size is `setApplyEmbeddedFontSizes`.
             // In our API, for FE apps, default is `true` means override the styling
             // Hence reverting the value coming in `subtitleStyleSettings.isOverrideCueStyling()`
             exoPlayerSubtitleView.setApplyEmbeddedStyles(!subtitleStyleSettings.isOverrideCueStyling());

--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
@@ -1797,7 +1797,7 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.Listener, Metadata
     private void configureSubtitleView() {
         SubtitleView exoPlayerSubtitleView;
         SubtitleStyleSettings subtitleStyleSettings = playerSettings.getSubtitleStyleSettings();
-        if(exoPlayerView != null) {
+        if (exoPlayerView != null) {
             if (subtitleStyleSettings.getSubtitlePosition() != null) {
                 exoPlayerView.setSubtitleViewPosition(subtitleStyleSettings.getSubtitlePosition());
             }
@@ -1808,9 +1808,10 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.Listener, Metadata
         }
 
         if (exoPlayerSubtitleView != null ) {
-            // We are overriding the styling & font sizes given in the TTML or VTT file
-            exoPlayerSubtitleView.setApplyEmbeddedStyles(false);
-            exoPlayerSubtitleView.setApplyEmbeddedFontSizes(false);
+            // Setting `false` will tell ExoPlayer to remove the styling of the cue.
+            // In our API, for FE apps, default is `true` means override the styling
+            // Hence reverting the value coming in `subtitleStyleSettings.isOverrideCueStyling()`
+            exoPlayerSubtitleView.setApplyEmbeddedStyles(!subtitleStyleSettings.isOverrideCueStyling());
 
             exoPlayerSubtitleView.setStyle(subtitleStyleSettings.toCaptionStyle());
             exoPlayerSubtitleView.setFractionalTextSize(SubtitleView.DEFAULT_TEXT_SIZE_FRACTION * subtitleStyleSettings.getTextSizeFraction());

--- a/playkit/src/main/java/com/kaltura/playkit/player/PKSubtitlePosition.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/PKSubtitlePosition.java
@@ -11,7 +11,7 @@ public class PKSubtitlePosition {
 
     private int LINE_TYPE_FRACTION = 0;
 
-    public static float DIMEN_UNSET = -Float.MAX_VALUE;
+    private static float DIMEN_UNSET = -Float.MAX_VALUE;
 
     private static int TYPE_UNSET = Integer.MIN_VALUE;
 

--- a/playkit/src/main/java/com/kaltura/playkit/player/PKSubtitlePosition.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/PKSubtitlePosition.java
@@ -11,9 +11,9 @@ public class PKSubtitlePosition {
 
     private int LINE_TYPE_FRACTION = 0;
 
-    private static float DIMEN_UNSET = -Float.MAX_VALUE;
+    private final float DIMEN_UNSET = -Float.MAX_VALUE;
 
-    private static int TYPE_UNSET = Integer.MIN_VALUE;
+    private final int TYPE_UNSET = Integer.MIN_VALUE;
 
     // Override the current subtitle Positioning with the In-stream subtitle text track configuration
     private boolean overrideInlineCueConfig;

--- a/playkit/src/main/java/com/kaltura/playkit/player/PKSubtitlePosition.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/PKSubtitlePosition.java
@@ -11,9 +11,9 @@ public class PKSubtitlePosition {
 
     private int LINE_TYPE_FRACTION = 0;
 
-    private float DIMEN_UNSET = -Float.MAX_VALUE;
+    public static float DIMEN_UNSET = -Float.MAX_VALUE;
 
-    private int TYPE_UNSET = Integer.MIN_VALUE;
+    private static int TYPE_UNSET = Integer.MIN_VALUE;
 
     // Override the current subtitle Positioning with the In-stream subtitle text track configuration
     private boolean overrideInlineCueConfig;
@@ -62,37 +62,10 @@ public class PKSubtitlePosition {
     }
 
     /**
-     * Allow the subtitle view to move left (ALIGN_NORMAL), middle (ALIGN_CENTER) and right (ALIGN_OPPOSITE)
-     * For RTL texts, Allow the subtitle view to move Right (ALIGN_NORMAL), middle (ALIGN_CENTER) and left (ALIGN_OPPOSITE)
-     *
-     * Set the horizontal(Left/Right viewport) positions, percentage starts from
-     * center(10 is for 10%) to Left/Right(100 is for 100%)
-     *
-     * @param horizontalPositionPercentage percentage to left/right viewport from center
-     * @param horizontalPosition subtitle view positioning
-     * @return PKSubtitlePosition
-     */
-    private PKSubtitlePosition setHorizontalPositionLevel(float horizontalPositionPercentage, Layout.Alignment horizontalPosition) {
-        this.subtitleHorizontalPosition = horizontalPosition;
-        this.horizontalPositionPercentage = horizontalPositionPercentage;
-        return this;
-    }
-
-    /**
-     * Set the vertical(Top to Bottom) positions, percentage starts from
-     * Top(10 is for 10%) to Bottom(100 is for 100%)
-     *
-     * @param verticalPositionPercentage percentage to vertical viewport from top to bottom
-     * @return PKSubtitlePosition
-     */
-    private PKSubtitlePosition setVerticalPositionLevel(float verticalPositionPercentage) {
-        this.verticalPositionPercentage = verticalPositionPercentage;
-        return this;
-    }
-
-    /**
      * Set the subtitle position any where on the video frame. This method allows to move in X-Y coordinates
      * To set the subtitle only in vertical direction (Y - coordinate) use {@link PKSubtitlePosition#setVerticalPosition(int)}
+     *
+     * If horizontal alignment and horizontal position is not valid then treat it as {@link PKSubtitlePosition#setVerticalPosition(int)}
      *
      * @param horizontalPositionPercentage Set the horizontal(Left/Right viewport) positions, percentage starts from
      *                                     center(10 is for 10%) to Left/Right(100 is for 100%)
@@ -139,15 +112,16 @@ public class PKSubtitlePosition {
     }
 
     /**
-     * If `overrideInlineCueConfig` is false that mean; app does not want to override the inline Cue configuration.
+     * If `overrideInlineCueConfig` is `false` that mean; app does not want to override the inline Cue configuration.
      * App wants to go with Cue configuration.
-     * BUT Beware that it will call {@link PKSubtitlePosition#setOverrideInlineCueConfig(boolean)} with false value
+     *
+     * BUT Beware that it will call {@link PKSubtitlePosition#setOverrideInlineCueConfig(boolean)} with `false` value
      * means after that in next call, app needs to {@link PKSubtitlePosition#setOverrideInlineCueConfig(boolean)}
      * with another value.
      *
      * OTHERWISE
      *
-     * If `overrideInlineCueConfig` is true then it will move subtitle to Bottom-Center which is a standard position for it
+     * If `overrideInlineCueConfig` is `true` then it will move subtitle to Bottom-Center which is a standard position for it
      *
      * @return PKSubtitlePosition
      */
@@ -175,6 +149,32 @@ public class PKSubtitlePosition {
     public PKSubtitlePosition setOverrideInlineCueConfig(boolean overrideInlineCueConfig) {
         this.overrideInlineCueConfig = overrideInlineCueConfig;
         return this;
+    }
+
+
+    /**
+     * Allow the subtitle view to move left (ALIGN_NORMAL), middle (ALIGN_CENTER) and right (ALIGN_OPPOSITE)
+     * For RTL texts, Allow the subtitle view to move Right (ALIGN_NORMAL), middle (ALIGN_CENTER) and left (ALIGN_OPPOSITE)
+     *
+     * Set the horizontal(Left/Right viewport) positions, percentage starts from
+     * center(10 is for 10%) to Left/Right(100 is for 100%)
+     *
+     * @param horizontalPositionPercentage percentage to left/right viewport from center
+     * @param horizontalPosition subtitle view positioning
+     */
+    private void setHorizontalPositionLevel(float horizontalPositionPercentage, Layout.Alignment horizontalPosition) {
+        this.subtitleHorizontalPosition = horizontalPosition;
+        this.horizontalPositionPercentage = horizontalPositionPercentage;
+    }
+
+    /**
+     * Set the vertical(Top to Bottom) positions, percentage starts from
+     * Top(10 is for 10%) to Bottom(100 is for 100%)
+     *
+     * @param verticalPositionPercentage percentage to vertical viewport from top to bottom
+     */
+    private void setVerticalPositionLevel(float verticalPositionPercentage) {
+        this.verticalPositionPercentage = verticalPositionPercentage;
     }
 
     private float checkPositionPercentageLimit(int positionPercentage) {

--- a/playkit/src/main/java/com/kaltura/playkit/player/SubtitleStyleSettings.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/SubtitleStyleSettings.java
@@ -56,6 +56,7 @@ public class SubtitleStyleSettings {
     private int subtitleEdgeColor = Color.WHITE;
     private Typeface subtitleTypeface = Typeface.DEFAULT;
     private String subtitleStyleName;
+    private boolean overrideCueStyling = true;
     private PKSubtitlePosition subtitlePosition;
 
     public SubtitleStyleSettings(String subtitleStyleName) {
@@ -96,6 +97,10 @@ public class SubtitleStyleSettings {
 
     public String getStyleName() {
         return subtitleStyleName;
+    }
+
+    public boolean isOverrideCueStyling() {
+        return overrideCueStyling;
     }
 
     public PKSubtitlePosition getSubtitlePosition() {
@@ -207,6 +212,28 @@ public class SubtitleStyleSettings {
         } else {
             subtitleTypeface = asstTypeface;
         }
+        return this;
+    }
+
+    /**
+     * If the text track cues have the styling inside then passing
+     * `overrideCueStyling` `false` will disable it and
+     * styling inside the cue will be used.
+     *
+     * If the styling does not exist inside the cue then passed
+     * styling will be applied. Passing `false` will be having no
+     * impact in that case because there is no styling inside the cue.
+     *
+     * It will override the font size as well.
+     *
+     * Default is `true` means enabled, We will override the cue styling
+     * anyways.
+     *
+     * @param overrideCueStyling pass `false` to take cue's styling
+     * @return SubtitleStyleSettings
+     */
+    public SubtitleStyleSettings overrideCueStyling(boolean overrideCueStyling) {
+        this.overrideCueStyling = overrideCueStyling;
         return this;
     }
 

--- a/playkit/src/main/java/com/kaltura/playkit/player/SubtitleStyleSettings.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/SubtitleStyleSettings.java
@@ -27,7 +27,7 @@ public class SubtitleStyleSettings {
     }
 
     public enum SubtitleTextSizeFraction {
-        SUBTITLE_FRACTION_50, SUBTITLE_FRACTION_75, SUBTITLE_FRACTION_100, SUBTITLE_FRACTION_125, SUBTITLE_FRACTION_150, SUBTITLE_FRACTION_200
+        SUBTITLE_FRACTION_50, SUBTITLE_FRACTION_75, SUBTITLE_FRACTION_100, SUBTITLE_FRACTION_125, SUBTITLE_FRACTION_150, SUBTITLE_FRACTION_175, SUBTITLE_FRACTION_200
     }
 
     public enum SubtitleStyleTypeface {
@@ -43,6 +43,7 @@ public class SubtitleStyleSettings {
     private static final float fraction100 = 1.0f;
     private static final float fraction125 = 1.25f;
     private static final float fraction150 = 1.50f;
+    private static final float fraction175 = 1.75f;
     private static final float fraction200 = 2.0f;
 
     private int subtitleTextColor = Color.WHITE;
@@ -155,6 +156,9 @@ public class SubtitleStyleSettings {
                 break;
             case SUBTITLE_FRACTION_150:
                 this.subtitleTextSizeFraction = fraction150;
+                break;
+            case SUBTITLE_FRACTION_175:
+                this.subtitleTextSizeFraction = fraction175;
                 break;
             case SUBTITLE_FRACTION_200:
                 this.subtitleTextSizeFraction = fraction200;

--- a/playkit/src/main/java/com/kaltura/playkit/player/SubtitleStyleSettings.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/SubtitleStyleSettings.java
@@ -57,6 +57,8 @@ public class SubtitleStyleSettings {
     private Typeface subtitleTypeface = Typeface.DEFAULT;
     private String subtitleStyleName;
     private PKSubtitlePosition subtitlePosition;
+    private boolean useEmbeddedStyles;
+    private boolean useEmbeddedFontSizes;
 
     public SubtitleStyleSettings(String subtitleStyleName) {
         if (!TextUtils.isEmpty(subtitleStyleName)) {
@@ -100,6 +102,14 @@ public class SubtitleStyleSettings {
 
     public PKSubtitlePosition getSubtitlePosition() {
         return subtitlePosition;
+    }
+
+    public boolean isUseEmbeddedStyles() {
+        return useEmbeddedStyles;
+    }
+
+    public boolean isUseEmbeddedFontSizes() {
+        return useEmbeddedFontSizes;
     }
 
     public SubtitleStyleSettings setTextColor(int subtitleTextColor) {
@@ -212,6 +222,36 @@ public class SubtitleStyleSettings {
 
     public SubtitleStyleSettings setSubtitlePosition(PKSubtitlePosition subtitlePosition) {
         this.subtitlePosition = subtitlePosition;
+        return this;
+    }
+
+    /**
+     * If the text track cues have the styling then passing
+     * `useEmbeddedStyles` `true` will enable it and
+     * styling passed by app will be ignored.
+     *
+     * Default is `false` means disabled
+     *
+     * @param useEmbeddedStyles pass `true` to take embedded cues' styling
+     * @return SubtitleStyleSettings
+     */
+    public SubtitleStyleSettings setUseEmbeddedStyles(boolean useEmbeddedStyles) {
+        this.useEmbeddedStyles = useEmbeddedStyles;
+        return this;
+    }
+
+    /**
+     * If the text track cues have the font sizes then passing
+     * `useEmbeddedFontSizes` `true` will enable it and
+     * styling passed by app will be ignored.
+     *
+     * Default is `false` means disabled
+     *
+     * @param useEmbeddedFontSizes pass `true` to take embedded cues' font sizes
+     * @return SubtitleStyleSettings
+     */
+    public SubtitleStyleSettings setUseEmbeddedFontSizes(boolean useEmbeddedFontSizes) {
+        this.useEmbeddedFontSizes = useEmbeddedFontSizes;
         return this;
     }
 

--- a/playkit/src/main/java/com/kaltura/playkit/player/SubtitleStyleSettings.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/SubtitleStyleSettings.java
@@ -57,8 +57,6 @@ public class SubtitleStyleSettings {
     private Typeface subtitleTypeface = Typeface.DEFAULT;
     private String subtitleStyleName;
     private PKSubtitlePosition subtitlePosition;
-    private boolean useEmbeddedStyles;
-    private boolean useEmbeddedFontSizes;
 
     public SubtitleStyleSettings(String subtitleStyleName) {
         if (!TextUtils.isEmpty(subtitleStyleName)) {
@@ -102,14 +100,6 @@ public class SubtitleStyleSettings {
 
     public PKSubtitlePosition getSubtitlePosition() {
         return subtitlePosition;
-    }
-
-    public boolean isUseEmbeddedStyles() {
-        return useEmbeddedStyles;
-    }
-
-    public boolean isUseEmbeddedFontSizes() {
-        return useEmbeddedFontSizes;
     }
 
     public SubtitleStyleSettings setTextColor(int subtitleTextColor) {
@@ -222,36 +212,6 @@ public class SubtitleStyleSettings {
 
     public SubtitleStyleSettings setSubtitlePosition(PKSubtitlePosition subtitlePosition) {
         this.subtitlePosition = subtitlePosition;
-        return this;
-    }
-
-    /**
-     * If the text track cues have the styling then passing
-     * `useEmbeddedStyles` `true` will enable it and
-     * styling passed by app will be ignored.
-     *
-     * Default is `false` means disabled
-     *
-     * @param useEmbeddedStyles pass `true` to take embedded cues' styling
-     * @return SubtitleStyleSettings
-     */
-    public SubtitleStyleSettings setUseEmbeddedStyles(boolean useEmbeddedStyles) {
-        this.useEmbeddedStyles = useEmbeddedStyles;
-        return this;
-    }
-
-    /**
-     * If the text track cues have the font sizes then passing
-     * `useEmbeddedFontSizes` `true` will enable it and
-     * styling passed by app will be ignored.
-     *
-     * Default is `false` means disabled
-     *
-     * @param useEmbeddedFontSizes pass `true` to take embedded cues' font sizes
-     * @return SubtitleStyleSettings
-     */
-    public SubtitleStyleSettings setUseEmbeddedFontSizes(boolean useEmbeddedFontSizes) {
-        this.useEmbeddedFontSizes = useEmbeddedFontSizes;
         return this;
     }
 


### PR DESCRIPTION
- Fixed subtitle position bug where in stream styling was overriding the positioning. No Change in the APIs.
- Added subtitle font fraction 1.75f. 
     ```java
      new SubtitleStyleSettings("CustomStyle")
                .setTextSizeFraction(SubtitleStyleSettings.SubtitleTextSizeFraction.SUBTITLE_FRACTION_175)
     ```
- Added `ttml` mimeType support for subtitles.
     ```java
      PKExternalSubtitle pkExternalSubtitle = new PKExternalSubtitle()
                .setUrl("subtitle_url")
                .setMimeType(PKSubtitleFormat.ttml)
                .setLabel("label")
                .setLanguage("lang");
     ```
VR Fix: https://github.com/kaltura/playkit-android-vr/pull/62

### Checklists

- [x] Need to make sure that there is no regression on Subtitle positioning
- [x] Update the subtitle styling doc [Not required]
