### PR TITLE
FEC-12338 ExoPlayer upgrade to v2.18.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.5.20'
+    ext.kotlin_version = '1.7.10'
     repositories {
         google()
         mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         maven { url "https://maven.google.com" }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.3'
+        classpath 'com.android.tools.build:gradle:7.2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-all.zip

--- a/playkit/build.gradle
+++ b/playkit/build.gradle
@@ -51,7 +51,7 @@ dependencies {
     api 'com.squareup.okhttp3:okhttp:4.9.2'
 
     // Kotlin Config
-    implementation 'androidx.core:core-ktx:1.3.2'
+    implementation 'androidx.core:core-ktx:1.9.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
     def checkerframeworkVersion = '3.13.0'

--- a/playkit/build.gradle
+++ b/playkit/build.gradle
@@ -3,14 +3,14 @@ apply plugin: 'kotlin-android'
 apply from: 'version.gradle'
 
 android {
-    compileSdkVersion 32
+    compileSdkVersion 33
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 31
+        targetSdkVersion 33
         versionName playkitVersion  // defined in version.gradle
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String","VERSION_NAME","\"${playkitVersion}\"")
@@ -41,7 +41,7 @@ tasks.withType(Javadoc) {
 
 dependencies {
 
-    def exoPlayerVersion = '2.18.1'
+    def exoPlayerVersion = '2.18.2'
     api "com.kaltura.playkit:kexoplayer:$exoPlayerVersion"
 
     api 'com.google.code.gson:gson:2.8.6'

--- a/playkit/build.gradle
+++ b/playkit/build.gradle
@@ -3,14 +3,14 @@ apply plugin: 'kotlin-android'
 apply from: 'version.gradle'
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 32
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 30
+        targetSdkVersion 31
         versionName playkitVersion  // defined in version.gradle
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String","VERSION_NAME","\"${playkitVersion}\"")
@@ -41,7 +41,7 @@ tasks.withType(Javadoc) {
 
 dependencies {
 
-    def exoPlayerVersion = '2.17.1'
+    def exoPlayerVersion = '2.18.1'
     api "com.kaltura.playkit:kexoplayer:$exoPlayerVersion"
 
     api 'com.google.code.gson:gson:2.8.6'
@@ -54,16 +54,17 @@ dependencies {
     implementation 'androidx.core:core-ktx:1.3.2'
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
-    def checkerframeworkVersion = '3.3.0'
-    def checkerframeworkCompatVersion = '2.5.0'
+    def checkerframeworkVersion = '3.13.0'
+    def checkerframeworkCompatVersion = '2.5.5'
 
     compileOnly 'org.checkerframework:checker-qual:' + checkerframeworkVersion
     compileOnly 'org.checkerframework:checker-compat-qual:' + checkerframeworkCompatVersion
 
-    def guavaVersion = '27.1-android'
+    def guavaVersion = '31.0.1-android'
 
     api ('com.google.guava:guava:' + guavaVersion) {
         exclude group: 'org.checkerframework', module: 'checker-compat-qual'
+        exclude group: 'org.checkerframework', module: 'checker-qual'
     }
     // Tests
     testImplementation 'junit:junit:4.13.2'

--- a/playkit/src/main/java/com/kaltura/android/exoplayer2/dashmanifestparser/CustomDashManifest.java
+++ b/playkit/src/main/java/com/kaltura/android/exoplayer2/dashmanifestparser/CustomDashManifest.java
@@ -83,39 +83,6 @@ public class CustomDashManifest implements FilterableManifest<CustomDashManifest
 
     private final List<CustomPeriod> periods;
 
-    /**
-     * @deprecated Use {@link #CustomDashManifest(long, long, long, boolean, long, long, long, long,
-     *     ProgramInformation, UtcTimingElement, ServiceDescriptionElement, Uri, List)}.
-     */
-    @Deprecated
-    public CustomDashManifest(
-            long availabilityStartTimeMs,
-            long durationMs,
-            long minBufferTimeMs,
-            boolean dynamic,
-            long minUpdatePeriodMs,
-            long timeShiftBufferDepthMs,
-            long suggestedPresentationDelayMs,
-            long publishTimeMs,
-            @Nullable UtcTimingElement utcTiming,
-            @Nullable Uri location,
-            List<CustomPeriod> periods) {
-        this(
-                availabilityStartTimeMs,
-                durationMs,
-                minBufferTimeMs,
-                dynamic,
-                minUpdatePeriodMs,
-                timeShiftBufferDepthMs,
-                suggestedPresentationDelayMs,
-                publishTimeMs,
-                /* programInformation= */ null,
-                utcTiming,
-                /* serviceDescription= */ null,
-                location,
-                periods);
-    }
-
     public CustomDashManifest(
             long availabilityStartTimeMs,
             long durationMs,

--- a/playkit/src/main/java/com/kaltura/android/exoplayer2/dashmanifestparser/CustomFormat.java
+++ b/playkit/src/main/java/com/kaltura/android/exoplayer2/dashmanifestparser/CustomFormat.java
@@ -118,26 +118,36 @@ public final class CustomFormat implements Bundleable {
      */
     public static final class Builder {
 
-        @Nullable private String id;
-        @Nullable private String label;
-        @Nullable private String language;
+        @Nullable
+        private String id;
+        @Nullable
+        private String label;
+        @Nullable
+        private String language;
         private @C.SelectionFlags int selectionFlags;
         private @C.RoleFlags int roleFlags;
         private int averageBitrate;
         private int peakBitrate;
-        @Nullable private String codecs;
-        @Nullable private Metadata metadata;
-        @Nullable FormatThumbnailInfo formatThumbnailInfo;
+        @Nullable
+        private String codecs;
+        @Nullable
+        private Metadata metadata;
+        @Nullable
+        FormatThumbnailInfo formatThumbnailInfo;
         // Container specific.
 
-        @Nullable private String containerMimeType;
+        @Nullable
+        private String containerMimeType;
 
         // Sample specific.
 
-        @Nullable private String sampleMimeType;
+        @Nullable
+        private String sampleMimeType;
         private int maxInputSize;
-        @Nullable private List<byte[]> initializationData;
-        @Nullable private DrmInitData drmInitData;
+        @Nullable
+        private List<byte[]> initializationData;
+        @Nullable
+        private DrmInitData drmInitData;
         private long subsampleOffsetUs;
 
         // Video specific.
@@ -147,9 +157,11 @@ public final class CustomFormat implements Bundleable {
         private float frameRate;
         private int rotationDegrees;
         private float pixelWidthHeightRatio;
-        @Nullable private byte[] projectionData;
+        @Nullable
+        private byte[] projectionData;
         private int stereoMode;
-        @Nullable private ColorInfo colorInfo;
+        @Nullable
+        private ColorInfo colorInfo;
 
         // Audio specific.
 
@@ -165,9 +177,12 @@ public final class CustomFormat implements Bundleable {
 
         // Provided by the source.
 
-        @C.CryptoType private int cryptoType;
+        @C.CryptoType
+        private int cryptoType;
 
-        /** Creates a new instance with default values. */
+        /**
+         * Creates a new instance with default values.
+         */
         public Builder() {
             averageBitrate = NO_VALUE;
             peakBitrate = NO_VALUE;
@@ -600,7 +615,9 @@ public final class CustomFormat implements Bundleable {
         }
     }
 
-    /** A value for various fields to indicate that the field's value is unknown or not applicable. */
+    /**
+     * A value for various fields to indicate that the field's value is unknown or not applicable.
+     */
     public static final int NO_VALUE = -1;
 
     /**
@@ -611,15 +628,28 @@ public final class CustomFormat implements Bundleable {
 
     private static final CustomFormat DEFAULT = new Builder().build();
 
-    /** An identifier for the format, or null if unknown or not applicable. */
-    @Nullable public final String id;
-    /** The human readable label, or null if unknown or not applicable. */
-    @Nullable public final String label;
-    /** The language as an IETF BCP 47 conformant tag, or null if unknown or not applicable. */
-    @Nullable public final String language;
-    /** Track selection flags. */
+    /**
+     * An identifier for the format, or null if unknown or not applicable.
+     */
+    @Nullable
+    public final String id;
+    /**
+     * The human readable label, or null if unknown or not applicable.
+     */
+    @Nullable
+    public final String label;
+    /**
+     * The language as an IETF BCP 47 conformant tag, or null if unknown or not applicable.
+     */
+    @Nullable
+    public final String language;
+    /**
+     * Track selection flags.
+     */
     public final @C.SelectionFlags int selectionFlags;
-    /** Track role flags. */
+    /**
+     * Track role flags.
+     */
     public final @C.RoleFlags int roleFlags;
     /**
      * The average bitrate in bits per second, or {@link #NO_VALUE} if unknown or not applicable. The
@@ -667,20 +697,33 @@ public final class CustomFormat implements Bundleable {
      * peakBitrate : averageBitrate}.
      */
     public final int bitrate;
-    /** Codecs of the format as described in RFC 6381, or null if unknown or not applicable. */
-    @Nullable public final String codecs;
-    /** Metadata, or null if unknown or not applicable. */
-    @Nullable public final Metadata metadata;
-    @Nullable public final FormatThumbnailInfo formatThumbnailInfo;
+    /**
+     * Codecs of the format as described in RFC 6381, or null if unknown or not applicable.
+     */
+    @Nullable
+    public final String codecs;
+    /**
+     * Metadata, or null if unknown or not applicable.
+     */
+    @Nullable
+    public final Metadata metadata;
+    @Nullable
+    public final FormatThumbnailInfo formatThumbnailInfo;
     // Container specific.
 
-    /** The mime type of the container, or null if unknown or not applicable. */
-    @Nullable public final String containerMimeType;
+    /**
+     * The mime type of the container, or null if unknown or not applicable.
+     */
+    @Nullable
+    public final String containerMimeType;
 
     // Sample specific.
 
-    /** The sample mime type, or null if unknown or not applicable. */
-    @Nullable public final String sampleMimeType;
+    /**
+     * The sample mime type, or null if unknown or not applicable.
+     */
+    @Nullable
+    public final String sampleMimeType;
     /**
      * The maximum size of a buffer of data (typically one sample), or {@link #NO_VALUE} if unknown or
      * not applicable.
@@ -691,8 +734,11 @@ public final class CustomFormat implements Bundleable {
      * if initialization data is not required.
      */
     public final List<byte[]> initializationData;
-    /** DRM initialization data if the stream is protected, or null otherwise. */
-    @Nullable public final DrmInitData drmInitData;
+    /**
+     * DRM initialization data if the stream is protected, or null otherwise.
+     */
+    @Nullable
+    public final DrmInitData drmInitData;
 
     /**
      * For samples that contain subsamples, this is an offset that should be added to subsample
@@ -720,18 +766,27 @@ public final class CustomFormat implements Bundleable {
      * orientation, or 0 if unknown or not applicable. Only 0, 90, 180 and 270 are supported.
      */
     public final int rotationDegrees;
-    /** The width to height ratio of pixels in the video, or 1.0 if unknown or not applicable. */
+    /**
+     * The width to height ratio of pixels in the video, or 1.0 if unknown or not applicable.
+     */
     public final float pixelWidthHeightRatio;
-    /** The projection data for 360/VR video, or null if not applicable. */
-    @Nullable public final byte[] projectionData;
+    /**
+     * The projection data for 360/VR video, or null if not applicable.
+     */
+    @Nullable
+    public final byte[] projectionData;
     /**
      * The stereo layout for 360/3D/VR video, or {@link #NO_VALUE} if not applicable. Valid stereo
      * modes are {@link C#STEREO_MODE_MONO}, {@link C#STEREO_MODE_TOP_BOTTOM}, {@link
      * C#STEREO_MODE_LEFT_RIGHT}, {@link C#STEREO_MODE_STEREO_MESH}.
      */
-    @C.StereoMode public final int stereoMode;
-    /** The color metadata associated with the video, or null if not applicable. */
-    @Nullable public final ColorInfo colorInfo;
+    @C.StereoMode
+    public final int stereoMode;
+    /**
+     * The color metadata associated with the video, or null if not applicable.
+     */
+    @Nullable
+    public final ColorInfo colorInfo;
 
     // Audio specific.
 
@@ -743,8 +798,11 @@ public final class CustomFormat implements Bundleable {
      * The audio sampling rate in Hz, or {@link #NO_VALUE} if unknown or not applicable.
      */
     public final int sampleRate;
-    /** The {@link C.PcmEncoding} for PCM audio. Set to {@link #NO_VALUE} for other media types. */
-    @C.PcmEncoding public final int pcmEncoding;
+    /**
+     * The {@link C.PcmEncoding} for PCM audio. Set to {@link #NO_VALUE} for other media types.
+     */
+    @C.PcmEncoding
+    public final int pcmEncoding;
     /**
      * The number of frames to trim from the start of the decoded audio stream, or 0 if not
      * applicable.
@@ -757,7 +815,9 @@ public final class CustomFormat implements Bundleable {
 
     // Text specific.
 
-    /** The Accessibility channel, or {@link #NO_VALUE} if not known or applicable. */
+    /**
+     * The Accessibility channel, or {@link #NO_VALUE} if not known or applicable.
+     */
     public final int accessibilityChannel;
 
     // Provided by source.
@@ -768,14 +828,17 @@ public final class CustomFormat implements Bundleable {
      * {@link #drmInitData} is non-null, but may be {@link C#CRYPTO_TYPE_UNSUPPORTED} to indicate that
      * the samples are encrypted using an unsupported crypto type.
      */
-    @C.CryptoType public final int cryptoType;
+    @C.CryptoType
+    public final int cryptoType;
 
     // Lazily initialized hashcode.
     private int hashCode;
 
     // Video.
 
-    /** @deprecated Use {@link CustomFormat.Builder}. */
+    /**
+     * @deprecated Use {@link CustomFormat.Builder}.
+     */
     @Deprecated
     public static CustomFormat createVideoContainerFormat(
             @Nullable String id,
@@ -811,7 +874,9 @@ public final class CustomFormat implements Bundleable {
                 .build();
     }
 
-    /** @deprecated Use {@link CustomFormat.Builder}. */
+    /**
+     * @deprecated Use {@link CustomFormat.Builder}.
+     */
     @Deprecated
     public static CustomFormat createVideoSampleFormat(
             @Nullable String id,
@@ -839,7 +904,9 @@ public final class CustomFormat implements Bundleable {
                 .build();
     }
 
-    /** @deprecated Use {@link CustomFormat.Builder}. */
+    /**
+     * @deprecated Use {@link CustomFormat.Builder}.
+     */
     @Deprecated
     public static CustomFormat createVideoSampleFormat(
             @Nullable String id,
@@ -871,7 +938,9 @@ public final class CustomFormat implements Bundleable {
                 .build();
     }
 
-    /** @deprecated Use {@link CustomFormat.Builder}. */
+    /**
+     * @deprecated Use {@link CustomFormat.Builder}.
+     */
     @Deprecated
     public static CustomFormat createVideoSampleFormat(
             @Nullable String id,
@@ -911,7 +980,9 @@ public final class CustomFormat implements Bundleable {
 
     // Audio.
 
-    /** @deprecated Use {@link CustomFormat.Builder}. */
+    /**
+     * @deprecated Use {@link CustomFormat.Builder}.
+     */
     @Deprecated
     public static CustomFormat createAudioContainerFormat(
             @Nullable String id,
@@ -945,7 +1016,9 @@ public final class CustomFormat implements Bundleable {
                 .build();
     }
 
-    /** @deprecated Use {@link CustomFormat.Builder}. */
+    /**
+     * @deprecated Use {@link CustomFormat.Builder}.
+     */
     @Deprecated
     public static CustomFormat createAudioSampleFormat(
             @Nullable String id,
@@ -975,7 +1048,9 @@ public final class CustomFormat implements Bundleable {
                 .build();
     }
 
-    /** @deprecated Use {@link CustomFormat.Builder}. */
+    /**
+     * @deprecated Use {@link CustomFormat.Builder}.
+     */
     @Deprecated
     public static CustomFormat createAudioSampleFormat(
             @Nullable String id,
@@ -1007,7 +1082,9 @@ public final class CustomFormat implements Bundleable {
                 .build();
     }
 
-    /** @deprecated Use {@link CustomFormat.Builder}. */
+    /**
+     * @deprecated Use {@link CustomFormat.Builder}.
+     */
     @Deprecated
     public static CustomFormat createAudioSampleFormat(
             @Nullable String id,
@@ -1047,7 +1124,9 @@ public final class CustomFormat implements Bundleable {
 
     // Text.
 
-    /** @deprecated Use {@link CustomFormat.Builder}. */
+    /**
+     * @deprecated Use {@link CustomFormat.Builder}.
+     */
     @Deprecated
     public static CustomFormat createTextContainerFormat(
             @Nullable String id,
@@ -1073,7 +1152,9 @@ public final class CustomFormat implements Bundleable {
                 .build();
     }
 
-    /** @deprecated Use {@link CustomFormat.Builder}. */
+    /**
+     * @deprecated Use {@link CustomFormat.Builder}.
+     */
     @Deprecated
     public static CustomFormat createTextContainerFormat(
             @Nullable String id,
@@ -1101,7 +1182,9 @@ public final class CustomFormat implements Bundleable {
                 .build();
     }
 
-    /** @deprecated Use {@link CustomFormat.Builder}. */
+    /**
+     * @deprecated Use {@link CustomFormat.Builder}.
+     */
     @Deprecated
     public static CustomFormat createTextSampleFormat(
             @Nullable String id,
@@ -1116,7 +1199,9 @@ public final class CustomFormat implements Bundleable {
                 .build();
     }
 
-    /** @deprecated Use {@link CustomFormat.Builder}. */
+    /**
+     * @deprecated Use {@link CustomFormat.Builder}.
+     */
     @Deprecated
     public static CustomFormat createTextSampleFormat(
             @Nullable String id,
@@ -1139,7 +1224,9 @@ public final class CustomFormat implements Bundleable {
 
     // Image.
 
-    /** @deprecated Use {@link CustomFormat.Builder}. */
+    /**
+     * @deprecated Use {@link CustomFormat.Builder}.
+     */
     @Deprecated
     public static CustomFormat createImageSampleFormat(
             @Nullable String id,
@@ -1158,7 +1245,9 @@ public final class CustomFormat implements Bundleable {
 
     // Generic.
 
-    /** @deprecated Use {@link CustomFormat.Builder}. */
+    /**
+     * @deprecated Use {@link CustomFormat.Builder}.
+     */
     @Deprecated
     public static CustomFormat createContainerFormat(
             @Nullable String id,
@@ -1184,7 +1273,9 @@ public final class CustomFormat implements Bundleable {
                 .build();
     }
 
-    /** @deprecated Use {@link CustomFormat.Builder}. */
+    /**
+     * @deprecated Use {@link CustomFormat.Builder}.
+     */
     @Deprecated
     public static CustomFormat createSampleFormat(@Nullable String id, @Nullable String sampleMimeType) {
         return new Builder().setId(id).setSampleMimeType(sampleMimeType).build();
@@ -1238,30 +1329,40 @@ public final class CustomFormat implements Bundleable {
         }
     }
 
-    /** Returns a {@link CustomFormat.Builder} initialized with the values of this instance. */
+    /**
+     * Returns a {@link CustomFormat.Builder} initialized with the values of this instance.
+     */
     public Builder buildUpon() {
         return new Builder(this);
     }
 
-    /** @deprecated Use {@link #buildUpon()} and {@link Builder#setMaxInputSize(int)}. */
+    /**
+     * @deprecated Use {@link #buildUpon()} and {@link Builder#setMaxInputSize(int)}.
+     */
     @Deprecated
     public CustomFormat copyWithMaxInputSize(int maxInputSize) {
         return buildUpon().setMaxInputSize(maxInputSize).build();
     }
 
-    /** @deprecated Use {@link #buildUpon()} and {@link Builder#setSubsampleOffsetUs(long)}. */
+    /**
+     * @deprecated Use {@link #buildUpon()} and {@link Builder#setSubsampleOffsetUs(long)}.
+     */
     @Deprecated
     public CustomFormat copyWithSubsampleOffsetUs(long subsampleOffsetUs) {
         return buildUpon().setSubsampleOffsetUs(subsampleOffsetUs).build();
     }
 
-    /** @deprecated Use {@link #buildUpon()} and {@link Builder#setLabel(String)} . */
+    /**
+     * @deprecated Use {@link #buildUpon()} and {@link Builder#setLabel(String)} .
+     */
     @Deprecated
     public CustomFormat copyWithLabel(@Nullable String label) {
         return buildUpon().setLabel(label).build();
     }
 
-    /** @deprecated Use {@link #withManifestFormatInfo(CustomFormat)}. */
+    /**
+     * @deprecated Use {@link #withManifestFormatInfo(CustomFormat)}.
+     */
     @Deprecated
     public CustomFormat copyWithManifestFormatInfo(CustomFormat manifestFormat) {
         return withManifestFormatInfo(manifestFormat);
@@ -1336,26 +1437,32 @@ public final class CustomFormat implements Bundleable {
 
     /**
      * @deprecated Use {@link #buildUpon()}, {@link Builder#setEncoderDelay(int)} and {@link
-     *     Builder#setEncoderPadding(int)}.
+     * Builder#setEncoderPadding(int)}.
      */
     @Deprecated
     public CustomFormat copyWithGaplessInfo(int encoderDelay, int encoderPadding) {
         return buildUpon().setEncoderDelay(encoderDelay).setEncoderPadding(encoderPadding).build();
     }
 
-    /** @deprecated Use {@link #buildUpon()} and {@link Builder#setFrameRate(float)}. */
+    /**
+     * @deprecated Use {@link #buildUpon()} and {@link Builder#setFrameRate(float)}.
+     */
     @Deprecated
     public CustomFormat copyWithFrameRate(float frameRate) {
         return buildUpon().setFrameRate(frameRate).build();
     }
 
-    /** @deprecated Use {@link #buildUpon()} and {@link Builder#setDrmInitData(DrmInitData)}. */
+    /**
+     * @deprecated Use {@link #buildUpon()} and {@link Builder#setDrmInitData(DrmInitData)}.
+     */
     @Deprecated
     public CustomFormat copyWithDrmInitData(@Nullable DrmInitData drmInitData) {
         return buildUpon().setDrmInitData(drmInitData).build();
     }
 
-    /** @deprecated Use {@link #buildUpon()} and {@link Builder#setMetadata(Metadata)}. */
+    /**
+     * @deprecated Use {@link #buildUpon()} and {@link Builder#setMetadata(Metadata)}.
+     */
     @Deprecated
     public CustomFormat copyWithMetadata(@Nullable Metadata metadata) {
         return buildUpon().setMetadata(metadata).build();
@@ -1363,7 +1470,7 @@ public final class CustomFormat implements Bundleable {
 
     /**
      * @deprecated Use {@link #buildUpon()} and {@link Builder#setAverageBitrate(int)} and {@link
-     *     Builder#setPeakBitrate(int)}.
+     * Builder#setPeakBitrate(int)}.
      */
     @Deprecated
     public CustomFormat copyWithBitrate(int bitrate) {
@@ -1372,14 +1479,16 @@ public final class CustomFormat implements Bundleable {
 
     /**
      * @deprecated Use {@link #buildUpon()}, {@link Builder#setWidth(int)} and {@link
-     *     Builder#setHeight(int)}.
+     * Builder#setHeight(int)}.
      */
     @Deprecated
     public CustomFormat copyWithVideoSize(int width, int height) {
         return buildUpon().setWidth(width).setHeight(height).build();
     }
 
-    /** Returns a copy of this format with the specified {@link #cryptoType}. */
+    /**
+     * Returns a copy of this format with the specified {@link #cryptoType}.
+     */
     public CustomFormat copyWithCryptoType(@C.CryptoType int cryptoType) {
         return buildUpon().setCryptoType(cryptoType).build();
     }
@@ -1519,7 +1628,7 @@ public final class CustomFormat implements Bundleable {
      *
      * @param other The other format whose {@link #initializationData} is being compared.
      * @return Whether the {@link #initializationData}s belonging to this format and {@code other} are
-     *     equal.
+     * equal.
      */
     public boolean initializationDataEquals(CustomFormat other) {
         if (initializationData.size() != other.initializationData.size()) {
@@ -1535,7 +1644,9 @@ public final class CustomFormat implements Bundleable {
 
     // Utility methods
 
-    /** Returns a prettier {@link String} than {@link #toString()}, intended for logging. */
+    /**
+     * Returns a prettier {@link String} than {@link #toString()}, intended for logging.
+     */
     public static String toLogString(@Nullable CustomFormat format) {
         if (format == null) {
             return "null";
@@ -1627,7 +1738,8 @@ public final class CustomFormat implements Bundleable {
             FIELD_ACCESSIBILITY_CHANNEL,
             FIELD_CRYPTO_TYPE,
     })
-    private @interface FieldNumber {}
+    private @interface FieldNumber {
+    }
 
     private static final int FIELD_ID = 0;
     private static final int FIELD_LABEL = 1;
@@ -1695,7 +1807,9 @@ public final class CustomFormat implements Bundleable {
         bundle.putFloat(keyForField(FIELD_PIXEL_WIDTH_HEIGHT_RATIO), pixelWidthHeightRatio);
         bundle.putByteArray(keyForField(FIELD_PROJECTION_DATA), projectionData);
         bundle.putInt(keyForField(FIELD_STEREO_MODE), stereoMode);
-        bundle.putBundle(keyForField(FIELD_COLOR_INFO), BundleableUtil.toNullableBundle(colorInfo));
+        if (colorInfo != null) {
+            bundle.putBundle(keyForField(FIELD_COLOR_INFO), colorInfo.toBundle());
+        }
         // Audio specific.
         bundle.putInt(keyForField(FIELD_CHANNEL_COUNT), channelCount);
         bundle.putInt(keyForField(FIELD_SAMPLE_RATE), sampleRate);
@@ -1709,7 +1823,9 @@ public final class CustomFormat implements Bundleable {
         return bundle;
     }
 
-    /** Object that can restore {@code Format} from a {@link Bundle}. */
+    /**
+     * Object that can restore {@code Format} from a {@link Bundle}.
+     */
     public static final Creator<CustomFormat> CREATOR = CustomFormat::fromBundle;
 
     private static CustomFormat fromBundle(Bundle bundle) {
@@ -1762,11 +1878,15 @@ public final class CustomFormat implements Bundleable {
                         bundle.getFloat(
                                 keyForField(FIELD_PIXEL_WIDTH_HEIGHT_RATIO), DEFAULT.pixelWidthHeightRatio))
                 .setProjectionData(bundle.getByteArray(keyForField(FIELD_PROJECTION_DATA)))
-                .setStereoMode(bundle.getInt(keyForField(FIELD_STEREO_MODE), DEFAULT.stereoMode))
-                .setColorInfo(
-                        BundleableUtil.fromNullableBundle(
-                                ColorInfo.CREATOR, bundle.getBundle(keyForField(FIELD_COLOR_INFO))))
-                // Audio specific.
+                .setStereoMode(bundle.getInt(keyForField(FIELD_STEREO_MODE), DEFAULT.stereoMode));
+
+        Bundle colorInfoBundle = bundle.getBundle(keyForField(FIELD_COLOR_INFO));
+        if (colorInfoBundle != null) {
+            builder.setColorInfo(ColorInfo.CREATOR.fromBundle(colorInfoBundle));
+        }
+        
+        // Audio specific.
+        builder
                 .setChannelCount(bundle.getInt(keyForField(FIELD_CHANNEL_COUNT), DEFAULT.channelCount))
                 .setSampleRate(bundle.getInt(keyForField(FIELD_SAMPLE_RATE), DEFAULT.sampleRate))
                 .setPcmEncoding(bundle.getInt(keyForField(FIELD_PCM_ENCODING), DEFAULT.pcmEncoding))
@@ -1904,17 +2024,17 @@ public final class CustomFormat implements Bundleable {
                 return this;
             }
 
-            public FormatThumbnailInfo.Builder  setEndNumber(long endNumber) {
+            public FormatThumbnailInfo.Builder setEndNumber(long endNumber) {
                 this.endNumber = endNumber;
                 return this;
             }
 
-            public FormatThumbnailInfo.Builder  setImageTemplateUrl(String imageTemplateUrl) {
+            public FormatThumbnailInfo.Builder setImageTemplateUrl(String imageTemplateUrl) {
                 this.imageTemplateUrl = imageTemplateUrl;
                 return this;
             }
 
-            public FormatThumbnailInfo.Builder  setSegmentDuration(long segmentDuration) {
+            public FormatThumbnailInfo.Builder setSegmentDuration(long segmentDuration) {
                 this.segmentDuration = segmentDuration;
                 return this;
             }

--- a/playkit/src/main/java/com/kaltura/playkit/Player.java
+++ b/playkit/src/main/java/com/kaltura/playkit/Player.java
@@ -242,21 +242,6 @@ public interface Player {
         Settings allowChunklessPreparation(boolean allowChunklessPreparation);
 
         /**
-         * Sets whether the player reports diagnostics data to the Android platform.
-         *
-         * <p>If enabled, the player will use the {@link android.media.metrics.MediaMetricsManager} to
-         * create a {@link android.media.metrics.PlaybackSession} and forward playback events and
-         * performance data to this session. This helps to provide system performance and debugging
-         * information for media playback on the device. This data may also be collected by Google <a
-         * href="https://support.google.com/accounts/answer/6078260">if sharing usage and diagnostics
-         * data is enabled</a> by the user of the device.
-         *
-         * @param UsePlatformDiagnostics Default is `true`.
-         * @return - Player Settings
-         */
-        Settings usePlatformDiagnostics(boolean UsePlatformDiagnostics);
-
-        /**
          * Set the flag which handles the video view
          *
          * @param hide video surface visibility

--- a/playkit/src/main/java/com/kaltura/playkit/Player.java
+++ b/playkit/src/main/java/com/kaltura/playkit/Player.java
@@ -242,6 +242,21 @@ public interface Player {
         Settings allowChunklessPreparation(boolean allowChunklessPreparation);
 
         /**
+         * When enabled, the `DefaultTrackSelector` will prefer audio tracks whose
+         * channel count does not exceed the device output capabilities.
+         *
+         * On handheld devices, the DefaultTrackSelector will prefer stereo/mono over
+         * multichannel audio formats, unless the multichannel format can be Spatialized (Android 12L+)
+         * or is a Dolby surround sound format. In addition, on devices that support audio spatialization,
+         * the DefaultTrackSelector will monitor for changes in the Spatializer properties and
+         * trigger `tracksAvailable` event upon these.
+         *
+         * @param enabled Default is disabled.
+         * @return - Player Settings
+         */
+        Settings constrainAudioChannelCountToDeviceCapabilities(boolean enabled);
+
+        /**
          * Set the flag which handles the video view
          *
          * @param hide video surface visibility

--- a/playkit/src/main/java/com/kaltura/playkit/Player.java
+++ b/playkit/src/main/java/com/kaltura/playkit/Player.java
@@ -654,6 +654,20 @@ public interface Player {
     void resetABRSettings();
 
     /**
+     * Returns the media manifest of the window
+     * Manifest depends on the type of media being prepared.
+     * Must be called once the media preparation is complete (Means tracks are loaded)
+     *
+     * @return Manifest object depends on the media type
+     * ({@link com.kaltura.android.exoplayer2.source.hls.HlsManifest}
+     * or {@link com.kaltura.android.exoplayer2.source.dash.manifest.DashManifest})
+     * <br>
+     * OR `null`
+     */
+    @Nullable
+    Object getCurrentMediaManifest();
+
+    /**
      * Add listener by event type as Class object. This generics-based method allows the caller to
      * avoid the otherwise required cast.
      * <p>

--- a/playkit/src/main/java/com/kaltura/playkit/Player.java
+++ b/playkit/src/main/java/com/kaltura/playkit/Player.java
@@ -242,6 +242,21 @@ public interface Player {
         Settings allowChunklessPreparation(boolean allowChunklessPreparation);
 
         /**
+         * Sets whether the player reports diagnostics data to the Android platform.
+         *
+         * <p>If enabled, the player will use the {@link android.media.metrics.MediaMetricsManager} to
+         * create a {@link android.media.metrics.PlaybackSession} and forward playback events and
+         * performance data to this session. This helps to provide system performance and debugging
+         * information for media playback on the device. This data may also be collected by Google <a
+         * href="https://support.google.com/accounts/answer/6078260">if sharing usage and diagnostics
+         * data is enabled</a> by the user of the device.
+         *
+         * @param UsePlatformDiagnostics Default is `true`.
+         * @return - Player Settings
+         */
+        Settings usePlatformDiagnostics(boolean UsePlatformDiagnostics);
+
+        /**
          * Set the flag which handles the video view
          *
          * @param hide video surface visibility

--- a/playkit/src/main/java/com/kaltura/playkit/PlayerDecoratorBase.java
+++ b/playkit/src/main/java/com/kaltura/playkit/PlayerDecoratorBase.java
@@ -259,6 +259,12 @@ public class PlayerDecoratorBase implements Player {
         player.resetABRSettings();
     }
 
+    @Nullable
+    @Override
+    public Object getCurrentMediaManifest() {
+        return player.getCurrentMediaManifest();
+    }
+
     @Override
     public <E extends PKEvent> void addListener(Object groupId, Class<E> type, PKEvent.Listener<E> listener) {
         player.addListener(groupId, type, listener);

--- a/playkit/src/main/java/com/kaltura/playkit/PlayerEngineWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/PlayerEngineWrapper.java
@@ -1,5 +1,7 @@
 package com.kaltura.playkit;
 
+import androidx.annotation.Nullable;
+
 import com.kaltura.android.exoplayer2.upstream.cache.Cache;
 import com.kaltura.android.exoplayer2.source.dash.manifest.EventStream;
 import com.kaltura.playkit.player.ABRSettings;
@@ -239,6 +241,12 @@ public class PlayerEngineWrapper implements PlayerEngine {
     @Override
     public void resetABRSettings() {
         playerEngine.resetABRSettings();
+    }
+
+    @Nullable
+    @Override
+    public Object getCurrentMediaManifest() {
+        return playerEngine.getCurrentMediaManifest();
     }
 
     @Override

--- a/playkit/src/main/java/com/kaltura/playkit/ads/PKAdvertisingController.kt
+++ b/playkit/src/main/java/com/kaltura/playkit/ads/PKAdvertisingController.kt
@@ -918,7 +918,6 @@ class PKAdvertisingController: PKAdvertising, IMAEventsListener {
                                 adTagUrl = ads[0].ad
                             }
                         }
-
                     }
                 }
             }
@@ -939,6 +938,9 @@ class PKAdvertisingController: PKAdvertising, IMAEventsListener {
                         adTagUrl = getAdFromAdPod(adPodList, adBreakConfig.adBreakPositionType, isTriggeredFromPlayerPosition)
                     }
                 }
+            }
+            AdState.ERROR -> {
+                // Do Nothing
             }
         }
 

--- a/playkit/src/main/java/com/kaltura/playkit/ads/PKAdvertisingController.kt
+++ b/playkit/src/main/java/com/kaltura/playkit/ads/PKAdvertisingController.kt
@@ -939,7 +939,8 @@ class PKAdvertisingController: PKAdvertising, IMAEventsListener {
                     }
                 }
             }
-            AdState.ERROR -> {
+
+            else -> {
                 // Do Nothing
             }
         }

--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoAnalyticsAggregator.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoAnalyticsAggregator.java
@@ -8,6 +8,7 @@ import androidx.annotation.Nullable;
 
 import com.kaltura.android.exoplayer2.C;
 import com.kaltura.android.exoplayer2.Format;
+import com.kaltura.android.exoplayer2.Tracks;
 import com.kaltura.android.exoplayer2.analytics.AnalyticsListener;
 import com.kaltura.android.exoplayer2.decoder.DecoderCounters;
 import com.kaltura.android.exoplayer2.decoder.DecoderReuseEvaluation;
@@ -119,6 +120,11 @@ class ExoAnalyticsAggregator extends EventListener implements AnalyticsListener 
         if (listener != null) {
             listener.onLoadError(error, wasCanceled);
         }
+    }
+
+    @Override
+    public void onTracksChanged(EventTime eventTime, Tracks tracks) {
+        AnalyticsListener.super.onTracksChanged(eventTime, tracks);
     }
 
     @Override // OKHTTTP

--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoAnalyticsAggregator.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoAnalyticsAggregator.java
@@ -236,6 +236,10 @@ class ExoAnalyticsAggregator extends EventListener implements AnalyticsListener 
 
     @Override
     public void onTracksChanged(@NonNull EventTime eventTime, @NonNull Tracks tracks) {
+        if (tracks.isEmpty() || tracks.getGroups().isEmpty()) {
+            return;
+        }
+
         ImmutableList<Tracks.Group> trackGroups = tracks.getGroups();
         StringBuilder logOutput = new StringBuilder();
         Set<String> availableTrackType = new HashSet<>();

--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoAnalyticsAggregator.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoAnalyticsAggregator.java
@@ -1,11 +1,14 @@
 package com.kaltura.playkit.player;
 
+import static com.kaltura.playkit.utils.Consts.HTTP_METHOD_GET;
+
 import android.os.SystemClock;
 import android.text.TextUtils;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.google.common.collect.ImmutableList;
 import com.kaltura.android.exoplayer2.C;
 import com.kaltura.android.exoplayer2.Format;
 import com.kaltura.android.exoplayer2.Tracks;
@@ -14,21 +17,22 @@ import com.kaltura.android.exoplayer2.decoder.DecoderCounters;
 import com.kaltura.android.exoplayer2.decoder.DecoderReuseEvaluation;
 import com.kaltura.android.exoplayer2.source.LoadEventInfo;
 import com.kaltura.android.exoplayer2.source.MediaLoadData;
+import com.kaltura.android.exoplayer2.source.TrackGroup;
 import com.kaltura.playkit.PKLog;
 import com.kaltura.playkit.player.metadata.URIConnectionAcquiredInfo;
 
 import java.io.IOException;
 import java.net.InetAddress;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import okhttp3.Call;
 import okhttp3.Connection;
 import okhttp3.EventListener;
 import okhttp3.Handshake;
-
-import static com.kaltura.playkit.utils.Consts.HTTP_METHOD_GET;
 
 class ExoAnalyticsAggregator extends EventListener implements AnalyticsListener {
 
@@ -120,11 +124,6 @@ class ExoAnalyticsAggregator extends EventListener implements AnalyticsListener 
         if (listener != null) {
             listener.onLoadError(error, wasCanceled);
         }
-    }
-
-    @Override
-    public void onTracksChanged(EventTime eventTime, Tracks tracks) {
-        AnalyticsListener.super.onTracksChanged(eventTime, tracks);
     }
 
     @Override // OKHTTTP
@@ -233,6 +232,94 @@ class ExoAnalyticsAggregator extends EventListener implements AnalyticsListener 
         if (inputFormatChangedListener != null) {
             inputFormatChangedListener.onAudioInputFormatChanged(format);
         }
+    }
+
+    @Override
+    public void onTracksChanged(@NonNull EventTime eventTime, @NonNull Tracks tracks) {
+        ImmutableList<Tracks.Group> trackGroups = tracks.getGroups();
+        StringBuilder logOutput = new StringBuilder();
+        Set<String> availableTrackType = new HashSet<>();
+
+        for (int groupIndex = 0; groupIndex < trackGroups.size(); groupIndex++) {
+            Tracks.Group trackGroup = trackGroups.get(groupIndex);
+            String trackType = getTrackType(trackGroup.getType());
+
+            if (!availableTrackType.contains(trackType)) {
+                availableTrackType.add(trackType);
+                logOutput
+                        .append("\n\"").append(trackType).append("\"")
+                        .append(":")
+                        .append(" [").append("\n");
+            }
+
+            final TrackGroup mediaTrackGroup = trackGroup.getMediaTrackGroup();
+
+            for (int trackIndex = 0; trackIndex < trackGroup.length; trackIndex++) {
+                boolean isTrackSelected = trackGroup.isTrackSelected(trackIndex);
+                // Get format of each track group present individually in video/audio/text
+                Format format = mediaTrackGroup.getFormat(trackIndex);
+                String mediaFormat = Format.toLogString(format);
+                logOutput.append("\t{").append("\n");
+
+                logOutput.append("\t\"").append("isTrackSelected").append("\"").append(":")
+                        .append("\t\"").append(isTrackSelected).append("\"")
+                        .append("\t,").append("\n");
+
+                logOutput.append("\t\"").append("Format").append("\"").append(":")
+                        .append("\t\"").append(mediaFormat).append("\"").append("\n");
+
+                logOutput.append("\t}");
+                if (trackIndex + 1 < trackGroup.length) {
+                    logOutput.append(",").append("\n");
+                }
+            }
+            String nextTrackType = "";
+            if (groupIndex + 1 < trackGroups.size()) {
+                Tracks.Group nextTrackGroup = trackGroups.get(groupIndex + 1);
+                nextTrackType = getTrackType(nextTrackGroup.getType());
+            }
+
+            if (!availableTrackType.contains(nextTrackType)) {
+                logOutput.append("]");
+            }
+
+            if (groupIndex + 1 < trackGroups.size()) {
+                logOutput.append(",");
+            }
+        }
+        log.d("{" + logOutput + "\n }");
+    }
+
+    private String getTrackType(int type) {
+        String trackType;
+        switch (type) {
+            case C.TRACK_TYPE_VIDEO:
+                trackType =  "Video";
+                break;
+            case C.TRACK_TYPE_AUDIO:
+                trackType =  "Audio";
+                break;
+            case C.TRACK_TYPE_TEXT:
+                trackType =  "Text";
+                break;
+            case C.TRACK_TYPE_IMAGE:
+                trackType =  "Image";
+                break;
+            default:
+                trackType =  "None";
+                break;
+        }
+        return trackType;
+    }
+
+    @Override
+    public void onVideoCodecError(@NonNull EventTime eventTime, @NonNull Exception videoCodecError) {
+        log.v("onVideoCodecError Exception " + videoCodecError.getMessage());
+    }
+
+    @Override
+    public void onDrmSessionManagerError(@NonNull EventTime eventTime, @NonNull Exception error) {
+        log.v("onDrmSessionManagerError Exception " + error.getMessage());
     }
 }
 

--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerView.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerView.java
@@ -31,7 +31,6 @@ import com.kaltura.android.exoplayer2.ExoPlayer;
 import com.kaltura.android.exoplayer2.Player;
 import com.kaltura.android.exoplayer2.text.Cue;
 import com.kaltura.android.exoplayer2.text.CueGroup;
-import com.kaltura.android.exoplayer2.text.TextOutput;
 import com.kaltura.android.exoplayer2.ui.AspectRatioFrameLayout;
 import com.kaltura.android.exoplayer2.ui.SubtitleView;
 import com.kaltura.android.exoplayer2.video.VideoSize;

--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerView.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerView.java
@@ -30,6 +30,7 @@ import androidx.annotation.NonNull;
 import com.kaltura.android.exoplayer2.ExoPlayer;
 import com.kaltura.android.exoplayer2.Player;
 import com.kaltura.android.exoplayer2.text.Cue;
+import com.kaltura.android.exoplayer2.text.CueGroup;
 import com.kaltura.android.exoplayer2.text.TextOutput;
 import com.kaltura.android.exoplayer2.ui.AspectRatioFrameLayout;
 import com.kaltura.android.exoplayer2.ui.SubtitleView;
@@ -274,7 +275,7 @@ class ExoPlayerView extends BaseExoplayerView {
     @Override
     public void applySubtitlesChanges() {
         if (subtitleView != null && lastReportedCues != null) {
-            subtitleView.onCues(getModifiedSubtitlePosition(lastReportedCues, subtitleViewPosition));
+            subtitleView.setCues(getModifiedSubtitlePosition(lastReportedCues, subtitleViewPosition));
         }
     }
 
@@ -323,17 +324,18 @@ class ExoPlayerView extends BaseExoplayerView {
     /**
      * Local listener implementation.
      */
-    private final class ComponentListener implements TextOutput, Player.Listener, OnLayoutChangeListener {
+    private final class ComponentListener implements Player.Listener, OnLayoutChangeListener {
 
         @Override
-        public void onCues(List<Cue> cues) {
-            lastReportedCues = cues;
+        public void onCues(CueGroup cueGroup) {
+            lastReportedCues = cueGroup.cues;
+            List<Cue> cueList = null;
             if (subtitleViewPosition != null) {
-                cues = getModifiedSubtitlePosition(cues, subtitleViewPosition);
+                cueList = getModifiedSubtitlePosition(lastReportedCues, subtitleViewPosition);
             }
 
             if (subtitleView != null) {
-                subtitleView.onCues(cues);
+                subtitleView.setCues((cueList != null && !cueList.isEmpty()) ? cueList : lastReportedCues);
             }
         }
 

--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
@@ -249,7 +249,7 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.Listener, Metadata
                 .setLoadControl(getUpdatedLoadControl())
                 .setMediaSourceFactory(mediaSourceFactory)
                 .setBandwidthMeter(bandwidthMeter)
-                .setUsePlatformDiagnostics(playerSettings.isUsePlatformDiagnostics())
+                .setUsePlatformDiagnostics(false)
                 .build();
 
         player.setAudioAttributes(AudioAttributes.DEFAULT, /* handleAudioFocus= */ playerSettings.isHandleAudioFocus());

--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
@@ -248,7 +248,9 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.Listener, Metadata
                 .setTrackSelector(trackSelector)
                 .setLoadControl(getUpdatedLoadControl())
                 .setMediaSourceFactory(mediaSourceFactory)
-                .setBandwidthMeter(bandwidthMeter).build();
+                .setBandwidthMeter(bandwidthMeter)
+                .setUsePlatformDiagnostics(playerSettings.isUsePlatformDiagnostics())
+                .build();
 
         player.setAudioAttributes(AudioAttributes.DEFAULT, /* handleAudioFocus= */ playerSettings.isHandleAudioFocus());
         player.setHandleAudioBecomingNoisy(playerSettings.isHandleAudioBecomingNoisyEnabled());

--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
@@ -312,6 +312,8 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.Listener, Metadata
         metadataList.clear();
         isLoadedMetaDataFired = false;
         shouldGetTracksInfo = true;
+        // Need to clear the overrides of DefaultTrackSelector before loading the next media.
+        trackSelectionHelper.clearPreviousMediaOverrides();
         trackSelectionHelper.applyPlayerSettings(playerSettings);
 
         MediaSource mediaSource = null;

--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
@@ -35,7 +35,7 @@ import com.kaltura.android.exoplayer2.PlaybackException;
 import com.kaltura.android.exoplayer2.PlaybackParameters;
 import com.kaltura.android.exoplayer2.Player;
 import com.kaltura.android.exoplayer2.Timeline;
-import com.kaltura.android.exoplayer2.TracksInfo;
+import com.kaltura.android.exoplayer2.Tracks;
 import com.kaltura.android.exoplayer2.audio.AudioAttributes;
 import com.kaltura.android.exoplayer2.dashmanifestparser.CustomDashManifest;
 import com.kaltura.android.exoplayer2.dashmanifestparser.CustomDashManifestParser;
@@ -295,7 +295,7 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.Listener, Metadata
     private DefaultTrackSelector initializeTrackSelector() {
 
         DefaultTrackSelector trackSelector = new DefaultTrackSelector(context);
-        DefaultTrackSelector.ParametersBuilder parametersBuilder = new DefaultTrackSelector.ParametersBuilder(context);
+        DefaultTrackSelector.Parameters.Builder parametersBuilder = new DefaultTrackSelector.Parameters.Builder(context);
         trackSelectionHelper = new TrackSelectionHelper(context, trackSelector, lastSelectedTrackIds);
         trackSelectionHelper.updateTrackSelectorParameter(playerSettings, parametersBuilder);
         trackSelector.setParameters(parametersBuilder.build());
@@ -1014,12 +1014,11 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.Listener, Metadata
     }
     
     @Override
-    public void onTracksInfoChanged(@NonNull TracksInfo tracksInfo) {
-        log.d("onTracksInfoChanged");
+    public void onTracksChanged(@NonNull Tracks tracks) {
+        log.d("onTracksChanged");
 
-        //if onTracksInfoChanged happened when application went background, do not update the tracks.
-        if (assertTrackSelectionIsNotNull("onTracksInfoChanged()")) {
-
+        //if onTracksChanged happened when application went background, do not update the tracks.
+        if (assertTrackSelectionIsNotNull("onTracksChanged()")) {
             //if the track info new -> map the available tracks. and when ready, notify user about available tracks.
             if (shouldGetTracksInfo) {
                 CustomDashManifest customDashManifest = null;
@@ -1037,11 +1036,10 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.Listener, Metadata
                         dashManifestString = null;
                     }
                 }
-                shouldGetTracksInfo = !trackSelectionHelper.prepareTracks(tracksInfo, sourceConfig.getExternalVttThumbnailUrl(), customDashManifest);
+                shouldGetTracksInfo = !trackSelectionHelper.prepareTracks(tracks, sourceConfig.getExternalVttThumbnailUrl(), customDashManifest);
             }
+            trackSelectionHelper.notifyAboutTrackChange(tracks);
         }
-
-        trackSelectionHelper.notifyAboutTrackChange(tracksInfo);
     }
 
     @Override

--- a/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/ExoPlayerWrapper.java
@@ -229,7 +229,7 @@ public class ExoPlayerWrapper implements PlayerEngine, Player.Listener, Metadata
 
     @Override
     public void onBandwidthSample(int elapsedMs, long bytes, long bitrate) {
-        if (assertPlayerIsNotNull("onBandwidthSample") && player != null && trackSelectionHelper != null) {
+        if (assertPlayerIsNotNull("onBandwidthSample") && !isPlayerReleased && trackSelectionHelper != null) {
             sendEvent(PlayerEvent.Type.PLAYBACK_INFO_UPDATED);
         }
     }

--- a/playkit/src/main/java/com/kaltura/playkit/player/MediaPlayerWrapper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/MediaPlayerWrapper.java
@@ -25,6 +25,7 @@ import android.os.Build;
 import android.view.SurfaceHolder;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.kaltura.playkit.PKAbrFilter;
 import com.kaltura.android.exoplayer2.source.dash.manifest.EventStream;
@@ -661,6 +662,13 @@ class MediaPlayerWrapper implements PlayerEngine, SurfaceHolder.Callback, MediaP
     @Override
     public void updateSubtitleStyle(SubtitleStyleSettings subtitleStyleSettings) {
         //Do nothing
+    }
+
+    @Nullable
+    @Override
+    public Object getCurrentMediaManifest() {
+        // Do nothing
+        return null;
     }
 
     @NonNull

--- a/playkit/src/main/java/com/kaltura/playkit/player/PlayerController.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/PlayerController.java
@@ -797,6 +797,16 @@ public class PlayerController implements Player {
         }
     }
 
+    @Nullable
+    @Override
+    public Object getCurrentMediaManifest() {
+        log.v("getCurrentMediaManifest");
+        if (assertPlayerIsNotNull("getCurrentMediaManifest")) {
+            return player.getCurrentMediaManifest();
+        }
+        return null;
+    }
+
     @Override
     public <E extends PKEvent> void addListener(Object groupId, Class<E> type, PKEvent.Listener<E> listener) {
         Assert.shouldNeverHappen();

--- a/playkit/src/main/java/com/kaltura/playkit/player/PlayerEngine.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/PlayerEngine.java
@@ -12,6 +12,8 @@
 
 package com.kaltura.playkit.player;
 
+import androidx.annotation.Nullable;
+
 import com.kaltura.android.exoplayer2.upstream.cache.Cache;
 import com.kaltura.playkit.PKAbrFilter;
 import com.kaltura.android.exoplayer2.source.dash.manifest.EventStream;
@@ -299,6 +301,9 @@ public interface PlayerEngine {
      * Reset the ABR Settings
      */
     default void resetABRSettings() {}
+
+    @Nullable
+    Object getCurrentMediaManifest();
 
     /**
      * Generic getters for playkit controllers.

--- a/playkit/src/main/java/com/kaltura/playkit/player/PlayerSettings.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/PlayerSettings.java
@@ -42,7 +42,6 @@ public class PlayerSettings implements Player.Settings {
     //Only if IMA plugin is there then only this flag is set to true.
     private boolean forceSinglePlayerEngine = false;
     private boolean allowChunklessPreparation = true;
-    private boolean usePlatformDiagnostics = true;
 
     private PKWakeMode wakeMode = PKWakeMode.NONE;
     private VideoCodecSettings preferredVideoCodecSettings = new VideoCodecSettings();
@@ -158,10 +157,6 @@ public class PlayerSettings implements Player.Settings {
 
     public boolean isAllowChunklessPreparation() {
         return allowChunklessPreparation;
-    }
-
-    public boolean isUsePlatformDiagnostics() {
-        return usePlatformDiagnostics;
     }
 
     public VideoCodecSettings getPreferredVideoCodecSettings() {
@@ -342,11 +337,6 @@ public class PlayerSettings implements Player.Settings {
     @Override
     public Player.Settings allowChunklessPreparation(boolean allowChunklessPreparation) {
         this.allowChunklessPreparation = allowChunklessPreparation;
-        return this;
-    }
-
-    public Player.Settings usePlatformDiagnostics(boolean usePlatformDiagnostics) {
-        this.usePlatformDiagnostics = usePlatformDiagnostics;
         return this;
     }
 

--- a/playkit/src/main/java/com/kaltura/playkit/player/PlayerSettings.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/PlayerSettings.java
@@ -38,10 +38,13 @@ public class PlayerSettings implements Player.Settings {
     private boolean handleAudioBecomingNoisyEnabled;
     private boolean handleAudioFocus;
 
-    //Flag helping to check if client app wants to use a single player instance at a time
-    //Only if IMA plugin is there then only this flag is set to true.
+    // Flag helping to check if client app wants to use a single player instance at a time
+    // Only if IMA plugin is there then only this flag is set to true.
     private boolean forceSinglePlayerEngine = false;
     private boolean allowChunklessPreparation = true;
+    // When enabled, the `DefaultTrackSelector` will prefer audio tracks whose channel
+    // count does not exceed the device output capabilities.
+    private boolean constrainAudioChannelCountToDeviceCapabilities = false;
 
     private PKWakeMode wakeMode = PKWakeMode.NONE;
     private VideoCodecSettings preferredVideoCodecSettings = new VideoCodecSettings();
@@ -157,6 +160,10 @@ public class PlayerSettings implements Player.Settings {
 
     public boolean isAllowChunklessPreparation() {
         return allowChunklessPreparation;
+    }
+
+    public boolean isConstrainAudioChannelCountToDeviceCapabilities() {
+        return constrainAudioChannelCountToDeviceCapabilities;
     }
 
     public VideoCodecSettings getPreferredVideoCodecSettings() {
@@ -341,6 +348,12 @@ public class PlayerSettings implements Player.Settings {
     }
 
     @Override
+    public Player.Settings constrainAudioChannelCountToDeviceCapabilities(boolean enabled) {
+        this.constrainAudioChannelCountToDeviceCapabilities = enabled;
+        return this;
+    }
+
+    @Override
     public Player.Settings setHideVideoViews(boolean hide) {
         isVideoViewHidden = hide;
         return this;
@@ -414,7 +427,7 @@ public class PlayerSettings implements Player.Settings {
     }
 
     @Override
-    public Player.Settings setMaxVideoSize(PKMaxVideoSize maxVideoSize) {
+    public Player.Settings setMaxVideoSize(@NonNull PKMaxVideoSize maxVideoSize) {
         ABRSettings abrSettings = getAbrSettings();
         if (maxVideoSize != null &&
                 (abrSettings.getMaxVideoHeight() == Long.MAX_VALUE || abrSettings.getMaxVideoWidth() == Long.MAX_VALUE)) {
@@ -425,7 +438,7 @@ public class PlayerSettings implements Player.Settings {
     }
 
     @Override
-    public Player.Settings setMaxVideoBitrate(Integer maxVideoBitrate) {
+    public Player.Settings setMaxVideoBitrate(@NonNull Integer maxVideoBitrate) {
         ABRSettings abrSettings = getAbrSettings();
         if (maxVideoBitrate > 0 && abrSettings.getMaxVideoBitrate() == Long.MAX_VALUE) {
             abrSettings.setMaxVideoBitrate(maxVideoBitrate);
@@ -434,7 +447,7 @@ public class PlayerSettings implements Player.Settings {
     }
 
     @Override
-    public Player.Settings setMaxAudioBitrate(Integer maxAudioBitrate) {
+    public Player.Settings setMaxAudioBitrate(@NonNull Integer maxAudioBitrate) {
         this.maxAudioBitrate = maxAudioBitrate;
         return this;
     }

--- a/playkit/src/main/java/com/kaltura/playkit/player/PlayerSettings.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/PlayerSettings.java
@@ -42,6 +42,7 @@ public class PlayerSettings implements Player.Settings {
     //Only if IMA plugin is there then only this flag is set to true.
     private boolean forceSinglePlayerEngine = false;
     private boolean allowChunklessPreparation = true;
+    private boolean usePlatformDiagnostics = true;
 
     private PKWakeMode wakeMode = PKWakeMode.NONE;
     private VideoCodecSettings preferredVideoCodecSettings = new VideoCodecSettings();
@@ -157,6 +158,10 @@ public class PlayerSettings implements Player.Settings {
 
     public boolean isAllowChunklessPreparation() {
         return allowChunklessPreparation;
+    }
+
+    public boolean isUsePlatformDiagnostics() {
+        return usePlatformDiagnostics;
     }
 
     public VideoCodecSettings getPreferredVideoCodecSettings() {
@@ -337,6 +342,11 @@ public class PlayerSettings implements Player.Settings {
     @Override
     public Player.Settings allowChunklessPreparation(boolean allowChunklessPreparation) {
         this.allowChunklessPreparation = allowChunklessPreparation;
+        return this;
+    }
+
+    public Player.Settings usePlatformDiagnostics(boolean usePlatformDiagnostics) {
+        this.usePlatformDiagnostics = usePlatformDiagnostics;
         return this;
     }
 

--- a/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
@@ -1672,6 +1672,7 @@ public class TrackSelectionHelper {
         if (playerSettings.getPreferredVideoCodecSettings().getAllowMixedCodecAdaptiveness()) {
             parametersBuilder.setAllowVideoMixedMimeTypeAdaptiveness(true);
         }
+        parametersBuilder.setConstrainAudioChannelCountToDeviceCapabilities(playerSettings.isConstrainAudioChannelCountToDeviceCapabilities());
     }
 
     public ThumbnailInfo getThumbnailInfo(long positionMS) {

--- a/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
@@ -1920,10 +1920,6 @@ public class TrackSelectionHelper {
             externalVttThumbnailRangesInfo.clear();
             externalVttThumbnailRangesInfo = null;
         }
-        if (trackSelectionOverridesBuilder != null) {
-            trackSelectionOverridesBuilder.setTrackTypeDisabled(C.TRACK_TYPE_TEXT, false);
-            selector.setParameters(trackSelectionOverridesBuilder.build());
-        }
     }
 
     protected void release() {

--- a/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
@@ -1641,11 +1641,12 @@ public class TrackSelectionHelper {
         TrackGroup trackGroup = mappedTrackInfo.getTrackGroups(rendererIndex).get(groupIndex);
         if (!selectedIndices.isEmpty()) {
             if (rendererIndex == TRACK_TYPE_TEXT && selectedIndices.get(0) == TRACK_DISABLED) {
-                trackSelectionOverridesBuilder.setTrackTypeDisabled(C.TRACK_TYPE_TEXT, true);
-            } else {
-                TrackSelectionOverride trackSelectionOverride = new TrackSelectionOverride(trackGroup, selectedIndices);
-                trackSelectionOverridesBuilder.setOverrideForType(trackSelectionOverride);
+                // Just clear the selected indices,
+                // it will let exoplayer know that no tracks from trackGroup should be played
+                selectedIndices.clear();
             }
+            TrackSelectionOverride trackSelectionOverride = new TrackSelectionOverride(trackGroup, selectedIndices);
+            trackSelectionOverridesBuilder.setOverrideForType(trackSelectionOverride);
         } else {
             //clear all the selections if selectedIndices are empty.
             trackSelectionOverridesBuilder.clearOverride(trackGroup);
@@ -1978,12 +1979,13 @@ public class TrackSelectionHelper {
     @Nullable
     private Format getSelectedTextTrackFormat() {
         if (tracksInfo != null && !tracksInfo.getGroups().isEmpty()) {
-
             for (Tracks.Group trackGroupInfo : tracksInfo.getGroups()) {
+
                 if (trackGroupInfo.getType() == C.TRACK_TYPE_TEXT &&
                         trackGroupInfo.isSelected() &&
                         trackGroupInfo.getMediaTrackGroup().length > 0) {
                     for (int groupIndex = 0; groupIndex < trackGroupInfo.length; groupIndex++) {
+
                         if (trackGroupInfo.isTrackSelected(groupIndex)) {
                             return trackGroupInfo.getTrackFormat(groupIndex);
                         }

--- a/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
@@ -113,16 +113,17 @@ public class TrackSelectionHelper {
 
     private List<VideoTrack> videoTracks = new ArrayList<>();
     private List<VideoTrack> originalVideoTracks;
-    private List<AudioTrack> audioTracks = new ArrayList<>();
-    private List<TextTrack> textTracks = new ArrayList<>();
-    private List<ImageTrack> imageTracks = new ArrayList<>();
+    private final List<AudioTrack> audioTracks = new ArrayList<>();
+    private final List<TextTrack> textTracks = new ArrayList<>();
+    private final List<ImageTrack> imageTracks = new ArrayList<>();
+
     private @Nullable Format currentVideoFormat;
     private @Nullable Format currentAudioFormat;
-    private Map<Pair<Long,Long>, ThumbnailInfo> externalVttThumbnailRangesInfo;
 
-    private Map<String, Map<String, List<Format>>> subtitleListMap = new HashMap<>();
-    private Map<PKVideoCodec,List<VideoTrack>> videoTracksCodecsMap = new HashMap<>();
-    private Map<PKAudioCodec,List<AudioTrack>> audioTracksCodecsMap = new HashMap<>();
+    private Map<Pair<Long,Long>, ThumbnailInfo> externalVttThumbnailRangesInfo;
+    private final Map<String, Map<String, List<Format>>> subtitleListMap = new HashMap<>();
+    private final Map<PKVideoCodec,List<VideoTrack>> videoTracksCodecsMap = new HashMap<>();
+    private final Map<PKAudioCodec,List<AudioTrack>> audioTracksCodecsMap = new HashMap<>();
 
     private String[] lastSelectedTrackIds;
     private String[] requestedChangeTrackIds;
@@ -1927,19 +1928,13 @@ public class TrackSelectionHelper {
         tracksInfoListener = null;
         trackSelectionParameters = null;
         trackSelectionOverridesBuilder = null;
+        selector.release();
         clearTracksLists();
     }
 
     protected boolean isAudioOnlyStream() {
-        if (tracksInfo != null && !tracksInfo.getGroups().isEmpty()) {
-            boolean isVideoFormatAvailable = false;
-            for (Tracks.Group trackGroupInfo: tracksInfo.getGroups()) {
-                if (trackGroupInfo.getType() == C.TRACK_TYPE_VIDEO) {
-                    isVideoFormatAvailable = true;
-                    break;
-                }
-            }
-            return !isVideoFormatAvailable;
+        if (tracksInfo != null) {
+            return !tracksInfo.containsType(C.TRACK_TYPE_VIDEO);
         }
         return false;
     }

--- a/playkit/src/main/java/com/kaltura/playkit/profiler/ExoPlayerProfilingListener.java
+++ b/playkit/src/main/java/com/kaltura/playkit/profiler/ExoPlayerProfilingListener.java
@@ -12,6 +12,7 @@ import com.kaltura.android.exoplayer2.Format;
 import com.kaltura.android.exoplayer2.PlaybackException;
 import com.kaltura.android.exoplayer2.PlaybackParameters;
 import com.kaltura.android.exoplayer2.Player;
+import com.kaltura.android.exoplayer2.Tracks;
 import com.kaltura.android.exoplayer2.analytics.AnalyticsListener;
 import com.kaltura.android.exoplayer2.decoder.DecoderCounters;
 import com.kaltura.android.exoplayer2.decoder.DecoderReuseEvaluation;
@@ -241,6 +242,11 @@ class ExoPlayerProfilingListener implements AnalyticsListener {
     }
 
     @Override
+    public void onTracksChanged(EventTime eventTime, Tracks tracks) {
+        // TODO
+    }
+
+    /*@Override
     public void onTracksChanged(EventTime eventTime, TrackGroupArray trackGroups, TrackSelectionArray trackSelections) {
         LinkedHashSet<TrackGroup> trackGroupSet = new LinkedHashSet<>(trackGroups.length);
         for (int i = 0; i < trackSelections.length; i++) {
@@ -280,7 +286,7 @@ class ExoPlayerProfilingListener implements AnalyticsListener {
         log("TracksChanged",
                 field("available", jTrackGroups.toString()),
                 field("selected", jTrackSelections.toString()));
-    }
+    }*/
 
     private JsonObject toJSON(@Nullable Format format) {
 

--- a/playkit/src/main/java/com/kaltura/playkit/profiler/ExoPlayerProfilingListener.java
+++ b/playkit/src/main/java/com/kaltura/playkit/profiler/ExoPlayerProfilingListener.java
@@ -34,8 +34,10 @@ import android.util.Pair;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.google.common.collect.ImmutableList;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
+import com.kaltura.android.exoplayer2.C;
 import com.kaltura.android.exoplayer2.Format;
 import com.kaltura.android.exoplayer2.PlaybackException;
 import com.kaltura.android.exoplayer2.PlaybackParameters;
@@ -115,13 +117,13 @@ class ExoPlayerProfilingListener implements AnalyticsListener {
     }
 
     @Override
-    public void onIsPlayingChanged(EventTime eventTime, boolean isPlaying) {
+    public void onIsPlayingChanged(@NonNull EventTime eventTime, boolean isPlaying) {
         log("IsPlayingChanged",
                 field("isPlaying", isPlaying));
     }
 
     @Override
-    public void onPlaybackStateChanged(EventTime eventTime,  int playbackState) {
+    public void onPlaybackStateChanged(@NonNull EventTime eventTime,  int playbackState) {
         String state;
         switch (playbackState) {
             case Player.STATE_IDLE:
@@ -143,18 +145,27 @@ class ExoPlayerProfilingListener implements AnalyticsListener {
     }
 
     @Override
-    public void onPlayWhenReadyChanged(EventTime eventTime, boolean playWhenReady, int reason) {
+    public void onPlayWhenReadyChanged(@NonNull EventTime eventTime, boolean playWhenReady, int reason) {
         shouldPlay = playWhenReady;
     }
 
     @Override
-    public void onTimelineChanged(EventTime eventTime, int reason) {
-
+    public void onTimelineChanged(@NonNull EventTime eventTime, int reason) {
+        String timeLineChangeReason = "NONE";
+        switch (reason) {
+            case Player.TIMELINE_CHANGE_REASON_SOURCE_UPDATE:
+                timeLineChangeReason = "SOURCE_UPDATE";
+                break;
+            case Player.TIMELINE_CHANGE_REASON_PLAYLIST_CHANGED:
+                timeLineChangeReason = "PLAYLIST_CHANGED";
+                break;
+        }
+        log("onTimelineChanged", field("reason", timeLineChangeReason));
     }
 
     @Override
-    public void onPositionDiscontinuity(EventTime eventTime, Player.PositionInfo oldPosition,
-                                        Player.PositionInfo newPosition, int reason) {
+    public void onPositionDiscontinuity(@NonNull EventTime eventTime, @NonNull Player.PositionInfo oldPosition,
+                                        @NonNull Player.PositionInfo newPosition, int reason) {
         String reasonString;
         switch (reason) {
             case DISCONTINUITY_REASON_AUTO_TRANSITION:
@@ -184,14 +195,14 @@ class ExoPlayerProfilingListener implements AnalyticsListener {
     }
 
     @Override
-    public void onPlaybackParametersChanged(EventTime eventTime, PlaybackParameters playbackParameters) {
+    public void onPlaybackParametersChanged(@NonNull EventTime eventTime, PlaybackParameters playbackParameters) {
         log("PlaybackParametersChanged",
                 field("speed", playbackParameters.speed),
                 field("pitch", playbackParameters.pitch));
     }
 
     @Override
-    public void onRepeatModeChanged(EventTime eventTime, int repeatMode) {
+    public void onRepeatModeChanged(@NonNull EventTime eventTime, int repeatMode) {
         String strMode;
         switch (repeatMode) {
             case Player.REPEAT_MODE_OFF:
@@ -211,36 +222,36 @@ class ExoPlayerProfilingListener implements AnalyticsListener {
     }
 
     @Override
-    public void onShuffleModeChanged(EventTime eventTime, boolean shuffleModeEnabled) {
+    public void onShuffleModeChanged(@NonNull EventTime eventTime, boolean shuffleModeEnabled) {
         log("ShuffleModeChanged", field("shuffleModeEnabled", shuffleModeEnabled));
     }
 
     @Override
-    public void onAudioCodecError(EventTime eventTime, Exception audioCodecError) {
+    public void onAudioCodecError(@NonNull EventTime eventTime, Exception audioCodecError) {
         log("PlayerError", field("type", "audioCodecError"), "cause={" + audioCodecError.getCause() + "}");
     }
 
     @Override
-    public void onAudioSinkError(EventTime eventTime, Exception audioSinkError) {
+    public void onAudioSinkError(@NonNull EventTime eventTime, Exception audioSinkError) {
         log("PlayerError", field("type", "audioSinkError"), "cause={" + audioSinkError.getCause() + "}");
     }
 
     @Override
-    public void onVideoCodecError(EventTime eventTime, Exception videoCodecError) {
+    public void onVideoCodecError(@NonNull EventTime eventTime, Exception videoCodecError) {
         log("PlayerError", field("type", "videoCodecError"), "cause={" + videoCodecError.getCause() + "}");
     }
 
     @Override
-    public void onPlayerError(EventTime eventTime, PlaybackException playbackException) {
+    public void onPlayerError(@NonNull EventTime eventTime, @NonNull PlaybackException playbackException) {
         Pair<PKPlayerErrorType, String> exceptionPair = PKPlaybackException.getPlaybackExceptionType(playbackException);
         String type = exceptionPair.first.toString();
         log("PlayerError", field("type", type), "cause={" + playbackException.getCause() + "}");
     }
 
     @Override
-    public void onTracksChanged(EventTime eventTime, Tracks tracks) {
+    public void onTracksChanged(@NonNull EventTime eventTime, Tracks tracks) {
         // Tracks.Group contains video/audio/text track groups
-        List<Tracks.Group> trackGroups = tracks.getGroups();
+        ImmutableList<Tracks.Group> trackGroups = tracks.getGroups();
         JsonArray jTrackGroups = new JsonArray(trackGroups.size());
         JsonArray jTrackSelections = new JsonArray();
 
@@ -303,28 +314,28 @@ class ExoPlayerProfilingListener implements AnalyticsListener {
     }
 
     @Override
-    public void onLoadStarted(EventTime eventTime, LoadEventInfo loadEventInfo, MediaLoadData mediaLoadData) {
+    public void onLoadStarted(@NonNull EventTime eventTime, @NonNull LoadEventInfo loadEventInfo, @NonNull MediaLoadData mediaLoadData) {
         logLoadingEvent("LoadStarted", loadEventInfo, mediaLoadData, null, null);
         profiler.maybeLogServerInfo(loadEventInfo.uri);
     }
 
     @Override
-    public void onLoadCompleted(EventTime eventTime, LoadEventInfo loadEventInfo, MediaLoadData mediaLoadData) {
+    public void onLoadCompleted(@NonNull EventTime eventTime, @NonNull LoadEventInfo loadEventInfo, @NonNull MediaLoadData mediaLoadData) {
         logLoadingEvent("LoadCompleted", loadEventInfo, mediaLoadData, null, null);
     }
 
     @Override
-    public void onLoadCanceled(EventTime eventTime, LoadEventInfo loadEventInfo, MediaLoadData mediaLoadData) {
+    public void onLoadCanceled(@NonNull EventTime eventTime, @NonNull LoadEventInfo loadEventInfo, @NonNull MediaLoadData mediaLoadData) {
         logLoadingEvent("LoadCanceled", loadEventInfo, mediaLoadData, null, null);
     }
 
     @Override
-    public void onLoadError(EventTime eventTime, LoadEventInfo loadEventInfo, MediaLoadData mediaLoadData, IOException error, boolean wasCanceled) {
+    public void onLoadError(@NonNull EventTime eventTime, @NonNull LoadEventInfo loadEventInfo, @NonNull MediaLoadData mediaLoadData, @NonNull IOException error, boolean wasCanceled) {
         logLoadingEvent("LoadError", loadEventInfo, mediaLoadData, error, wasCanceled);
     }
 
     @Override
-    public void onDownstreamFormatChanged(EventTime eventTime, MediaLoadData mediaLoadData) {
+    public void onDownstreamFormatChanged(@NonNull EventTime eventTime, MediaLoadData mediaLoadData) {
         String trackTypeString = trackTypeString(mediaLoadData.trackType);
         if (trackTypeString == null) {
             return;
@@ -334,7 +345,7 @@ class ExoPlayerProfilingListener implements AnalyticsListener {
     }
 
     @Override
-    public void onUpstreamDiscarded(EventTime eventTime, MediaLoadData mediaLoadData) {
+    public void onUpstreamDiscarded(@NonNull EventTime eventTime, MediaLoadData mediaLoadData) {
         String trackTypeString = trackTypeString(mediaLoadData.trackType);
         if (trackTypeString == null) {
             return;
@@ -343,7 +354,7 @@ class ExoPlayerProfilingListener implements AnalyticsListener {
     }
 
     @Override
-    public void onBandwidthEstimate(EventTime eventTime, int totalLoadTimeMs, long totalBytesLoaded, long bitrateEstimate) {
+    public void onBandwidthEstimate(@NonNull EventTime eventTime, int totalLoadTimeMs, long totalBytesLoaded, long bitrateEstimate) {
         log("BandwidthSample",
                 field("bandwidth", bitrateEstimate),
                 timeField("totalLoadTime", totalLoadTimeMs),
@@ -352,92 +363,92 @@ class ExoPlayerProfilingListener implements AnalyticsListener {
     }
 
     @Override
-    public void onMetadata(EventTime eventTime, Metadata metadata) {
+    public void onMetadata(@NonNull EventTime eventTime, @NonNull Metadata metadata) {
 
     }
 
     @Override
-    public void onAudioEnabled(EventTime eventTime, DecoderCounters counters) {
+    public void onAudioEnabled(@NonNull EventTime eventTime, @NonNull DecoderCounters counters) {
 
     }
 
     @Override
-    public void onVideoEnabled(EventTime eventTime, DecoderCounters counters) {
+    public void onVideoEnabled(@NonNull EventTime eventTime, @NonNull DecoderCounters counters) {
 
     }
 
     @Override
-    public void onVideoDecoderInitialized(EventTime eventTime, String decoderName, long initializedTimestampMs, long initializationDurationMs) {
+    public void onVideoDecoderInitialized(@NonNull EventTime eventTime, @NonNull String decoderName, long initializedTimestampMs, long initializationDurationMs) {
         log("DecoderInitialized", field("name", decoderName), field("duration", initializationDurationMs / MSEC_MULTIPLIER_FLOAT));
     }
 
     @Override
-    public void onVideoInputFormatChanged(EventTime eventTime, Format format, DecoderReuseEvaluation decoderReuseEvaluation) {
+    public void onVideoInputFormatChanged(@NonNull EventTime eventTime, Format format, DecoderReuseEvaluation decoderReuseEvaluation) {
         log("DecoderInputFormatChanged", field("id", format.id), field("codecs", format.codecs), field("bitrate", format.bitrate));
     }
 
     @Override
-    public void onVideoDisabled(EventTime eventTime, DecoderCounters decoderCounters) {
+    public void onVideoDisabled(@NonNull EventTime eventTime, @NonNull DecoderCounters decoderCounters) {
 
     }
 
     @Override
-    public void onAudioUnderrun(EventTime eventTime, int bufferSize, long bufferSizeMs, long elapsedSinceLastFeedMs) {
+    public void onAudioUnderrun(@NonNull EventTime eventTime, int bufferSize, long bufferSizeMs, long elapsedSinceLastFeedMs) {
 
     }
 
     @Override
-    public void onDroppedVideoFrames(EventTime eventTime, int droppedFrames, long elapsedMs) {
+    public void onDroppedVideoFrames(@NonNull EventTime eventTime, int droppedFrames, long elapsedMs) {
         log("DroppedFrames", field("count", droppedFrames), field("time", elapsedMs / MSEC_MULTIPLIER_FLOAT));
     }
 
     @Override
-    public void onVideoSizeChanged(EventTime eventTime, @NonNull VideoSize videoSize) {
+    public void onVideoSizeChanged(@NonNull EventTime eventTime, @NonNull VideoSize videoSize) {
         log("VideoSizeChanged", field("width", videoSize.width), field("height", videoSize.height));
     }
 
     @Override
-    public void onRenderedFirstFrame(EventTime eventTime, Object output, long renderTimeMs) {
+    public void onRenderedFirstFrame(@NonNull EventTime eventTime, @NonNull Object output, long renderTimeMs) {
         log("RenderedFirstFrame");
     }
 
     @Override
-    public void onSurfaceSizeChanged(EventTime eventTime, int width, int height) {
+    public void onSurfaceSizeChanged(@NonNull EventTime eventTime, int width, int height) {
         log("ViewportSizeChange", field("width", width), field("height", height));
     }
 
     @Override
-    public void onVolumeChanged(EventTime eventTime, float volume) {
+    public void onVolumeChanged(@NonNull EventTime eventTime, float volume) {
         log("VolumeChanged", field("volume", volume));
     }
 
     @Override
-    public void onDrmSessionAcquired(EventTime eventTime, @DrmSession.State int state) {
+    public void onDrmSessionAcquired(@NonNull EventTime eventTime, @DrmSession.State int state) {
         log("DrmSessionAcquired");
     }
 
     @Override
-    public void onDrmSessionReleased(EventTime eventTime) {
+    public void onDrmSessionReleased(@NonNull EventTime eventTime) {
         log("DrmSessionReleased");
     }
 
     @Override
-    public void onDrmKeysLoaded(EventTime eventTime) {
-
+    public void onDrmKeysLoaded(@NonNull EventTime eventTime) {
+        log("onDrmKeysLoaded");
     }
 
     @Override
-    public void onDrmSessionManagerError(EventTime eventTime, Exception error) {
-
+    public void onDrmSessionManagerError(@NonNull EventTime eventTime, @NonNull Exception error) {
+        log("onDrmSessionManagerError " + field("error", error.getMessage()));
     }
 
     @Override
-    public void onDrmKeysRestored(EventTime eventTime) {
-
+    public void onDrmKeysRestored(@NonNull EventTime eventTime) {
+        log("onDrmKeysRestored");
     }
 
     @Override
-    public void onDrmKeysRemoved(EventTime eventTime) {
-
+    public void onDrmKeysRemoved(@NonNull EventTime eventTime) {
+        log("onDrmKeysRemoved");
     }
 }

--- a/playkit/src/main/java/com/kaltura/playkit/profiler/ExoPlayerProfilingListener.java
+++ b/playkit/src/main/java/com/kaltura/playkit/profiler/ExoPlayerProfilingListener.java
@@ -37,7 +37,6 @@ import androidx.annotation.Nullable;
 import com.google.common.collect.ImmutableList;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
-import com.kaltura.android.exoplayer2.C;
 import com.kaltura.android.exoplayer2.Format;
 import com.kaltura.android.exoplayer2.PlaybackException;
 import com.kaltura.android.exoplayer2.PlaybackParameters;
@@ -56,7 +55,6 @@ import com.kaltura.playkit.PKPlaybackException;
 import com.kaltura.playkit.player.PKPlayerErrorType;
 
 import java.io.IOException;
-import java.util.List;
 
 class ExoPlayerProfilingListener implements AnalyticsListener {
 

--- a/playkit/src/main/java/com/kaltura/playkit/profiler/PlayKitProfiler.java
+++ b/playkit/src/main/java/com/kaltura/playkit/profiler/PlayKitProfiler.java
@@ -62,7 +62,7 @@ public class PlayKitProfiler {
     private static final PKLog pkLog = PKLog.get("PlayKitProfiler");
 
     // Dev mode: shorter logs, write to local file, always enable
-    private static final boolean devMode = false;
+    private static final boolean devMode = true;
     private static final int SEND_INTERVAL_DEV = 60;    // in seconds
     private static final int SEND_PERCENTAGE_DEV = 100; // always
 

--- a/playkit/src/main/java/com/kaltura/playkit/profiler/PlayKitProfiler.java
+++ b/playkit/src/main/java/com/kaltura/playkit/profiler/PlayKitProfiler.java
@@ -62,7 +62,7 @@ public class PlayKitProfiler {
     private static final PKLog pkLog = PKLog.get("PlayKitProfiler");
 
     // Dev mode: shorter logs, write to local file, always enable
-    private static final boolean devMode = true;
+    private static final boolean devMode = false;
     private static final int SEND_INTERVAL_DEV = 60;    // in seconds
     private static final int SEND_PERCENTAGE_DEV = 100; // always
 


### PR DESCRIPTION
### Description of the Changes

### Features
- FEC-12722 | Added `getCurrentMediaManifest` Returns `nullable` media manifest of the window. Manifest depends on the type of media being prepared. Must be called once the media preparation is complete (Means tracks are loaded)
   ```java
   Object mediaManifest = player.getCurrentMediaManifest();

   if (mediaManifest instanceOf DashManifest) {
     DashManifest manifest = (DashManifest)mediaManifest;
   } else if (mediaManifest instanceOf HlsManifest) {
     HlsManifest manifest = (HlsManifest)mediaManifest;
   }
   ```
- Android-13 support.
- Added `constrainAudioChannelCountToDeviceCapabilities` API on `PlayerSettings`.

### Upgrades
- `Gradle build version` - v7.2.1
- `targetSdkVersion` - 33
- `checkerframeworkVersion` - 3.13.0
- `guavaVersion` - 31.0.1-android

### Fixes
- Tracks changes for Profiler
- Fixed https://kaltura.atlassian.net/browse/FEC-12057
- Fixed https://kaltura.atlassian.net/browse/FEC-12009
- Fixed https://kaltura.atlassian.net/browse/FEC-12007

### Linked PRs
 - https://github.com/kaltura/kaltura-player-android/pull/164
 - https://github.com/kaltura/playkit-android-vr/pull/63
 - https://github.com/kaltura/playkit-android-ima/pull/156

### CheckLists

- [ ] Subtitle positioning API in 360 content as well (VR)
- [ ] Audio Only media
- [ ] External Subtitles (With preference)
- [ ] Tracks (Video, Audio, Text, Image)
- [ ] New API docs needs to be updated
