### PR TITLE
feat(FEC-12865) | Exposed ability to pass post params on DRM license

### DIFF
--- a/playkit/src/main/java/com/kaltura/playkit/PKRequestParams.java
+++ b/playkit/src/main/java/com/kaltura/playkit/PKRequestParams.java
@@ -16,6 +16,8 @@ import android.net.Uri;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import org.json.JSONObject;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -52,5 +54,7 @@ public class PKRequestParams {
         void updateParams(Player player);
 
         String getApplicationName();
+
+        default JSONObject updateDRMData(byte[] data) { return null;}
     }
 }

--- a/playkit/src/main/java/com/kaltura/playkit/PKRequestParams.java
+++ b/playkit/src/main/java/com/kaltura/playkit/PKRequestParams.java
@@ -55,6 +55,14 @@ public class PKRequestParams {
 
         String getApplicationName();
 
-        default JSONObject updateDRMData(byte[] data) { return null;}
+        /**
+         * Return a potentially modified DrmData.
+         * The implementation can return the JSONObject by adding the post params.
+         *
+         * @param drmData The opaque key request data
+         * @return Modified JSONObject
+         */
+        @Nullable
+        default JSONObject buildDrmPostParams(@NonNull byte[] drmData) { return null;}
     }
 }

--- a/playkit/src/main/java/com/kaltura/playkit/PKRequestParams.java
+++ b/playkit/src/main/java/com/kaltura/playkit/PKRequestParams.java
@@ -14,6 +14,7 @@ package com.kaltura.playkit;
 
 import android.net.Uri;
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -22,10 +23,15 @@ public class PKRequestParams {
 
     public final Uri url;
     @NonNull public final Map<String, String> headers;
+    @Nullable public Map<String, String> postBody;
 
     public PKRequestParams(Uri url, Map<String, String> headers) {
         this.url = url;
         this.headers = headers != null ? headers : new HashMap<>();
+    }
+
+    public void setPostBody(Map<String, String> postBody) {
+        this.postBody = postBody != null ? postBody : new HashMap<>();
     }
 
     /**

--- a/playkit/src/main/java/com/kaltura/playkit/PKRequestParams.java
+++ b/playkit/src/main/java/com/kaltura/playkit/PKRequestParams.java
@@ -62,7 +62,7 @@ public class PKRequestParams {
          * @param drmData The opaque key request data
          * @return Modified JSONObject
          */
-        @Nullable
-        default JSONObject buildDrmPostParams(@NonNull byte[] drmData) { return null;}
+
+        @Nullable default JSONObject buildDrmPostParams(@NonNull byte[] drmData) { return null;}
     }
 }

--- a/playkit/src/main/java/com/kaltura/playkit/PKRequestParams.java
+++ b/playkit/src/main/java/com/kaltura/playkit/PKRequestParams.java
@@ -30,8 +30,8 @@ public class PKRequestParams {
         this.headers = headers != null ? headers : new HashMap<>();
     }
 
