### PR TITLE
Upgrade ExoPlayer 2.18.7

### DIFF
--- a/playkit/build.gradle
+++ b/playkit/build.gradle
@@ -41,7 +41,7 @@ tasks.withType(Javadoc) {
 
 dependencies {
 
-    def exoPlayerVersion = '2.18.4'
+    def exoPlayerVersion = '2.18.7'
     api "com.kaltura.playkit:kexoplayer:$exoPlayerVersion"
 
     api 'com.google.code.gson:gson:2.8.6'

--- a/playkit/src/main/java/com/kaltura/playkit/drm/DeferredDrmSessionManager.java
+++ b/playkit/src/main/java/com/kaltura/playkit/drm/DeferredDrmSessionManager.java
@@ -116,6 +116,9 @@ public class DeferredDrmSessionManager implements DrmSessionManager, DrmSessionE
     public void setPlayer(@NonNull Looper looper, @NonNull PlayerId playerId) {
         playbackLooper = looper;
         playbackPlayerId = playerId;
+        if (drmSessionManager != null) {
+            drmSessionManager.setPlayer(playbackLooper, playbackPlayerId);
+        }
     }
 
     @Nullable
@@ -143,8 +146,6 @@ public class DeferredDrmSessionManager implements DrmSessionManager, DrmSessionE
                 drmSessionListener.onError(error);
             }
         }
-
-        drmSessionManager.setPlayer(playbackLooper, playbackPlayerId);
         return drmSessionManager.acquireSession(eventDispatcher, format);
     }
 


### PR DESCRIPTION
Moved the       drmSessionManager.setPlayer(playbackLooper, playbackPlayerId);
to class method setPlayer
due to new validation added in 2.18.6 (https://github.com/google/ExoPlayer/blob/ac9d5337b2b51a855f3c33f3b126d9ef921ebc69/library/core/src/main/java/com/google/android/exoplayer2/drm/DefaultDrmSessionManager.java#L471)

FEC-13228

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
