### PR TITLE
FEC-12227 Ability to give surface aspect ratio for the Ads

### DIFF
--- a/playkit/src/main/java/com/kaltura/playkit/Player.java
+++ b/playkit/src/main/java/com/kaltura/playkit/Player.java
@@ -204,7 +204,7 @@ public interface Player {
          * @param resizeMode Resize mode
          * @return - Player Settings
          */
-        Settings setSurfaceAspectRatioResizeMode(PKAspectRatioResizeMode resizeMode);
+        Settings setSurfaceAspectRatioResizeMode(@NonNull PKAspectRatioResizeMode resizeMode);
 
         /**
          * Do not prepare the content player when the Ad starts(if exists); instead content player will be prepared
@@ -632,7 +632,7 @@ public interface Player {
     /**
      * Update video size
      */
-    void updateSurfaceAspectRatioResizeMode(PKAspectRatioResizeMode resizeMode);
+    void updateSurfaceAspectRatioResizeMode(@NonNull PKAspectRatioResizeMode resizeMode);
 
     /**
      * Update Low Latency configuration

--- a/playkit/src/main/java/com/kaltura/playkit/PlayerDecoratorBase.java
+++ b/playkit/src/main/java/com/kaltura/playkit/PlayerDecoratorBase.java
@@ -240,7 +240,7 @@ public class PlayerDecoratorBase implements Player {
     }
 
     @Override
-    public void updateSurfaceAspectRatioResizeMode(PKAspectRatioResizeMode resizeMode) {
+    public void updateSurfaceAspectRatioResizeMode(@NonNull PKAspectRatioResizeMode resizeMode) {
         player.updateSurfaceAspectRatioResizeMode(resizeMode);
     }
 

--- a/playkit/src/main/java/com/kaltura/playkit/ads/AdsPlayerEngineWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/ads/AdsPlayerEngineWrapper.java
@@ -18,6 +18,7 @@ import com.kaltura.playkit.PKController;
 import com.kaltura.playkit.PKLog;
 import com.kaltura.playkit.PKMediaEntry;
 import com.kaltura.playkit.PlayerEngineWrapper;
+import com.kaltura.playkit.player.PKAspectRatioResizeMode;
 import com.kaltura.playkit.player.PKMediaSourceConfig;
 import com.kaltura.playkit.plugins.ads.AdsProvider;
 
@@ -128,6 +129,21 @@ public class AdsPlayerEngineWrapper extends PlayerEngineWrapper implements PKAdP
             log.d("AdWrapper decorator Calling content player pause");
             super.pause();
         }
+    }
+
+    @Override
+    public void updateSurfaceAspectRatioResizeMode(PKAspectRatioResizeMode resizeMode) {
+        if (resizeMode == null) {
+            log.e("Resize mode is invalid");
+            return;
+        }
+
+        if (adsProvider != null && adsProvider.isAdDisplayed()) {
+            adsProvider.updateSurfaceAspectRatioResizeMode(resizeMode);
+            return;
+        }
+
+        super.updateSurfaceAspectRatioResizeMode(resizeMode);
     }
 
     @Override

--- a/playkit/src/main/java/com/kaltura/playkit/ads/AdsPlayerEngineWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/ads/AdsPlayerEngineWrapper.java
@@ -138,9 +138,8 @@ public class AdsPlayerEngineWrapper extends PlayerEngineWrapper implements PKAdP
             return;
         }
 
-        if (adsProvider != null && adsProvider.isAdDisplayed()) {
+        if (adsProvider != null) {
             adsProvider.updateSurfaceAspectRatioResizeMode(resizeMode);
-            return;
         }
 
         super.updateSurfaceAspectRatioResizeMode(resizeMode);

--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerView.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerView.java
@@ -423,7 +423,7 @@ class ExoPlayerView extends BaseExoplayerView {
 
     @Override
     public void setSurfaceAspectRatioResizeMode(PKAspectRatioResizeMode resizeMode) {
-        this.resizeMode = ExoPlayerView.getExoPlayerAspectRatioResizeMode(resizeMode);
+        this.resizeMode = PKAspectRatioResizeMode.getExoPlayerAspectRatioResizeMode(resizeMode);
         if (contentFrame != null) {
             contentFrame.setResizeMode(this.resizeMode);
         }
@@ -432,29 +432,6 @@ class ExoPlayerView extends BaseExoplayerView {
     @Override
     public void setSubtitleViewPosition(PKSubtitlePosition subtitleViewPosition) {
         this.subtitleViewPosition = subtitleViewPosition;
-    }
-
-    public static @AspectRatioFrameLayout.ResizeMode int getExoPlayerAspectRatioResizeMode(PKAspectRatioResizeMode resizeMode) {
-        @AspectRatioFrameLayout.ResizeMode int exoPlayerAspectRatioResizeMode;
-        switch(resizeMode) {
-            case fixedWidth:
-                exoPlayerAspectRatioResizeMode = AspectRatioFrameLayout.RESIZE_MODE_FIXED_WIDTH;
-                break;
-            case fixedHeight:
-                exoPlayerAspectRatioResizeMode = AspectRatioFrameLayout.RESIZE_MODE_FIXED_HEIGHT;
-                break;
-            case fill:
-                exoPlayerAspectRatioResizeMode = AspectRatioFrameLayout.RESIZE_MODE_FILL;
-                break;
-            case zoom:
-                exoPlayerAspectRatioResizeMode = AspectRatioFrameLayout.RESIZE_MODE_ZOOM;
-                break;
-            case fit:
-            default:
-                exoPlayerAspectRatioResizeMode = AspectRatioFrameLayout.RESIZE_MODE_FIT;
-                break;
-        }
-        return exoPlayerAspectRatioResizeMode;
     }
 
     /**

--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
@@ -241,7 +241,9 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.Listener, Metadata
 
         window = new Timeline.Window();
         setPlayerListeners();
-        exoPlayerView.setSurfaceAspectRatioResizeMode(playerSettings.getAspectRatioResizeMode());
+        if (playerSettings.getAspectRatioResizeMode() != null) {
+            configureAspectRatioResizeMode(playerSettings.getAspectRatioResizeMode());
+        }
         exoPlayerView.setPlayer(player, useTextureView, isSurfaceSecured, playerSettings.isVideoViewHidden());
 
         player.setPlayWhenReady(false);
@@ -1844,8 +1846,12 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.Listener, Metadata
 
     @Override
     public void updateSurfaceAspectRatioResizeMode(PKAspectRatioResizeMode resizeMode) {
+        if (resizeMode == null) {
+            log.e("Resize mode is invalid");
+            return;
+        }
         playerSettings.setSurfaceAspectRatioResizeMode(resizeMode);
-        configureAspectRatioResizeMode();
+        configureAspectRatioResizeMode(playerSettings.getAspectRatioResizeMode());
         sendEvent(PlayerEvent.Type.ASPECT_RATIO_RESIZE_MODE_CHANGED);
     }
 
@@ -1891,9 +1897,9 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.Listener, Metadata
         return pkLowLatencyConfig;
     }
 
-    private void configureAspectRatioResizeMode() {
-        if(exoPlayerView != null){
-            exoPlayerView.setSurfaceAspectRatioResizeMode(playerSettings.getAspectRatioResizeMode());
+    private void configureAspectRatioResizeMode(PKAspectRatioResizeMode resizeMode) {
+        if (exoPlayerView != null) {
+            exoPlayerView.setSurfaceAspectRatioResizeMode(resizeMode);
         }
     }
 

--- a/playkit/src/main/java/com/kaltura/playkit/player/PKAspectRatioResizeMode.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/PKAspectRatioResizeMode.java
@@ -1,9 +1,34 @@
 package com.kaltura.playkit.player;
 
+import com.kaltura.android.exoplayer2.ui.AspectRatioFrameLayout;
+
 public enum PKAspectRatioResizeMode {
     fit,
     fixedWidth,
     fixedHeight,
     fill,
-    zoom
+    zoom;
+
+    public static @AspectRatioFrameLayout.ResizeMode int getExoPlayerAspectRatioResizeMode(PKAspectRatioResizeMode resizeMode) {
+        @AspectRatioFrameLayout.ResizeMode int exoPlayerAspectRatioResizeMode;
+        switch(resizeMode) {
+            case fixedWidth:
+                exoPlayerAspectRatioResizeMode = AspectRatioFrameLayout.RESIZE_MODE_FIXED_WIDTH;
+                break;
+            case fixedHeight:
+                exoPlayerAspectRatioResizeMode = AspectRatioFrameLayout.RESIZE_MODE_FIXED_HEIGHT;
+                break;
+            case fill:
+                exoPlayerAspectRatioResizeMode = AspectRatioFrameLayout.RESIZE_MODE_FILL;
+                break;
+            case zoom:
+                exoPlayerAspectRatioResizeMode = AspectRatioFrameLayout.RESIZE_MODE_ZOOM;
+                break;
+            case fit:
+            default:
+                exoPlayerAspectRatioResizeMode = AspectRatioFrameLayout.RESIZE_MODE_FIT;
+                break;
+        }
+        return exoPlayerAspectRatioResizeMode;
+    }
 }

--- a/playkit/src/main/java/com/kaltura/playkit/player/PlayerController.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/PlayerController.java
@@ -723,7 +723,7 @@ public class PlayerController implements Player {
     }
 
     @Override
-    public void updateSurfaceAspectRatioResizeMode(PKAspectRatioResizeMode resizeMode) {
+    public void updateSurfaceAspectRatioResizeMode(@NonNull PKAspectRatioResizeMode resizeMode) {
         log.v("updateSurfaceAspectRatioResizeMode");
         if (assertPlayerIsNotNull("updateSurfaceAspectRatioResizeMode")) {
             player.updateSurfaceAspectRatioResizeMode(resizeMode);

--- a/playkit/src/main/java/com/kaltura/playkit/player/PlayerSettings.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/PlayerSettings.java
@@ -12,6 +12,8 @@
 
 package com.kaltura.playkit.player;
 
+import androidx.annotation.NonNull;
+
 import com.kaltura.playkit.PKDrmParams;
 import com.kaltura.playkit.PKMediaFormat;
 import com.kaltura.playkit.PKRequestConfig;
@@ -321,7 +323,7 @@ public class PlayerSettings implements Player.Settings {
     }
 
     @Override
-    public Player.Settings setSurfaceAspectRatioResizeMode(PKAspectRatioResizeMode resizeMode) {
+    public Player.Settings setSurfaceAspectRatioResizeMode(@NonNull PKAspectRatioResizeMode resizeMode) {
         this.resizeMode = resizeMode;
         return this;
     }

--- a/playkit/src/main/java/com/kaltura/playkit/plugins/ads/AdEvent.java
+++ b/playkit/src/main/java/com/kaltura/playkit/plugins/ads/AdEvent.java
@@ -17,6 +17,7 @@ import androidx.annotation.Nullable;
 import com.kaltura.playkit.PKError;
 import com.kaltura.playkit.PKEvent;
 import com.kaltura.playkit.ads.AdBreakConfig;
+import com.kaltura.playkit.player.PKAspectRatioResizeMode;
 
 @SuppressWarnings("unused")
 public class AdEvent implements PKEvent {
@@ -38,6 +39,7 @@ public class AdEvent implements PKEvent {
     public static final Class<DAISourceSelected> daiSourceSelected = DAISourceSelected.class;
     public static final Class<AdWaterFalling> adWaterFalling = AdWaterFalling.class;
     public static final Class<AdWaterFallingFailed> adWaterFallingFailed = AdWaterFallingFailed.class;
+    public static final Class<AdSurfaceAspectRatioResizeModeChanged> adSurfaceAspectRationSizeModeChanged = AdSurfaceAspectRatioResizeModeChanged.class;
 
     public static final AdEvent.Type adFirstPlay = Type.AD_FIRST_PLAY;
     public static final AdEvent.Type adDisplayedAfterContentPause = Type.AD_DISPLAYED_AFTER_CONTENT_PAUSE;
@@ -222,6 +224,20 @@ public class AdEvent implements PKEvent {
         }
     }
 
+    /**
+     * This event is only being sent for IMA Ads not for IMADAI Ads
+     * For IMADAI ads event, listen to {@link com.kaltura.playkit.PlayerEvent#surfaceAspectRationSizeModeChanged}
+     */
+    public static class AdSurfaceAspectRatioResizeModeChanged extends AdEvent {
+
+        public final PKAspectRatioResizeMode resizeMode;
+
+        public AdSurfaceAspectRatioResizeModeChanged(PKAspectRatioResizeMode resizeMode) {
+            super(Type.ASPECT_RATIO_RESIZE_MODE_CHANGED);
+            this.resizeMode = resizeMode;
+        }
+    }
+
     public static class AdWaterFalling extends AdEvent {
 
         public final AdBreakConfig adBreakConfig;
@@ -277,6 +293,7 @@ public class AdEvent implements PKEvent {
         AD_PLAYBACK_INFO_UPDATED,
         ERROR,
         DAI_SOURCE_SELECTED,
+        ASPECT_RATIO_RESIZE_MODE_CHANGED,
         AD_WATERFALLING,
         AD_WATERFALLING_FAILED
     }

--- a/playkit/src/main/java/com/kaltura/playkit/plugins/ads/AdEvent.java
+++ b/playkit/src/main/java/com/kaltura/playkit/plugins/ads/AdEvent.java
@@ -39,7 +39,7 @@ public class AdEvent implements PKEvent {
     public static final Class<DAISourceSelected> daiSourceSelected = DAISourceSelected.class;
     public static final Class<AdWaterFalling> adWaterFalling = AdWaterFalling.class;
     public static final Class<AdWaterFallingFailed> adWaterFallingFailed = AdWaterFallingFailed.class;
-    public static final Class<AdSurfaceAspectRatioResizeModeChanged> adSurfaceAspectRationSizeModeChanged = AdSurfaceAspectRatioResizeModeChanged.class;
+    public static final Class<AdSurfaceAspectRatioResizeModeChanged> adSurfaceAspectRatioSizeModeChanged = AdSurfaceAspectRatioResizeModeChanged.class;
 
     public static final AdEvent.Type adFirstPlay = Type.AD_FIRST_PLAY;
     public static final AdEvent.Type adDisplayedAfterContentPause = Type.AD_DISPLAYED_AFTER_CONTENT_PAUSE;

--- a/playkit/src/main/java/com/kaltura/playkit/plugins/ads/AdEvent.java
+++ b/playkit/src/main/java/com/kaltura/playkit/plugins/ads/AdEvent.java
@@ -17,7 +17,6 @@ import androidx.annotation.Nullable;
 import com.kaltura.playkit.PKError;
 import com.kaltura.playkit.PKEvent;
 import com.kaltura.playkit.ads.AdBreakConfig;
-import com.kaltura.playkit.player.PKAspectRatioResizeMode;
 
 @SuppressWarnings("unused")
 public class AdEvent implements PKEvent {

--- a/playkit/src/main/java/com/kaltura/playkit/plugins/ads/AdEvent.java
+++ b/playkit/src/main/java/com/kaltura/playkit/plugins/ads/AdEvent.java
@@ -39,7 +39,6 @@ public class AdEvent implements PKEvent {
     public static final Class<DAISourceSelected> daiSourceSelected = DAISourceSelected.class;
     public static final Class<AdWaterFalling> adWaterFalling = AdWaterFalling.class;
     public static final Class<AdWaterFallingFailed> adWaterFallingFailed = AdWaterFallingFailed.class;
-    public static final Class<AdSurfaceAspectRatioResizeModeChanged> adSurfaceAspectRatioSizeModeChanged = AdSurfaceAspectRatioResizeModeChanged.class;
 
     public static final AdEvent.Type adFirstPlay = Type.AD_FIRST_PLAY;
     public static final AdEvent.Type adDisplayedAfterContentPause = Type.AD_DISPLAYED_AFTER_CONTENT_PAUSE;
@@ -224,20 +223,6 @@ public class AdEvent implements PKEvent {
         }
     }
 
-    /**
-     * This event is only being sent for IMA Ads not for IMADAI Ads
-     * For IMADAI ads event, listen to {@link com.kaltura.playkit.PlayerEvent#surfaceAspectRationSizeModeChanged}
-     */
-    public static class AdSurfaceAspectRatioResizeModeChanged extends AdEvent {
-
-        public final PKAspectRatioResizeMode resizeMode;
-
-        public AdSurfaceAspectRatioResizeModeChanged(PKAspectRatioResizeMode resizeMode) {
-            super(Type.ASPECT_RATIO_RESIZE_MODE_CHANGED);
-            this.resizeMode = resizeMode;
-        }
-    }
-
     public static class AdWaterFalling extends AdEvent {
 
         public final AdBreakConfig adBreakConfig;
@@ -293,7 +278,6 @@ public class AdEvent implements PKEvent {
         AD_PLAYBACK_INFO_UPDATED,
         ERROR,
         DAI_SOURCE_SELECTED,
-        ASPECT_RATIO_RESIZE_MODE_CHANGED,
         AD_WATERFALLING,
         AD_WATERFALLING_FAILED
     }

--- a/playkit/src/main/java/com/kaltura/playkit/plugins/ads/AdsProvider.java
+++ b/playkit/src/main/java/com/kaltura/playkit/plugins/ads/AdsProvider.java
@@ -20,6 +20,7 @@ import com.kaltura.playkit.ads.PKAdInfo;
 import com.kaltura.playkit.ads.PKAdPluginType;
 import com.kaltura.playkit.ads.PKAdProviderListener;
 import com.kaltura.playkit.ads.PKAdvertisingAdInfo;
+import com.kaltura.playkit.player.PKAspectRatioResizeMode;
 
 import java.util.List;
 
@@ -34,6 +35,8 @@ public interface AdsProvider {
     void pause();
 
     default void setVolume(float volume) {}
+
+    default void updateSurfaceAspectRatioResizeMode(PKAspectRatioResizeMode resizeMode) {}
 
     void contentCompleted();
 


### PR DESCRIPTION
Aspect ratio passed for the Content will be applied same for the Ad's view.

To set the resize mode,

```java
player.getSettings().setSurfaceAspectRatioResizeMode(PKAspectRatioResizeMode.zoom);
```
To update the resize mode,

```java
player.updateSurfaceAspectRatioResizeMode(PKAspectRatioResizeMode.fit);
```

Additional feature PR:
https://github.com/kaltura/playkit-android-ima/pull/153
https://github.com/kaltura/playkit-android-providers/pull/138

Sample Change:
https://github.com/kaltura/kaltura-player-android-samples/pull/144
