### PR TITLE
feat(FEC-12974): Expose API to give apps ability to disable the audio/video tracks

### DIFF
--- a/playkit/src/main/java/com/kaltura/playkit/Player.java
+++ b/playkit/src/main/java/com/kaltura/playkit/Player.java
@@ -338,6 +338,22 @@ public interface Player {
         Settings setHandleAudioFocus(boolean handleAudioFocus);
 
         /**
+         * Set AllowDisableVideoTrack - expose video track to disable video playback. default: false (audio only experience)
+         *
+         * @param allowDisableVideoTrack
+         * @return - Player Settings
+         */
+        Settings setAllowDisableVideoTrack(boolean allowDisableVideoTrack);
+
+        /**
+         * Set AllowDisableVideoTrack - expose audio track to disable audio playback. default: false (video only experience)
+         *
+         * @param allowDisableAudioTrack
+         * @return - Player Settings
+         */
+        Settings setAllowDisableAudioTrack(boolean allowDisableAudioTrack);
+
+        /**
          * Set preference to choose internal subtitles over external subtitles (Only in the case if the same language is present
          * in both Internal and External subtitles) - Default is true (Internal is preferred)
          *

--- a/playkit/src/main/java/com/kaltura/playkit/player/PlayerSettings.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/PlayerSettings.java
@@ -37,6 +37,9 @@ public class PlayerSettings implements Player.Settings {
     private boolean isTunneledAudioPlayback;
     private boolean handleAudioBecomingNoisyEnabled;
     private boolean handleAudioFocus;
+    private boolean allowDisableVideoTrack;
+    private boolean allowDisableAudioTrack;
+
 
     // Flag helping to check if client app wants to use a single player instance at a time
     // Only if IMA plugin is there then only this flag is set to true.
@@ -192,6 +195,14 @@ public class PlayerSettings implements Player.Settings {
 
     public boolean isHandleAudioFocus() {
         return handleAudioFocus;
+    }
+
+    public boolean isAllowDisableVideoTrack() {
+        return allowDisableVideoTrack;
+    }
+
+    public boolean isAllowDisableAudioTrack() {
+        return allowDisableAudioTrack;
     }
 
     public PKSubtitlePreference getSubtitlePreference() {
@@ -413,6 +424,18 @@ public class PlayerSettings implements Player.Settings {
     @Override
     public Player.Settings setHandleAudioFocus(boolean handleAudioFocus) {
         this.handleAudioFocus = handleAudioFocus;
+        return this;
+    }
+
+    @Override
+    public Player.Settings setAllowDisableVideoTrack(boolean allowDisableVideoTrack) {
+        this.allowDisableVideoTrack = allowDisableVideoTrack;
+        return this;
+    }
+
+    @Override
+    public Player.Settings setAllowDisableAudioTrack(boolean allowDisableAudioTrack) {
+        this.allowDisableAudioTrack = allowDisableAudioTrack;
         return this;
     }
 

--- a/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
+++ b/playkit/src/main/java/com/kaltura/playkit/player/TrackSelectionHelper.java
@@ -1023,7 +1023,7 @@ public class TrackSelectionHelper {
         String uniqueId = getUniqueId(TRACK_TYPE_TEXT, 0, TRACK_DISABLED);
         textTracks.add(0, new TextTrack(uniqueId, NONE, NONE, NONE, -1));
     }
-    
+
     /**
      * Find the default selected track, based on the media manifest.
      *


### PR DESCRIPTION
FEC-12974 - 

once the api is set to true 
tracks available will also contain one more fake track at the end with bitrate -1 with type (-2) in the uniqueId
that will be used to disable the audio/video track

            player.getSettings().setAllowDisableVideoTrack(true);
            player.getSettings().setAllowDisableAudioTrack(true);