-    public void setPostBody(Map<String, String> postBody) {
-        this.postBody = postBody != null ? postBody : new HashMap<>();
+    public void setPostBody(@Nullable Map<String, String> postBody) {
+        this.postBody = postBody;
     }
 
     /**

--- a/playkit/src/main/java/com/kaltura/playkit/drm/DrmCallback.java
+++ b/playkit/src/main/java/com/kaltura/playkit/drm/DrmCallback.java
@@ -75,7 +75,7 @@ public class DrmCallback implements MediaDrmCallback {
             if (!headers.isEmpty()) {
                 requestProperties.putAll(headers);
             }
-            JSONObject postBodyJsonObject = adapter.updateDRMData(request.getData());
+            JSONObject postBodyJsonObject = adapter.buildDrmPostParams(request.getData());
             return executePost(dataSourceFactory, licenseUrl, postBodyJsonObject, requestProperties);
         } else {
             return callback.executeKeyRequest(uuid, request);
@@ -92,15 +92,17 @@ public class DrmCallback implements MediaDrmCallback {
 
         if (adapter != null) {
             params = adapter.adapt(params);
-            if (params.postBody != null && !params.postBody.isEmpty()) {
-                postBodyMap.putAll(params.postBody);
-            }
             if (params.url != null) {
                 this.licenseUrl = params.url.toString();
             } else {
                 log.e("Adapter returned null license URL");
                 return;
             }
+
+            if (params.postBody != null && !params.postBody.isEmpty()) {
+                postBodyMap.putAll(params.postBody);
+            }
+
             headers.putAll(params.headers);
         }
 

--- a/playkit/src/main/java/com/kaltura/playkit/drm/DrmCallback.java
+++ b/playkit/src/main/java/com/kaltura/playkit/drm/DrmCallback.java
@@ -121,6 +121,7 @@ public class DrmCallback implements MediaDrmCallback {
 
     /**
      * Do network call with customized post params and get the key byte data in response
+     * Taken from here {<a href="https://github.com/google/ExoPlayer/blob/a9444c880230d2c2c79097e89259ce0b9f80b87d/library/core/src/main/java/com/google/android/exoplayer2/drm/HttpMediaDrmCallback.java#L162">...</a>}
      * @throws MediaDrmCallbackException
      */
     private static byte[] executePost(

--- a/playkit/src/main/java/com/kaltura/playkit/drm/DrmCallback.java
+++ b/playkit/src/main/java/com/kaltura/playkit/drm/DrmCallback.java
@@ -75,7 +75,7 @@ public class DrmCallback implements MediaDrmCallback {
             if (!headers.isEmpty()) {
                 requestProperties.putAll(headers);
             }
-            JSONObject postBodyJsonObject = null;
+            JSONObject postBodyJsonObject = adapter.buildDrmPostParams(request.getData());
             return executePost(dataSourceFactory, licenseUrl, postBodyJsonObject, requestProperties);
         } else {
             return callback.executeKeyRequest(uuid, request);

--- a/playkit/src/main/java/com/kaltura/playkit/drm/DrmCallback.java
+++ b/playkit/src/main/java/com/kaltura/playkit/drm/DrmCallback.java
@@ -105,11 +105,11 @@ public class DrmCallback implements MediaDrmCallback {
                 return;
             }
 
+            headers.putAll(params.headers);
+
             if (params.postBody != null && !params.postBody.isEmpty()) {
                 postBodyMap.putAll(params.postBody);
             }
-
-            headers.putAll(params.headers);
         }
 
         callback = new HttpMediaDrmCallback(params.url.toString(), dataSourceFactory);

--- a/playkit/src/main/java/com/kaltura/playkit/drm/DrmCallback.java
+++ b/playkit/src/main/java/com/kaltura/playkit/drm/DrmCallback.java
@@ -39,6 +39,7 @@ public class DrmCallback implements MediaDrmCallback {
     private HttpMediaDrmCallback callback;
     private final Map<String, String> postBodyMap = new HashMap<>();
     private String licenseUrl;
+    private final Map<String, String> headers = new HashMap<>();;
     private final String KEY_DRM_INFO = "drm_info";
 
     public DrmCallback(HttpDataSource.Factory dataSourceFactory, PKRequestParams.Adapter adapter) {
@@ -75,10 +76,13 @@ public class DrmCallback implements MediaDrmCallback {
                 requestProperties.put(
                         "SOAPAction", "http://schemas.microsoft.com/DRM/2007/03/protocols/AcquireLicense");
             }
+            if (!headers.isEmpty()) {
+                requestProperties.putAll(headers);
+            }
             JSONObject postBodyJsonObject;
             try {
                 postBodyJsonObject = getPostBodyJson(request.getData(), postBodyMap);
-                return executePost(dataSourceFactory, licenseUrl, postBodyJsonObject.toString().getBytes() , requestProperties);
+                return executePost(dataSourceFactory, licenseUrl, postBodyJsonObject.toString().getBytes(), requestProperties);
             } catch (JSONException e) {
                 throw new MediaDrmCallbackException(
                         new DataSpec.Builder().setUri(licenseUrl).build(),
@@ -107,11 +111,12 @@ public class DrmCallback implements MediaDrmCallback {
                 postBodyMap.putAll(params.postBody);
             }
             if (params.url != null) {
-                this.licenseUrl = licenseUrl;
+                this.licenseUrl = params.url.toString();
             } else {
                 log.e("Adapter returned null license URL");
                 return;
             }
+            headers.putAll(params.headers);
         }
 
         callback = new HttpMediaDrmCallback(params.url.toString(), dataSourceFactory);

--- a/playkit/src/main/java/com/kaltura/playkit/drm/DrmCallback.java
+++ b/playkit/src/main/java/com/kaltura/playkit/drm/DrmCallback.java
@@ -121,7 +121,7 @@ public class DrmCallback implements MediaDrmCallback {
 
     /**
      * Do network call with customized post params and get the key byte data in response
-     * Taken from here {<a href="https://github.com/google/ExoPlayer/blob/a9444c880230d2c2c79097e89259ce0b9f80b87d/library/core/src/main/java/com/google/android/exoplayer2/drm/HttpMediaDrmCallback.java#L162">...</a>}
+     * Taken from here {<a href="https://github.com/google/ExoPlayer/blob/r2.18.2/library/core/src/main/java/com/google/android/exoplayer2/drm/HttpMediaDrmCallback.java#L162">...</a>}
      * @throws MediaDrmCallbackException
      */
     private static byte[] executePost(

--- a/playkit/src/main/java/com/kaltura/playkit/drm/DrmCallback.java
+++ b/playkit/src/main/java/com/kaltura/playkit/drm/DrmCallback.java
@@ -1,16 +1,33 @@
 package com.kaltura.playkit.drm;
 
 import android.net.Uri;
+import android.text.TextUtils;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.google.common.collect.ImmutableMap;
+import com.kaltura.android.exoplayer2.C;
 import com.kaltura.android.exoplayer2.drm.ExoMediaDrm;
 import com.kaltura.android.exoplayer2.drm.HttpMediaDrmCallback;
 import com.kaltura.android.exoplayer2.drm.MediaDrmCallback;
 import com.kaltura.android.exoplayer2.drm.MediaDrmCallbackException;
+import com.kaltura.android.exoplayer2.upstream.DataSource;
+import com.kaltura.android.exoplayer2.upstream.DataSourceInputStream;
+import com.kaltura.android.exoplayer2.upstream.DataSpec;
 import com.kaltura.android.exoplayer2.upstream.HttpDataSource;
+import com.kaltura.android.exoplayer2.upstream.StatsDataSource;
+import com.kaltura.android.exoplayer2.util.Util;
 import com.kaltura.playkit.PKLog;
 import com.kaltura.playkit.PKRequestParams;
+import com.kaltura.playkit.player.MediaSupport;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -20,20 +37,59 @@ public class DrmCallback implements MediaDrmCallback {
     private final HttpDataSource.Factory dataSourceFactory;
     private final PKRequestParams.Adapter adapter;
     private HttpMediaDrmCallback callback;
-
-    @Override
-    public byte[] executeProvisionRequest(UUID uuid, ExoMediaDrm.ProvisionRequest request) throws MediaDrmCallbackException {
-        return callback.executeProvisionRequest(uuid, request);
-    }
-
-    @Override
-    public byte[] executeKeyRequest(UUID uuid, ExoMediaDrm.KeyRequest request) throws MediaDrmCallbackException {
-        return callback.executeKeyRequest(uuid, request);
-    }
+    private final Map<String, String> postBodyMap = new HashMap<>();
+    private String licenseUrl;
+    private final String KEY_DRM_INFO = "drm_info";
 
     public DrmCallback(HttpDataSource.Factory dataSourceFactory, PKRequestParams.Adapter adapter) {
         this.dataSourceFactory = dataSourceFactory;
         this.adapter = adapter;
+    }
+
+    @NonNull
+    @Override
+    public byte[] executeProvisionRequest(@NonNull UUID uuid, @NonNull ExoMediaDrm.ProvisionRequest request) throws MediaDrmCallbackException {
+        return callback.executeProvisionRequest(uuid, request);
+    }
+
+    @NonNull
+    @Override
+    public byte[] executeKeyRequest(@NonNull UUID uuid, @NonNull ExoMediaDrm.KeyRequest request) throws MediaDrmCallbackException {
+        if (adapter != null && !postBodyMap.isEmpty()) {
+            if (TextUtils.isEmpty(licenseUrl)) {
+                throw new MediaDrmCallbackException(
+                        new DataSpec.Builder().setUri(Uri.EMPTY).build(),
+                        Uri.EMPTY,
+                        ImmutableMap.of(),
+                        0,
+                        new IllegalStateException("No license URL"));
+            }
+            Map<String, String> requestProperties = new HashMap<>();
+            // Add standard request properties for supported schemes.
+            String contentType =
+                    MediaSupport.PLAYREADY_UUID.equals(uuid)
+                            ? "text/xml"
+                            : (C.CLEARKEY_UUID.equals(uuid) ? "application/json" : "application/octet-stream");
+            requestProperties.put("Content-Type", contentType);
+            if (MediaSupport.PLAYREADY_UUID.equals(uuid)) {
+                requestProperties.put(
+                        "SOAPAction", "http://schemas.microsoft.com/DRM/2007/03/protocols/AcquireLicense");
+            }
+            JSONObject postBodyJsonObject;
+            try {
+                postBodyJsonObject = getPostBodyJson(request.getData(), postBodyMap);
+                return executePost(dataSourceFactory, licenseUrl, postBodyJsonObject.toString().getBytes() , requestProperties);
+            } catch (JSONException e) {
+                throw new MediaDrmCallbackException(
+                        new DataSpec.Builder().setUri(licenseUrl).build(),
+                        Uri.EMPTY,
+                        ImmutableMap.of(),
+                        0,
+                        new JSONException(e.getMessage()));
+            }
+        } else {
+            return callback.executeKeyRequest(uuid, request);
+        }
     }
 
     void setLicenseUrl(String licenseUrl) {
@@ -47,7 +103,12 @@ public class DrmCallback implements MediaDrmCallback {
 
         if (adapter != null) {
             params = adapter.adapt(params);
-            if (params.url == null) {
+            if (params.postBody != null && !params.postBody.isEmpty()) {
+                postBodyMap.putAll(params.postBody);
+            }
+            if (params.url != null) {
+                this.licenseUrl = licenseUrl;
+            } else {
                 log.e("Adapter returned null license URL");
                 return;
             }
@@ -58,5 +119,117 @@ public class DrmCallback implements MediaDrmCallback {
         for (Map.Entry<String, String> entry : params.headers.entrySet()) {
             callback.setKeyRequestProperty(entry.getKey(), entry.getValue());
         }
+    }
+
+    /**
+     * Create the post JSON payload having custom post key/values and drm data
+     * @param data drm data
+     * @param requestProperties custom post params
+     * @return JSONObject
+     * @throws JSONException if there is some exception in JSON creation
+     */
+    @NonNull
+    private JSONObject getPostBodyJson(byte[] data, Map<String, String> requestProperties) throws JSONException {
+        JSONObject json = new JSONObject();
+        for (Map.Entry<String, String> entry: requestProperties.entrySet()) {
+            if (TextUtils.equals(entry.getKey(), KEY_DRM_INFO)) {
+                JSONArray jsonArray = doMaskingOnDrmInfo(data);
+                if (jsonArray == null) {
+                    continue;
+                }
+                json.put(KEY_DRM_INFO, jsonArray);
+            } else {
+                json.put(entry.getKey(), entry.getValue());
+            }
+        }
+        return json;
+    }
+
+    /**
+     * Do bitmask for the drm data
+     * @param data drm data
+     * @return JSONArray of the bitmasked drm data
+     */
+    @Nullable
+    private JSONArray doMaskingOnDrmInfo(@Nullable byte[] data) {
+        if (data == null) {
+            log.e("Invalid key request data");
+            return null;
+        }
+
+        JSONArray jsonArray = new JSONArray();
+        int bitmask = 0x000000FF;
+        for (byte aData : data) {
+            jsonArray.put(bitmask & aData);
+        }
+        return jsonArray;
+    }
+
+    /**
+     * Do network call with customized post params and get the key byte data in response
+     * @throws MediaDrmCallbackException
+     */
+    private static byte[] executePost(
+            DataSource.Factory dataSourceFactory,
+            String url,
+            @Nullable byte[] httpBody,
+            Map<String, String> requestProperties)
+            throws MediaDrmCallbackException {
+        StatsDataSource dataSource = new StatsDataSource(dataSourceFactory.createDataSource());
+        int manualRedirectCount = 0;
+        DataSpec dataSpec =
+                new DataSpec.Builder()
+                        .setUri(url)
+                        .setHttpRequestHeaders(requestProperties)
+                        .setHttpMethod(DataSpec.HTTP_METHOD_POST)
+                        .setHttpBody(httpBody)
+                        .setFlags(DataSpec.FLAG_ALLOW_GZIP)
+                        .build();
+        DataSpec originalDataSpec = dataSpec;
+        try {
+            while (true) {
+                DataSourceInputStream inputStream = new DataSourceInputStream(dataSource, dataSpec);
+                try {
+                    return Util.toByteArray(inputStream);
+                } catch (HttpDataSource.InvalidResponseCodeException e) {
+                    @Nullable String redirectUrl = getRedirectUrl(e, manualRedirectCount);
+                    if (redirectUrl == null) {
+                        throw e;
+                    }
+                    manualRedirectCount++;
+                    dataSpec = dataSpec.buildUpon().setUri(redirectUrl).build();
+                } finally {
+                    Util.closeQuietly(inputStream);
+                }
+            }
+        } catch (Exception e) {
+            throw new MediaDrmCallbackException(
+                    originalDataSpec,
+                    dataSource.getLastOpenedUri(),
+                    dataSource.getResponseHeaders(),
+                    dataSource.getBytesRead(),
+                    /* cause= */ e);
+        }
+    }
+
+    @Nullable
+    private static String getRedirectUrl(
+            HttpDataSource.InvalidResponseCodeException exception, int manualRedirectCount) {
+        // For POST requests, the underlying network stack will not normally follow 307 or 308
+        // redirects automatically. Do so manually here.
+        boolean manuallyRedirect =
+                (exception.responseCode == 307 || exception.responseCode == 308)
+                        && manualRedirectCount < 10;
+        if (!manuallyRedirect) {
+            return null;
+        }
+        Map<String, List<String>> headerFields = exception.headerFields;
+        if (headerFields != null) {
+            @Nullable List<String> locationHeaders = headerFields.get("Location");
+            if (locationHeaders != null && !locationHeaders.isEmpty()) {
+                return locationHeaders.get(0);
+            }
+        }
+        return null;
     }
 }

--- a/playkit/src/main/java/com/kaltura/playkit/drm/DrmCallback.java
+++ b/playkit/src/main/java/com/kaltura/playkit/drm/DrmCallback.java
@@ -34,9 +34,9 @@ public class DrmCallback implements MediaDrmCallback {
     private final HttpDataSource.Factory dataSourceFactory;
     private final PKRequestParams.Adapter adapter;
     private HttpMediaDrmCallback callback;
-    private final Map<String, String> postBodyMap = new HashMap<>();
     private String licenseUrl;
-    private final Map<String, String> headers = new HashMap<>();;
+    private final Map<String, String> headers = new HashMap<>();
+    private final Map<String, String> postBodyMap = new HashMap<>();
 
     public DrmCallback(HttpDataSource.Factory dataSourceFactory, PKRequestParams.Adapter adapter) {
         this.dataSourceFactory = dataSourceFactory;
@@ -75,20 +75,26 @@ public class DrmCallback implements MediaDrmCallback {
             if (!headers.isEmpty()) {
                 requestProperties.putAll(headers);
             }
-            JSONObject postBodyJsonObject = adapter.buildDrmPostParams(request.getData());
+            JSONObject postBodyJsonObject = null;
             return executePost(dataSourceFactory, licenseUrl, postBodyJsonObject, requestProperties);
         } else {
             return callback.executeKeyRequest(uuid, request);
         }
     }
 
-    void setLicenseUrl(String licenseUrl) {
-        if (licenseUrl == null) {
+    /**
+     * In case if the adapter is given then
+     * set the license URL after adapting it from outside.
+     * Otherwise use the license URL as it is for {@link HttpMediaDrmCallback}
+     * @param url license URL
+     */
+    void setLicenseUrl(String url) {
+        if (url == null) {
             log.e("Invalid license URL = null");
             return;
         }
 
-        PKRequestParams params = new PKRequestParams(Uri.parse(licenseUrl), new HashMap<>());
+        PKRequestParams params = new PKRequestParams(Uri.parse(url), new HashMap<>());
 
         if (adapter != null) {
             params = adapter.adapt(params);


### PR DESCRIPTION
### Description of the Changes

This feature gives ability to FE apps to pass `POST` parameters on the DRM license request. It can be done using `PKRequestParams.Adapter`'s `buildDrmPostParams` implementation.

> `Uri uri = requestParams.url.buildUpon().build(); ` URI is license URL which is important to pass while using `Adapter`.
    FE can pass the `QUERY` params on DRM license as well. `requestParams.url.buildUpon().appendQueryParameter("CustomParam", "MyQueryParam").build();`
   
>   - In case if the license URL is not passed then FE will get a Player Error event,
     ` errorType = DRM_ERROR errorMessage = java.lang.IllegalStateException: No license URL-ERROR_CODE_DRM_LICENSE_ACQUISITION_FAILED`

> - In case if the `POST` params are null then FE will get Player Error event,
    `errorType = DRM_ERROR errorMessage = com.kaltura.android.exoplayer2.upstream.HttpDataSource$InvalidResponseCodeException: Response code: 400-ERROR_CODE_DRM_LICENSE_ACQUISITION_FAILED`

#### Steps to pass `POST` parms

1. Create a class implementing `PKRequestParams.Adapter`.
2. Implement `PKRequestParams adapt(PKRequestParams requestParams)` method and modify the license URL if required for `QUERY` params otherwise send as it is.
3. Create `PKRequestParams` object by passing the license URI and headers if required.
4. Call `setPostBody` and pass `POST` body `Map` object.
5. Implement `JSONObject buildDrmPostParams(@NonNull byte[] data)` method and create a `JSONObject` for the `POST` params. FE apps can use `byte[] data` for further purposes. Return the `JSONObject`.
6. Now create an instance of this class and pass it to the `PlayerSettings`.
    Example:
    ```java
    DRMAdapter licenseRequestAdapter = new DRMAdapter();
    player.getSettings().setLicenseRequestAdapter(licenseRequestAdapter);
    ```


Example:

```java
static class DRMAdapter implements PKRequestParams.Adapter {
        String TOKEN = "YOUR_CUSTOM_TOKEN_FOR_DRM_LICENSE_POST_PARAM";

        public static String customData;
        @Override
        public PKRequestParams adapt(PKRequestParams requestParams) {
            Map<String, String> headers = new HashMap<>();
            Map<String, String> postBody = new HashMap<>();
            postBody.put("token", TOKEN);
            Uri uri = requestParams.url.buildUpon().appendQueryParameter("CustomParam", "MyQueryParam").build();
            PKRequestParams params = new PKRequestParams(uri, headers);
            params.setPostBody(postBody);
            return params;
        }

        @Override
        public void updateParams(Player player) {
            // TODO
        }

        @Override
        public String getApplicationName() {
             // TODO
        }

        @Override
        public JSONObject buildDrmPostParams(@NonNull byte[] data) {
            try {
                return // Create a JSONObject for the post body for DRM license request.;
            } catch (JSONException e) {
                return null;
            }
        }
    }

DRMAdapter licenseRequestAdapter = new DRMAdapter();
player.getSettings().setLicenseRequestAdapter(licenseRequestAdapter);

```

