### PR TITLE
FEC-12535 - need to ignore trickplay tracks from being added as video tracks

### DIFF
--- a/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
@@ -306,6 +306,12 @@ public class TrackSelectionHelper {
                                     continue;
                                 }
 
+                                if (format.roleFlags == C.ROLE_FLAG_TRICK_PLAY) {
+                                    // ROLE_FLAG_TRICK_PLAY is not a video track
+                                    // in future handle that in hls case for thumbnailInfo
+                                    continue;
+                                }
+                                
                                 if (!videoTracksAvailable) {
                                     videoTracksAvailable = true;
                                 }


### PR DESCRIPTION
when building video tracks we will ignore this type of video track reported by exp player role flag TRICK_PLAY